### PR TITLE
fix(towner): simplify school notifications with state-based tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ ha_export_*.txt
 
 # Temporary script files
 scripts/*.tmp
+scripts/*.txt
 scripts/*.log
 
 # Custom Components

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,152 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Workflow
+
+### Issue Management
+```bash
+# Check existing issues before starting work
+gh issue list
+
+# Check existing labels before creating issues
+gh label list
+
+# Create new issue with appropriate labels
+gh issue create --title "Feature Name" --body "Description..." --label "enhancement"
+```
+
+### Branch Management
+```bash
+# Start from latest main
+git checkout main && git pull origin main
+
+# Create feature branch
+git checkout -b feature/descriptive-name
+# Or for bug fixes
+git checkout -b fix/descriptive-name
+
+# Frequent commits for tracking
+git add . && git commit -m "feat(scope): description"
+```
+
+### Pull Request Process
+```bash
+# Push branch after development
+git push origin feature/feature-name
+
+# Create PR to close issue
+gh pr create --title "Feature: Add descriptive name" --body "Description and closes #ISSUE_NUMBER" --base main
+
+# Merge after testing on HA machine
+gh pr merge --squash
+```
+
+## Architecture Overview
+
+This is a **Home Assistant configuration repository** organized using the packages pattern for modular functionality. The system manages a smart home with comprehensive automation, security, and notification capabilities.
+
+### Core Structure
+
+- **`packages/`** - Modular feature packages containing related automations, scripts, and entities
+- **`configuration.yaml`** - Main configuration file that imports packages and core settings
+- **`automation/`** - Additional automation files loaded via `!include_dir_merge_list`
+- **`input_boolean/`** - Boolean switches for user control and automation state
+- **`blueprints/`** - Reusable automation templates
+
+### Key Packages
+
+**Core Infrastructure:**
+- `cameras.yaml` - Frigate camera integration with motion detection notifications
+- `presence.yaml` - Presence detection and location-based automations  
+- `notifications.yaml` - Multi-device notification system management
+- `security_lights.yaml` - Security-focused lighting automations
+- `weather.yaml` - Weather data processing and event monitoring
+
+**Daily Living:**
+- `chores.yaml` - Household chore rotation and tracking system
+- `light_groups.yaml` - Logical grouping of lights for easier control
+- `routines.yaml` - Common household routines (Good Night, morning wake-up, etc.)
+- `remotes.yaml` - Z-Wave remote control configuration
+
+**Advanced Features:**
+- `brief/` - AI-powered daily briefing system with modular data collection
+- `towner_notifications.yaml` - Zone-based notifications for specific areas
+- `device_health.yaml` - Device monitoring and health checks
+- `garage_door_monitoring.yaml` - Garage door state tracking and alerts
+
+### Package Architecture Pattern
+
+Each package follows a consistent structure:
+```yaml
+# Header comment describing purpose and features
+automation:
+  - alias: "Descriptive Name"
+    description: "Clear purpose description"
+    trigger: [triggers]
+    condition: [conditions]  
+    action: [actions]
+
+script:
+  script_name:
+    alias: "Script Name"
+    sequence: [steps]
+
+# Additional components (sensors, input_boolean, etc.)
+```
+
+### Configuration Loading Strategy
+
+The configuration uses Home Assistant's modular loading:
+- `packages: !include_dir_named packages` - Loads all package files
+- `automation: !include_dir_merge_list automation` - Merges automation files
+- `input_boolean: !include_dir_merge_named input_boolean` - Loads boolean controls
+
+### Notification System
+
+Multi-device notifications configured in `configuration.yaml`:
+- `notify.all_mobile_devices` - Group notification service for Brian and Hester's phones
+- Individual mobile app services: `mobile_app_brian_phone`, `mobile_app_hester_phone`
+
+### Development Standards
+
+- **YAML Formatting**: 2-space indentation, consistent quoting
+- **Entity Naming**: Descriptive names with underscores, domain prefixes
+- **Package Organization**: Group related functionality, use meaningful file names
+- **Automation Design**: Clear aliases, detailed descriptions, proper error handling
+- **Template Usage**: Leverage Jinja2 templates for dynamic content and logic
+- **Commit Strategy**: Frequent commits for each feature/change for tracking
+
+### Testing Process
+
+Development happens on this machine, testing on Home Assistant machine:
+1. User pulls branches to HA machine for testing
+2. Iterate based on testing feedback
+3. Create PR when feature is complete and tested
+4. Squash merge to main after approval
+
+### Git Workflow
+
+- Feature branches: `feature/descriptive-name`
+- Bug fixes: `fix/descriptive-name` 
+- Conventional commits with clear scope and description
+- Frequent commits for tracking progress
+- Pull requests required, squash merge to main
+- Issues tracked via GitHub for feature planning
+
+### Special Features
+
+**Daily Briefing System (`packages/brief/`)**:
+- Modular data collection from various home systems
+- AI-generated briefings via MQTT integration
+- Structured as subpackage with multiple YAML files
+
+**Security Integration**:
+- Frigate camera system with motion detection
+- Zone-based notification system for different areas
+- Security lighting responsive to presence and events
+
+**Presence Detection**:
+- Multiple presence sensors and zones
+- Automated responses to home/away states
+- Integration with lighting, security, and climate systems

--- a/packages/towner_notifications.yaml
+++ b/packages/towner_notifications.yaml
@@ -120,7 +120,7 @@ automation:
       # Verify still in the school zone
       - condition: template
         value_template: >
-          {{ (states(person.towner) | lower) == 'la vista middle school' }}
+          {{ (states('person.towner') | lower) == 'la vista middle school' }}
       # Scheduling & weekday
       - condition: template
         value_template: >
@@ -134,11 +134,12 @@ automation:
           {%- set start_ts = as_timestamp(start_dt) -%}
           {%- set end_ts = as_timestamp(end_dt) -%}
           {%- set weekday_ok = now().weekday() < 5 -%}
+          {%- set school_day_ok = is_state('input_boolean.towner_school_day_enabled','on') -%}
           {%- if start_ts <= end_ts -%}
-            {{ weekday_ok and (now_ts >= start_ts) and (now_ts <=end_ts) }}
+            {{ school_day_ok and weekday_ok and (now_ts >= start_ts) and (now_ts <=end_ts) }}
           {%- else -%}
-            {# window crosses midnight; accpt if now >= start or now <= end #}
-            {{ weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
+            {# window crosses midnight; accept if now >= start or now <= end #}
+            {{ school_day_ok and weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
           {%- endif -%}
       - service: notify.all_mobile_devices
         data:
@@ -167,7 +168,7 @@ automation:
       # Verify not in school zone
       - condition: template
         value_template: >
-          {{ not ((states(person.towner) | lower) == 'la vista middle school') }}
+          {{ not ((states('person.towner') | lower) == 'la vista middle school') }}
       # Scheduling & weekday (same robust check as above)
       - condition: template
         value_template: >
@@ -181,10 +182,11 @@ automation:
           {%- set start_ts = as_timestamp(start_dt) -%}
           {%- set end_ts = as_timestamp(end_dt) -%}
           {%- set weekday_ok = now().weekday() < 5 -%}
+          {%- set school_day_ok = is_state('input_boolean.towner_school_day_enabled','on') -%}
           {%- if start_ts <= end_ts -%}
-            {{ weekday_ok and (now_ts >= start_ts) and (now_ts <= end_ts) }}
+            {{ school_day_ok and weekday_ok and (now_ts >= start_ts) and (now_ts <= end_ts) }}
           {%- else -%}
-            {{ weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
+            {{ school_day_ok and weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
           {%- endif -%}
       # Send departure notification
       - service: notify.all_mobile_devices

--- a/packages/towner_notifications.yaml
+++ b/packages/towner_notifications.yaml
@@ -62,7 +62,7 @@ automation:
       # Verify still at home
       - condition: template
         value_template: >
-          {{ is_state('person.towner', 'Home') }}
+          {{ (states('person.towner') | lower) == 'home' }}
       # Only notify if expected-home flag is ON
       - condition: state
         entity_id: input_boolean.towner_expected_home
@@ -93,7 +93,7 @@ automation:
           seconds: "{{ delay_seconds }}"
       - condition: template
         value_template: >
-          {{ not is_state('person.towner', 'Home') }}
+          {{ not ((states('person.towner') | lower) == 'home') }}
       - service: notify.all_mobile_devices
         data:
           title: "Towner — Left Home"
@@ -120,7 +120,7 @@ automation:
       # Verify still in the school zone
       - condition: template
         value_template: >
-          {{ is_state('person.towner', 'La Vista Middle School') }}
+          {{ (states(person.towner) | lower) == 'la vista middle school' }}
       # Scheduling & weekday
       - condition: template
         value_template: >
@@ -167,7 +167,7 @@ automation:
       # Verify not in school zone
       - condition: template
         value_template: >
-          {{ not is_state('person.towner', 'La Vista Middle School') }}
+          {{ not ((states(person.towner) | lower) == 'la vista middle school') }}
       # Scheduling & weekday (same robust check as above)
       - condition: template
         value_template: >

--- a/packages/towner_notifications.yaml
+++ b/packages/towner_notifications.yaml
@@ -1,36 +1,99 @@
-# packages/quick_notifications.yaml
+# packages/towner_notifications.yaml
 #
-# Quick notifications for Towner zone transitions:
-# - Arrive/leave home
-# - Arrive/leave La Vista Middle School
+# Towner notifications
+#
+# - Debounce configurable
+# - School window configurable
+# - Single toggle for days off
+# - Expected-home flag
+# - Arrival home notifications only when expected flag set
+# - Weekdays only by default
+# - Daily safety reset clears expected flag
+
+input_number:
+  towner_notification_delay_seconds:
+    name: "Towner Notification Delay (seconds)"
+    min: 5
+    max: 300
+    step: 1
+    unit_of_measurement: "s"
+    icon: mdi:clock
+    initial: 30
+
+input_datetime:
+  towner_school_window_start_time:
+    name: "Towner School Window Start"
+    has_date: false
+    has_time: true
+    icon: mdi:calendar-clock
+    initial: "06:30:00"
+
+  towner_school_window_end_time:
+    name: "Towner School Window End"
+    has_date: false
+    has_time: true
+    icon: mdi:calendar-clock
+    initial: "16:00:00"
+
+input_boolean:
+  towner_school_day_enabled:
+    name: "Towner School Day Enabled"
+    icon: mdi:school
+    initial: true
+
+  towner_expected_home:
+    name: "Towner Expected Home"
+    icon: mdi:account-clock
+    initial: false
 
 automation:
-  - id: "notify_towner_arrived_home"
-    alias: "Notify: Towner arrived home"
-    description: "Notify when Towner enters home zone"
+  - id: "notify_towner_arrived_home_if_expected"
+    alias: "Notify: Towner arrived home (only if expected)"
     trigger:
       - platform: zone
         entity_id: person.towner
         zone: zone.home
         event: enter
     action:
+      - variables:
+          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
+      - delay:
+          seconds: "{{ delay_seconds }}"
+      # Verify still at home
+      - condition: template
+        value_template: >
+          {{ is_state('person.towner', 'Home') }}
+      # Only notify if expected-home flag is ON
+      - condition: state
+        entity_id: input_boolean.towner_expected_home
+        state: "on"
       - service: notify.all_mobile_devices
         data:
           title: "Towner — Arrived Home"
           message: "Towner arrived home at {{ now().strftime('%-I:%M %p') }}."
           data:
             tag: "towner-arrived-home"
+      # Clear expected flag after arrival
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.towner_expected_home
     mode: single
 
   - id: "notify_towner_left_home"
     alias: "Notify: Towner left home"
-    description: "Notify when Towner leaves home zone"
     trigger:
       - platform: zone
         entity_id: person.towner
         zone: zone.home
         event: leave
     action:
+      - variables:
+          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
+      - delay:
+          seconds: "{{ delay_seconds }}"
+      - condition: template
+        value_template: >
+          {{ not is_state('person.towner', 'Home') }}
       - service: notify.all_mobile_devices
         data:
           title: "Towner — Left Home"
@@ -48,6 +111,35 @@ automation:
         zone: zone.la_vista_middle_school
         event: enter
     action:
+      - variables:
+          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
+          start_raw: "{{ states('input_datetime.towner_school_window_start_time') }}" 
+          end_raw: "{{ states('input_datetime.towner_school_window_end_time') }}"
+      - delay:
+          seconds: "{{ delay_seconds }}"
+      # Verify still in the school zone
+      - condition: template
+        value_template: >
+          {{ is_state('person.towner', 'La Vista Middle School') }}
+      # Scheduling & weekday
+      - condition: template
+        value_template: >
+          {%- set s = start_raw if start_raw not in ['unknown', 'unavailable', ''] else '00:00:00' -%}
+          {%- set e = end_raw if end_raw not in ['unknown', 'unavailable', ''] else '23:59:59' -%}
+          {%- set fmt = '%Y-%m-%d %H:%M:%S' -%}
+          {%- set today = now().strftime('%Y-%m-%d') -%}
+          {%- set start_dt = strptime(today ~ ' ' ~  s, fmt) -%}
+          {%- set end_dt = strptime(today ~ ' ' ~ e, fmt) -%}
+          {%- set now_ts = as_timestamp(now()) -%}
+          {%- set start_ts = as_timestamp(start_dt) -%}
+          {%- set end_ts = as_timestamp(end_dt) -%}
+          {%- set weekday_ok = now().weekday() < 5 -%}
+          {%- if start_ts <= end_ts -%}
+            {{ weekday_ok and (now_ts >= start_ts) and (now_ts <=end_ts) }}
+          {%- else -%}
+            {# window crosses midnight; accpt if now >= start or now <= end #}
+            {{ weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
+          {%- endif -%}
       - service: notify.all_mobile_devices
         data:
           title: "Towner — Arrived School"
@@ -65,10 +157,59 @@ automation:
         zone: zone.la_vista_middle_school
         event: leave
     action:
+      - variables:
+          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
+          start_raw: "{{ states('input_datetime.towner_school_window_start_time') }}"
+          end_raw: "{{ states('input_datetime.towner_school_window_end_time') }}"
+          school_day_on: "{{ is_state('input_boolean.towner_school_day_enabled','on') }}"
+      - delay:
+          seconds: "{{ delay_seconds }}"
+      # Verify not in school zone
+      - condition: template
+        value_template: >
+          {{ not is_state('person.towner', 'La Vista Middle School') }}
+      # Scheduling & weekday (same robust check as above)
+      - condition: template
+        value_template: >
+          {%- set s = start_raw if start_raw not in ['unknown','unavailable',''] else '00:00:00' -%}
+          {%- set e = end_raw if end_raw not in ['unknown','unavailable',''] else '23:59:59' -%}
+          {%- set fmt = '%Y-%m-%d %H:%M:%S' -%}
+          {%- set today = now().strftime('%Y-%m-%d') -%}
+          {%- set start_dt = strptime(today ~ ' ' ~ s, fmt) -%}
+          {%- set end_dt = strptime(today ~ ' ' ~ e, fmt) -%}
+          {%- set now_ts = as_timestamp(now()) -%}
+          {%- set start_ts = as_timestamp(start_dt) -%}
+          {%- set end_ts = as_timestamp(end_dt) -%}
+          {%- set weekday_ok = now().weekday() < 5 -%}
+          {%- if start_ts <= end_ts -%}
+            {{ weekday_ok and (now_ts >= start_ts) and (now_ts <= end_ts) }}
+          {%- else -%}
+            {{ weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
+          {%- endif -%}
+      # Send departure notification
       - service: notify.all_mobile_devices
         data:
           title: "Towner — Left School"
           message: "Towner left La Vista Middle School at {{ now().strftime('%-I:%M %p') }}."
           data:
             tag: "towner-left-school"
+      # If school_day toggle ON, set expected-home flag
+      - if:
+          - condition: template
+            value_template: "{{ school_day_on }}"
+        then:
+          - service: input_boolean.turn_on
+            target:
+              entity_id: input_boolean.towner_expected_home
+    mode: single
+
+  - id: "towner_expected_home_daily_reset"
+    alias: "Towner expected-home daily reset"
+    trigger:
+      - platform: time
+        at: "02:00:00"
+    action:
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.towner_expected_home
     mode: single

--- a/packages/towner_notifications.yaml
+++ b/packages/towner_notifications.yaml
@@ -1,233 +1,117 @@
 # packages/towner_notifications.yaml
 #
-# Towner notifications
-#
-# - Debounce configurable
-# - School window configurable
-# - Single toggle for days off
-# - Expected-home flag
-# - Arrival home notifications only when expected flag set
-# - Weekdays only by default
-# - Daily safety reset clears expected flag
-
-input_number:
-  towner_notification_delay_seconds:
-    name: "Towner Notification Delay (seconds)"
-    min: 5
-    max: 300
-    step: 1
-    unit_of_measurement: "s"
-    icon: mdi:clock
-    initial: 30
-
-input_datetime:
-  towner_school_window_start_time:
-    name: "Towner School Window Start"
-    has_date: false
-    has_time: true
-    icon: mdi:calendar-clock
-    initial: "06:30:00"
-
-  towner_school_window_end_time:
-    name: "Towner School Window End"
-    has_date: false
-    has_time: true
-    icon: mdi:calendar-clock
-    initial: "16:00:00"
+# Simple Towner school notifications
+# - Morning: notify when leaving for school (6:30-9:00 AM on weekdays)
+# - Afternoon: notify when arriving home from school (first arrival home since leaving)
 
 input_boolean:
-  towner_school_day_enabled:
-    name: "Towner School Day Enabled"
+  towner_left_for_school_today:
+    name: "Towner Left for School Today"
     icon: mdi:school
-    initial: true
-
-  towner_expected_home:
-    name: "Towner Expected Home"
-    icon: mdi:account-clock
     initial: false
 
 automation:
-  - id: "notify_towner_arrived_home_if_expected"
-    alias: "Notify: Towner arrived home (only if expected)"
+  - id: "notify_towner_left_for_school"
+    alias: "Notify: Towner left for school"
+    description: "Notify when Towner leaves home for school in the morning"
     trigger:
-      - platform: zone
+      - platform: state
         entity_id: person.towner
-        zone: zone.home
-        event: enter
+        from: "home"
+    condition:
+      - condition: time
+        after: "06:30:00"
+        before: "09:00:00"
+        weekday:
+          - mon
+          - tue
+          - wed
+          - thu
+          - fri
     action:
-      - variables:
-          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
-      - delay:
-          seconds: "{{ delay_seconds }}"
-      # Verify still at home
-      - condition: template
-        value_template: >
-          {{ (states('person.towner') | lower) == 'home' }}
-      # Check that person was away from home for at least delay_seconds before this arrival
-      - condition: template
-        value_template: >
-          {% set last_changed = states.person.towner.last_changed %}
-          {% set now_ts = as_timestamp(now()) %}
-          {% set changed_ts = as_timestamp(last_changed) %}
-          {% set time_since_change = now_ts - changed_ts %}
-          {{ time_since_change >= delay_seconds }}
-      # Only notify if expected-home flag is ON
-      - condition: state
-        entity_id: input_boolean.towner_expected_home
-        state: "on"
       - service: notify.all_mobile_devices
         data:
-          title: "Towner — Arrived Home"
-          message: "Towner arrived home at {{ now().strftime('%-I:%M %p') }}."
+          title: "Towner — Left for School"
+          message: "Towner left home for school at {{ now().strftime('%-I:%M %p') }}."
           data:
-            tag: "towner-arrived-home"
-      # Clear expected flag after arrival
-      - service: input_boolean.turn_off
+            tag: "towner-school"
+      - service: input_boolean.turn_on
         target:
-          entity_id: input_boolean.towner_expected_home
-    mode: single
-
-  - id: "notify_towner_left_home"
-    alias: "Notify: Towner left home"
-    trigger:
-      - platform: zone
-        entity_id: person.towner
-        zone: zone.home
-        event: leave
-    action:
-      - variables:
-          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
-      - delay:
-          seconds: "{{ delay_seconds }}"
-      - condition: template
-        value_template: >
-          {{ not ((states('person.towner') | lower) == 'home') }}
-      - service: notify.all_mobile_devices
-        data:
-          title: "Towner — Left Home"
-          message: "Towner left home at {{ now().strftime('%-I:%M %p') }}."
-          data:
-            tag: "towner-left-home"
+          entity_id: input_boolean.towner_left_for_school_today
     mode: single
 
   - id: "notify_towner_arrived_school"
-    alias: "Notify: Towner arrived La Vista Middle School"
-    description: "Notify when Towner enters La Vista Middle School zone"
+    alias: "Notify: Towner arrived at school"
+    description: "Notify when Towner arrives at La Vista Middle School"
     trigger:
-      - platform: zone
+      - platform: state
         entity_id: person.towner
-        zone: zone.la_vista_middle_school
-        event: enter
+        to: "La Vista Middle School"
+    condition:
+      - condition: state
+        entity_id: input_boolean.towner_left_for_school_today
+        state: "on"
     action:
-      - variables:
-          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
-          start_raw: "{{ states('input_datetime.towner_school_window_start_time') }}" 
-          end_raw: "{{ states('input_datetime.towner_school_window_end_time') }}"
-      - delay:
-          seconds: "{{ delay_seconds }}"
-      # Verify still in the school zone
-      - condition: template
-        value_template: >
-          {{ (states('person.towner') | lower) == 'la vista middle school' }}
-      # Check that person was away from school for at least delay_seconds before this arrival
-      - condition: template
-        value_template: >
-          {% set last_changed = states.person.towner.last_changed %}
-          {% set now_ts = as_timestamp(now()) %}
-          {% set changed_ts = as_timestamp(last_changed) %}
-          {% set time_since_change = now_ts - changed_ts %}
-          {{ time_since_change >= delay_seconds }}
-      # Scheduling & weekday
-      - condition: template
-        value_template: >
-          {%- set s = start_raw if start_raw not in ['unknown', 'unavailable', ''] else '00:00:00' -%}
-          {%- set e = end_raw if end_raw not in ['unknown', 'unavailable', ''] else '23:59:59' -%}
-          {%- set fmt = '%Y-%m-%d %H:%M:%S' -%}
-          {%- set today = now().strftime('%Y-%m-%d') -%}
-          {%- set start_dt = strptime(today ~ ' ' ~  s, fmt) -%}
-          {%- set end_dt = strptime(today ~ ' ' ~ e, fmt) -%}
-          {%- set now_ts = as_timestamp(now()) -%}
-          {%- set start_ts = as_timestamp(start_dt) -%}
-          {%- set end_ts = as_timestamp(end_dt) -%}
-          {%- set weekday_ok = now().weekday() < 5 -%}
-          {%- set school_day_ok = is_state('input_boolean.towner_school_day_enabled','on') -%}
-          {%- if start_ts <= end_ts -%}
-            {{ school_day_ok and weekday_ok and (now_ts >= start_ts) and (now_ts <=end_ts) }}
-          {%- else -%}
-            {# window crosses midnight; accept if now >= start or now <= end #}
-            {{ school_day_ok and weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
-          {%- endif -%}
       - service: notify.all_mobile_devices
         data:
-          title: "Towner — Arrived School"
+          title: "Towner — Arrived at School"
           message: "Towner arrived at La Vista Middle School at {{ now().strftime('%-I:%M %p') }}."
           data:
-            tag: "towner-arrived-school"
+            tag: "towner-school"
     mode: single
 
   - id: "notify_towner_left_school"
-    alias: "Notify: Towner left La Vista Middle School"
-    description: "Notify when Towner leaves La Vista Middle School zone"
+    alias: "Notify: Towner left school"
+    description: "Notify when Towner leaves La Vista Middle School"
     trigger:
-      - platform: zone
+      - platform: state
         entity_id: person.towner
-        zone: zone.la_vista_middle_school
-        event: leave
+        from: "La Vista Middle School"
+        for: "00:01:00"
+    condition:
+      - condition: state
+        entity_id: input_boolean.towner_left_for_school_today
+        state: "on"
     action:
-      - variables:
-          delay_seconds: "{{ states('input_number.towner_notification_delay_seconds') | int(30) }}"
-          start_raw: "{{ states('input_datetime.towner_school_window_start_time') }}"
-          end_raw: "{{ states('input_datetime.towner_school_window_end_time') }}"
-          school_day_on: "{{ is_state('input_boolean.towner_school_day_enabled','on') }}"
-      - delay:
-          seconds: "{{ delay_seconds }}"
-      # Verify not in school zone
-      - condition: template
-        value_template: >
-          {{ not ((states('person.towner') | lower) == 'la vista middle school') }}
-      # Scheduling & weekday (same robust check as above)
-      - condition: template
-        value_template: >
-          {%- set s = start_raw if start_raw not in ['unknown','unavailable',''] else '00:00:00' -%}
-          {%- set e = end_raw if end_raw not in ['unknown','unavailable',''] else '23:59:59' -%}
-          {%- set fmt = '%Y-%m-%d %H:%M:%S' -%}
-          {%- set today = now().strftime('%Y-%m-%d') -%}
-          {%- set start_dt = strptime(today ~ ' ' ~ s, fmt) -%}
-          {%- set end_dt = strptime(today ~ ' ' ~ e, fmt) -%}
-          {%- set now_ts = as_timestamp(now()) -%}
-          {%- set start_ts = as_timestamp(start_dt) -%}
-          {%- set end_ts = as_timestamp(end_dt) -%}
-          {%- set weekday_ok = now().weekday() < 5 -%}
-          {%- set school_day_ok = is_state('input_boolean.towner_school_day_enabled','on') -%}
-          {%- if start_ts <= end_ts -%}
-            {{ school_day_ok and weekday_ok and (now_ts >= start_ts) and (now_ts <= end_ts) }}
-          {%- else -%}
-            {{ school_day_ok and weekday_ok and ((now_ts >= start_ts) or (now_ts <= end_ts)) }}
-          {%- endif -%}
-      # Send departure notification
       - service: notify.all_mobile_devices
         data:
           title: "Towner — Left School"
           message: "Towner left La Vista Middle School at {{ now().strftime('%-I:%M %p') }}."
           data:
-            tag: "towner-left-school"
-      # If school_day toggle ON, set expected-home flag
-      - if:
-          - condition: template
-            value_template: "{{ school_day_on }}"
-        then:
-          - service: input_boolean.turn_on
-            target:
-              entity_id: input_boolean.towner_expected_home
+            tag: "towner-school"
     mode: single
 
-  - id: "towner_expected_home_daily_reset"
-    alias: "Towner expected-home daily reset"
+  - id: "notify_towner_home_from_school"
+    alias: "Notify: Towner arrived home from school"
+    description: "Notify when Towner arrives home from school (first time since leaving)"
+    trigger:
+      - platform: state
+        entity_id: person.towner
+        to: "home"
+    condition:
+      - condition: state
+        entity_id: input_boolean.towner_left_for_school_today
+        state: "on"
+    action:
+      - service: notify.all_mobile_devices
+        data:
+          title: "Towner — Home from School"
+          message: "Towner arrived home from school at {{ now().strftime('%-I:%M %p') }}."
+          data:
+            tag: "towner-school"
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.towner_left_for_school_today
+    mode: single
+
+  - id: "towner_school_flag_daily_reset"
+    alias: "Reset Towner school flag daily"
+    description: "Reset the left-for-school flag each morning"
     trigger:
       - platform: time
-        at: "02:00:00"
+        at: "06:00:00"
     action:
       - service: input_boolean.turn_off
         target:
-          entity_id: input_boolean.towner_expected_home
+          entity_id: input_boolean.towner_left_for_school_today
     mode: single

--- a/packages/towner_notifications.yaml
+++ b/packages/towner_notifications.yaml
@@ -63,6 +63,14 @@ automation:
       - condition: template
         value_template: >
           {{ (states('person.towner') | lower) == 'home' }}
+      # Check that person was away from home for at least delay_seconds before this arrival
+      - condition: template
+        value_template: >
+          {% set last_changed = states.person.towner.last_changed %}
+          {% set now_ts = as_timestamp(now()) %}
+          {% set changed_ts = as_timestamp(last_changed) %}
+          {% set time_since_change = now_ts - changed_ts %}
+          {{ time_since_change >= delay_seconds }}
       # Only notify if expected-home flag is ON
       - condition: state
         entity_id: input_boolean.towner_expected_home
@@ -121,6 +129,14 @@ automation:
       - condition: template
         value_template: >
           {{ (states('person.towner') | lower) == 'la vista middle school' }}
+      # Check that person was away from school for at least delay_seconds before this arrival
+      - condition: template
+        value_template: >
+          {% set last_changed = states.person.towner.last_changed %}
+          {% set now_ts = as_timestamp(now()) %}
+          {% set changed_ts = as_timestamp(last_changed) %}
+          {% set time_since_change = now_ts - changed_ts %}
+          {{ time_since_change >= delay_seconds }}
       # Scheduling & weekday
       - condition: template
         value_template: >


### PR DESCRIPTION
Simplified Towner school notification system by replacing complex zone event handling with clean state-based tracking.

## Changes

- **Replaced zone events with state transitions**: Changed from `platform: zone` with `event: enter/leave` to `platform: state` with `to/from` values for more reliable tracking
- **Added school day state tracking**: New `input_boolean.towner_left_for_school_today` tracks whether Towner has left for school
- **School-specific notifications**: Only triggers school arrival/departure notifications if he actually left for school that day (6:30-9:00 AM weekdays)
- **Prevents false home arrivals**: Home arrival notifications only fire if the school day flag is set
- **Daily reset**: Automatic flag reset at 6:00 AM each day
- **1-minute delay on school departure**: Added `for: "00:01:00"` to prevent GPS bounce false positives
- **Consistent notification tagging**: All school-related notifications use `towner-school` tag

## Implementation Details

The new system uses a simple boolean flag that:
1. Gets set when Towner leaves home during school hours (weekday mornings 6:30-9:00)
2. Gates all subsequent school-related notifications 
3. Gets cleared when he arrives home OR at 6:00 AM daily reset
4. Eliminates complex templating in favor of straightforward state conditions

This fixes GPS bouncing issues and ensures notifications only happen during actual school day workflows.

Closes #70