### PR TITLE
refactor: standardize entity state validation

### DIFF
--- a/packages/brief/data_collectors.yaml
+++ b/packages/brief/data_collectors.yaml
@@ -12,13 +12,11 @@ script:
       dishwasher_state:
         "{{ states('sensor.kitchen_dishwasher_operation_state') }}"
       dishwasher_available: >
-        {{ not is_state('sensor.kitchen_dishwasher_operation_state',
-        'unavailable') and
-           not is_state('sensor.kitchen_dishwasher_operation_state', 'unknown')
-        }}
+        {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+        {{ dishwasher_state not in invalid_states }}
       dishwasher_running: >
         {{ dishwasher_available and
-           states('sensor.kitchen_dishwasher_operation_state') == "run" }}
+           dishwasher_state == "run" }}
       # Dishwasher maintenance sensors - checks if salt or rinse aid is low
       needs_salt: >
         {{ states('sensor.kitchen_dishwasher_salt_nearly_empty') == 'on' }}

--- a/packages/brief/validator.yaml
+++ b/packages/brief/validator.yaml
@@ -22,17 +22,18 @@ template:
         unique_id: brief_validation_status
         state: >
           {%- set config_entities = states('sensor.brief_config_entity_references') -%}
-          {%- if config_entities in ['unknown', 'unavailable'] -%}
+          {%- set invalid_states = ['unknown', 'unavailable', '', none] -%}
+          {%- if config_entities in invalid_states -%}
             pending
           {%- else -%}
             {%- set conversation_agent = state_attr('sensor.brief_config_entity_references', 'conversation_agent') -%}
             {%- set weather = state_attr('sensor.brief_config_entity_references', 'weather') -%}
             {%- set notification_service = state_attr('sensor.brief_config_entity_references', 'notification_service') -%}
             {%- set valid_count = 0 -%}
-            {%- if conversation_agent and states(conversation_agent) not in ['unknown', 'unavailable'] -%}
+            {%- if conversation_agent and states(conversation_agent) not in invalid_states -%}
               {%- set valid_count = valid_count + 1 -%}
             {%- endif -%}
-            {%- if weather and states(weather) not in ['unknown', 'unavailable'] -%}
+            {%- if weather and states(weather) not in invalid_states -%}
               {%- set valid_count = valid_count + 1 -%}
             {%- endif -%}
             {%- if notification_service -%}
@@ -53,17 +54,18 @@ template:
         unique_id: brief_validation_errors
         state: >
           {%- set config_entities = states('sensor.brief_config_entity_references') -%}
-          {%- if config_entities in ['unknown', 'unavailable'] -%}
+          {%- set invalid_states = ['unknown', 'unavailable', '', none] -%}
+          {%- if config_entities in invalid_states -%}
             Config entities not yet loaded
           {%- else -%}
             {%- set conversation_agent = state_attr('sensor.brief_config_entity_references', 'conversation_agent') -%}
             {%- set weather = state_attr('sensor.brief_config_entity_references', 'weather') -%}
             {%- set notification_service = state_attr('sensor.brief_config_entity_references', 'notification_service') -%}
             {%- set errors = [] -%}
-            {%- if conversation_agent and states(conversation_agent) in ['unknown', 'unavailable'] -%}
+            {%- if conversation_agent and states(conversation_agent) in invalid_states -%}
               {%- set errors = errors + [conversation_agent ~ ' (conversation agent)'] -%}
             {%- endif -%}
-            {%- if weather and states(weather) in ['unknown', 'unavailable'] -%}
+            {%- if weather and states(weather) in invalid_states -%}
               {%- set errors = errors + [weather ~ ' (weather)'] -%}
             {%- endif -%}
             {%- if errors | length > 0 -%}
@@ -128,7 +130,8 @@ automation:
       - platform: template
         value_template: >
           {% set sensor = states('sensor.brief_config_entity_references') %}
-          {{ sensor not in ['unknown', 'unavailable', 'unknown'] }}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {{ sensor not in invalid_states }}
     action:
       - service: template.reload
 

--- a/packages/garage_door_monitoring.yaml
+++ b/packages/garage_door_monitoring.yaml
@@ -152,8 +152,8 @@ automation:
       - if:
           - condition: template
             value_template:
