### PR TITLE
fix(security): respect guest privacy for cameras

### DIFF
--- a/packages/presence.yaml
+++ b/packages/presence.yaml
@@ -97,17 +97,27 @@ automation:
           entity_id: lock.front_door
 
   - alias: "Handle Home Alarm Armed Night"
-    description: "Secure house for night"
+    description: "Secure house for night, respecting guest privacy"
     trigger:
       - platform: state
         entity_id: alarm_control_panel.home_alarm
         to: "armed_night"
     action:
+      # Always turn on outdoor camera notifications
       - service: input_boolean.turn_on
         target:
-          entity_id:
-            - input_boolean.camera_notifications_indoor
-            - input_boolean.camera_notifications_outdoor
+          entity_id: input_boolean.camera_notifications_outdoor
+      # Only turn on indoor camera notifications if guest mode is OFF
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: input_boolean.guest_mode
+                state: "off"
+            sequence:
+              - service: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.camera_notifications_indoor
+      # Always lock the front door
       - service: lock.lock
         target:
           entity_id: lock.front_door


### PR DESCRIPTION
Update the "armed_night" alarm handler to check guest mode before enabling indoor camera notifications. This ensures guest privacy while maintaining outdoor security monitoring.

Closes #37