### PR TITLE
fix(security): move door unlock to arrival logic

### DIFF
--- a/packages/presence.yaml
+++ b/packages/presence.yaml
@@ -71,11 +71,19 @@ automation:
       - platform: numeric_state
         entity_id: zone.home
         above: 0
-    condition:
-      - condition: state
-        entity_id: input_boolean.guest_mode
-        state: "off"
     action:
+      - if:
+          condition: state
+          entity_id: alarm_control_panel.home_alarm
+          state: "armed_away"
+        then:
+          - service: lock.unlock
+            target:
+              entity_id: lock.front_door
+          - service: logbook.log
+            data:
+              name: "Front Door"
+              message: "Door unlocked due to arrival when system is in away mode"
       - service: alarm_control_panel.alarm_arm_home
         target:
           entity_id: alarm_control_panel.home_alarm
@@ -129,9 +137,6 @@ automation:
         entity_id: alarm_control_panel.home_alarm
         to: "armed_home"
     action:
-      - service: lock.unlock
-        target:
-          entity_id: lock.front_door
       - service: input_boolean.turn_on
         target:
           entity_id: input_boolean.camera_notifications_outdoor


### PR DESCRIPTION
Move door unlocking from alarm mode change to presence detection
with specific security conditions. Only unlocks when someone
arrives and system was in away mode.