-              "{{ active_tag != 'unknown' and active_tag != '' and active_tag !=
-              'unset' }}"
+              "{% set invalid_states = ['unknown', 'unavailable', '', none,
+              'unset'] %}{{ active_tag not in invalid_states }}"
         then:
           - service: notify.all_mobile_devices
             data:
@@ -240,8 +240,8 @@ automation:
               - if:
                   - condition: template
                     value_template:
-                      "{{ active_tag != 'unknown' and active_tag != '' and
-                      active_tag != 'unset' }}"
+                      "{% set invalid_states = ['unknown', 'unavailable', '',
+                      none, 'unset'] %}{{ active_tag not in invalid_states }}"
                 then:
                   - service: notify.all_mobile_devices
                     data:
@@ -284,8 +284,8 @@ automation:
               - if:
                   - condition: template
                     value_template:
-                      "{{ active_tag != 'unknown' and active_tag != '' and
-                      active_tag != 'unset' }}"
+                      "{% set invalid_states = ['unknown', 'unavailable', '',
+                      none, 'unset'] %}{{ active_tag not in invalid_states }}"
                 then:
                   - service: notify.all_mobile_devices
                     data:

--- a/packages/routines.yaml
+++ b/packages/routines.yaml
@@ -20,13 +20,11 @@ script:
           dishwasher_state:
             "{{ states('sensor.kitchen_dishwasher_operation_state') }}"
           is_dishwasher_available: >
-            {{ not is_state('sensor.kitchen_dishwasher_operation_state',
-            'unavailable') and
-               not is_state('sensor.kitchen_dishwasher_operation_state',
-            'unknown') }}
+            {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+            {{ dishwasher_state not in invalid_states }}
           is_dishwasher_running: >
             {{ is_dishwasher_available and
-               states('sensor.kitchen_dishwasher_operation_state') == "run" }}
+               dishwasher_state == "run" }}
 
       # Always: Turn on bedside lamps to 50% with a nice transition
       - service: light.turn_on

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -51,7 +51,8 @@ automation:
       - condition: template
         value_template: >
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
-          {{ sensor_state not in ('unknown', 'unavailable') }}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {{ sensor_state not in invalid_states }}
       # Only notify during reasonable hours
       - condition: time
         after: "05:00:00"
@@ -96,7 +97,8 @@ automation:
         value_template: >
           {% set last_updated = states('sensor.weather_last_updated') %}
           {% set min_interval = states('input_number.weather_update_frequency') | int %}
-          {% if last_updated == 'unknown' or last_updated == 'unavailable' %}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% if last_updated in invalid_states %}
             true
           {% else %}
             {% set time_diff = (now().timestamp() - as_timestamp(last_updated)) / 60 %}
