### PR TITLE
fix: harden template condition handling for remote dimming

### DIFF
--- a/packages/remotes.yaml
+++ b/packages/remotes.yaml
@@ -10,13 +10,17 @@ input_boolean:
 script:
   lamp_dim_sequence:
     variables:
-      lamp: null
-      direction: null # 'up' or 'down'
-      dimming_helper: null
+      lamp: ""
+      direction: "" # 'up' or 'down'
+      dimming_helper: ""
       transition_step: 5
       transition_time: 500
     mode: restart
     sequence:
+      - condition: template
+        value_template: >
+          {{ lamp | length > 0 and dimming_helper | length > 0 and direction in ['up', 'down'] }}
+
       # Start by making sure helper is in correct state
       - service: input_boolean.turn_on
         data:


### PR DESCRIPTION
## Summary
- replace null script defaults with empty strings in `packages/remotes.yaml`
- add a template guard so the dimming script only runs with valid lamp/helper/direction inputs
- keep scope to the remaining issue #79 reliability gap; `packages/cameras.yaml` is already handling missing payload data safely on `dev`

## Validation
- parsed `packages/remotes.yaml` and `packages/cameras.yaml` with `python3` + `yaml.safe_load`
- ran `git diff --check`
- local Home Assistant config check was not run; this repo's notes indicate `ha core check` is not reliable here, so CI validation will come from the existing GitHub workflow

Closes #79