@@ -182,7 +184,8 @@ template:
         unique_id: weather_forecast_condition_next_hour
         state: >
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
-          {% if sensor_state not in ('unknown', 'unavailable') %}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% if sensor_state not in invalid_states %}
             {% set forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {{ forecast[0].condition | default('unknown') }}
@@ -197,7 +200,8 @@ template:
         unique_id: weather_forecast_condition_today
         state: >
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
-          {% if sensor_state not in ('unknown', 'unavailable') %}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% if sensor_state not in invalid_states %}
             {% set forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {{ forecast[0].condition | default('unknown') }}
@@ -212,7 +216,8 @@ template:
         unique_id: weather_forecast_precipitation_next_hour
         state: >
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
-          {% if sensor_state not in ('unknown', 'unavailable') %}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% if sensor_state not in invalid_states %}
             {% set forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {% if forecast[0].precipitation is defined %}
@@ -232,7 +237,8 @@ template:
         unique_id: weather_forecast_temperature_high_today
         state: >
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
-          {% if sensor_state not in ('unknown', 'unavailable') %}
+          {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% if sensor_state not in invalid_states %}
             {% set forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {% if forecast[0].temperature is defined %}

--- a/tests/test_entity_state_validation.py
+++ b/tests/test_entity_state_validation.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WEATHER_YAML = ROOT / "packages" / "weather.yaml"
+ROUTINES_YAML = ROOT / "packages" / "routines.yaml"
+GARAGE_YAML = ROOT / "packages" / "garage_door_monitoring.yaml"
+FIXED_NOW = datetime(2026, 6, 3, 12, 0, 0)
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text())
+
+
+def render_template(template_string: str, *, state_map=None, context=None):
+    env = Environment(trim_blocks=True, lstrip_blocks=True)
+    state_map = state_map or {}
+    context = context or {}
+
+    def states(entity_id):
+        return state_map.get(entity_id)
+
+    def as_timestamp(value):
+        if isinstance(value, datetime):
+            return value.timestamp()
+        if value in (None, "", "unknown", "unavailable"):
+            raise ValueError(f"invalid timestamp source: {value!r}")
+        return datetime.fromisoformat(value).timestamp()
+
+    env.globals.update(
+        states=states,
+        is_state=lambda entity_id, expected: states(entity_id) == expected,
+        state_attr=lambda entity_id, attr: context.get("state_attr", {}).get((entity_id, attr)),
+        as_timestamp=as_timestamp,
+        now=lambda: FIXED_NOW,
+    )
+    return env.from_string(template_string).render(context)
+
+
+def normalize_bool(value):
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise AssertionError(f"expected boolean-like render, got {value!r}")
+
+
+def weather_automation(automation_id: str):
+    for automation in load_yaml(WEATHER_YAML)["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"weather automation {automation_id!r} not found")
+
+
+def garage_automation(automation_id: str):
+    for automation in load_yaml(GARAGE_YAML)["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"garage automation {automation_id!r} not found")
+
+
+def garage_active_tag_templates():
+    closed_reset = garage_automation("garage_door_closed_reset_notification")
+    action_handler = garage_automation("garage_door_notification_actions")
+    choose_blocks = action_handler["action"][0]["choose"]
+    return [
+        closed_reset["action"][2]["if"][0]["value_template"],
+        choose_blocks[1]["sequence"][2]["if"][0]["value_template"],
+        choose_blocks[2]["sequence"][2]["if"][0]["value_template"],
+    ]
+
+
+def test_weather_refresh_treats_empty_and_none_last_updated_as_invalid():
+    template_string = weather_automation("weather_data_refresh")["condition"][0]["value_template"]
+
+    for invalid_value in ("unknown", "unavailable", "", None):
+        rendered = render_template(
+            template_string,
+            state_map={
+                "sensor.weather_last_updated": invalid_value,
+                "input_number.weather_update_frequency": "30",
+            },
+        )
+        assert normalize_bool(rendered) is True
+
+
+
+def test_good_night_dishwasher_availability_handles_empty_and_none_states():
+    variables = load_yaml(ROUTINES_YAML)["script"]["good_night"]["sequence"][0]["variables"]
+    template_string = variables["is_dishwasher_available"]
+
+    for invalid_value in ("unknown", "unavailable", "", None):
+        rendered = render_template(
+            template_string,
+            state_map={"sensor.kitchen_dishwasher_operation_state": invalid_value},
+            context={"dishwasher_state": invalid_value},
+        )
+        assert normalize_bool(rendered) is False
+
+    rendered = render_template(
+        template_string,
+        state_map={"sensor.kitchen_dishwasher_operation_state": "run"},
+        context={"dishwasher_state": "run"},
+    )
+    assert normalize_bool(rendered) is True
+
+
+
+def test_garage_notification_tag_checks_share_the_same_invalid_state_handling():
+    for template_string in garage_active_tag_templates():
+        for invalid_value in ("unknown", "unavailable", "", None, "unset"):
+            rendered = render_template(template_string, context={"active_tag": invalid_value})
+            assert normalize_bool(rendered) is False
+
+        rendered = render_template(template_string, context={"active_tag": "garage-door-open-123"})
+        assert normalize_bool(rendered) is True


### PR DESCRIPTION
## Summary
- standardize invalid entity state checks around unknown/unavailable/empty/none values in the weather, routines, garage-door, and brief packages
- reuse local template variables where available instead of repeating direct `states()` lookups
- add regression tests covering weather refresh timestamps, dishwasher availability checks, and garage notification tag validation

## Validation
- pytest -q
- pytest tests/test_entity_state_validation.py -q
- python YAML parse check for changed package files
- git diff --check
- dockerized `hass --script check_config --config .` against a temp copy with dummy service-account/secrets files

Closes #80