### PR TITLE
feat(device_health): add connectivity monitoring alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This Home Assistant configuration provides a comprehensive smart home automation
 - **Lighting Control**: Automated lighting based on presence, time of day, and security events
 - **Routine Automation**: Good night routines, morning wake-up sequences, and presence-based automations
 - **Notification System**: Multi-device alerts for critical events and daily briefings
+- **Device Health Monitoring**: Battery, Z-Wave connectivity, and stale-device visibility
 - **Weather Integration**: Automated responses to weather conditions
 - **Chore Management**: Tracking and rotation of household responsibilities
 
@@ -41,6 +42,7 @@ This Home Assistant configuration provides a comprehensive smart home automation
 This configuration uses Home Assistant's packages feature to organize functionality into discrete modules:
 
 - **cameras.yaml**: Camera integration with motion detection and notifications
+- **device_health.yaml**: Battery monitoring plus conservative device connectivity alerts
 - **chores.yaml**: Household chore rotation and tracking system
 - **light_groups.yaml**: Logical grouping of lights for easier control
 - **presence.yaml**: Presence detection and related automations

--- a/packages/device_health.yaml
+++ b/packages/device_health.yaml
@@ -34,6 +34,21 @@ input_boolean:
     icon: mdi:battery-10
     initial: false
 
+  device_connectivity_monitoring_enabled:
+    name: "Device Connectivity Monitoring"
+    icon: mdi:access-point-network
+    initial: true
+
+  device_connectivity_alerts_enabled:
+    name: "Device Connectivity Alerts"
+    icon: mdi:network-alert
+    initial: true
+
+  device_connectivity_alert_sent:
+    name: "Device Connectivity Alert Status"
+    icon: mdi:bell-ring
+    initial: false
+
 input_number:
   device_health_critical_threshold:
     name: "Critical Battery Threshold"
@@ -61,6 +76,15 @@ input_number:
     unit_of_measurement: "%"
     icon: mdi:battery-alert-variant-outline
     initial: *low_threshold
+
+  device_connectivity_last_seen_threshold_hours:
+    name: "Device Connectivity Last Seen Threshold"
+    min: 1
+    max: 168
+    step: 1
+    unit_of_measurement: "hours"
+    icon: mdi:clock-alert-outline
+    initial: 24
 
 template:
   - sensor:
@@ -226,6 +250,118 @@ template:
           {% endif %}
         device_class: problem
 
+  - sensor:
+      - name: "Device Connectivity Z-Wave Problems"
+        unique_id: device_connectivity_zwave_problems
+        state: >
+          {% set ns = namespace(problem_nodes=[]) %}
+          {% for entity in states.sensor %}
+            {% if entity.entity_id.endswith('_node_status') and not entity.entity_id.startswith('sensor.device_connectivity_') %}
+              {% set status = entity.state | string | lower %}
+              {% if status not in ['alive', 'asleep', 'awake'] %}
+                {% set ns.problem_nodes = ns.problem_nodes + [entity.name or entity.entity_id] %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.problem_nodes | length }}
+        unit_of_measurement: "nodes"
+        attributes:
+          problem_nodes: >
+            {% set ns = namespace(problem_nodes=[]) %}
+            {% for entity in states.sensor %}
+              {% if entity.entity_id.endswith('_node_status') and not entity.entity_id.startswith('sensor.device_connectivity_') %}
+                {% set status = entity.state | string | lower %}
+                {% if status not in ['alive', 'asleep', 'awake'] %}
+                  {% set ns.problem_nodes = ns.problem_nodes + [(entity.name or entity.entity_id) ~ ' (' ~ entity.state ~ ')'] %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.problem_nodes | join(', ') if ns.problem_nodes else 'None' }}
+
+      - name: "Device Connectivity Stale Last Seen"
+        unique_id: device_connectivity_stale_last_seen
+        state: >
+          {% set threshold_hours = states('input_number.device_connectivity_last_seen_threshold_hours') | int(24) %}
+          {% set now_ts = as_timestamp(now()) %}
+          {% set ns = namespace(stale_devices=[]) %}
+          {% for entity in states.sensor %}
+            {% if entity.entity_id.endswith('_last_seen') and not entity.entity_id.startswith('sensor.device_connectivity_') %}
+              {% set last_seen = entity.state %}
+              {% if last_seen not in ['unknown', 'unavailable', '', none] %}
+                {% set age_hours = ((now_ts - as_timestamp(last_seen)) / 3600) | round(1) %}
+                {% if age_hours > threshold_hours %}
+                  {% set ns.stale_devices = ns.stale_devices + [(entity.name or entity.entity_id) ~ ' (' ~ age_hours ~ 'h)'] %}
+                {% endif %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.stale_devices | length }}
+        unit_of_measurement: "devices"
+        attributes:
+          threshold_hours: >
+            {{ states('input_number.device_connectivity_last_seen_threshold_hours') | int(24) }}
+          stale_devices: >
+            {% set threshold_hours = states('input_number.device_connectivity_last_seen_threshold_hours') | int(24) %}
+            {% set now_ts = as_timestamp(now()) %}
+            {% set ns = namespace(stale_devices=[]) %}
+            {% for entity in states.sensor %}
+              {% if entity.entity_id.endswith('_last_seen') and not entity.entity_id.startswith('sensor.device_connectivity_') %}
+                {% set last_seen = entity.state %}
+                {% if last_seen not in ['unknown', 'unavailable', '', none] %}
+                  {% set age_hours = ((now_ts - as_timestamp(last_seen)) / 3600) | round(1) %}
+                  {% if age_hours > threshold_hours %}
+                    {% set ns.stale_devices = ns.stale_devices + [(entity.name or entity.entity_id) ~ ' (' ~ age_hours ~ 'h)'] %}
+                  {% endif %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.stale_devices | join(', ') if ns.stale_devices else 'None' }}
+
+      - name: "Device Connectivity Integration Problems"
+        unique_id: device_connectivity_integration_problems
+        state: >
+          {% set ns = namespace(problem_updates=[]) %}
+          {% for entity in states.update %}
+            {% if entity.state in ['unavailable', 'unknown'] %}
+              {% set ns.problem_updates = ns.problem_updates + [entity.name or entity.entity_id] %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.problem_updates | length }}
+        unit_of_measurement: "entities"
+        attributes:
+          problem_updates: >
+            {% set ns = namespace(problem_updates=[]) %}
+            {% for entity in states.update %}
+              {% if entity.state in ['unavailable', 'unknown'] %}
+                {% set ns.problem_updates = ns.problem_updates + [(entity.name or entity.entity_id) ~ ' (' ~ entity.state ~ ')'] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.problem_updates | join(', ') if ns.problem_updates else 'None' }}
+
+      - name: "Device Connectivity Summary"
+        unique_id: device_connectivity_summary
+        state: >
+          {{
+            states('sensor.device_connectivity_zwave_problems') | int(0)
+            + states('sensor.device_connectivity_stale_last_seen') | int(0)
+            + states('sensor.device_connectivity_integration_problems') | int(0)
+          }}
+        unit_of_measurement: "issues"
+        attributes:
+          zwave_problem_nodes: >
+            {{ state_attr('sensor.device_connectivity_zwave_problems', 'problem_nodes') }}
+          stale_devices: >
+            {{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}
+          integration_problems: >
+            {{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}
+
+  - binary_sensor:
+      - name: "Device Connectivity Has Issues"
+        unique_id: device_connectivity_has_issues
+        state: >
+          {{ states('sensor.device_connectivity_summary') | int(0) > 0 }}
+        device_class: problem
+
 automation:
   - alias: "device_health_critical_battery_alert"
     id: "device_health_critical_battery_alert"
@@ -388,3 +524,76 @@ automation:
               - service: input_boolean.turn_off
                 target:
                   entity_id: input_boolean.device_health_critical_alert_sent
+
+  - alias: "device_connectivity_issue_alert"
+    id: "device_connectivity_issue_alert"
+    description: "Alert when Z-Wave nodes, last_seen sensors, or integration update entities look unhealthy"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.device_connectivity_has_issues
+        to: "on"
+        for:
+          minutes: 15
+    condition:
+      - condition: state
+        entity_id: input_boolean.device_connectivity_monitoring_enabled
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.device_connectivity_alerts_enabled
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.device_connectivity_alert_sent
+        state: "off"
+    action:
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.device_connectivity_alert_sent
+      - variables:
+          total_issues: "{{ states('sensor.device_connectivity_summary') | int(0) }}"
+          zwave_count: "{{ states('sensor.device_connectivity_zwave_problems') | int(0) }}"
+          stale_count: "{{ states('sensor.device_connectivity_stale_last_seen') | int(0) }}"
+          integration_count: "{{ states('sensor.device_connectivity_integration_problems') | int(0) }}"
+          zwave_summary: "{{ state_attr('sensor.device_connectivity_zwave_problems', 'problem_nodes') }}"
+          stale_summary: "{{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}"
+          integration_summary: "{{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}"
+      - service: notify.all_mobile_devices
+        data:
+          title: "Device Connectivity Alert"
+          message: >
+            Detected {{ total_issues }} connectivity issue{{ 's' if total_issues != 1 else '' }}.
+            Z-Wave: {{ zwave_count }} ({{ zwave_summary }}).
+            Last seen: {{ stale_count }} ({{ stale_summary }}).
+            Integrations: {{ integration_count }} ({{ integration_summary }}).
+          data:
+            tag: "device-connectivity-alert"
+            priority: "high"
+            ttl: 0
+      - service: persistent_notification.create
+        data:
+          title: "Device Connectivity Alert"
+          notification_id: device_connectivity_alert
+          message: >
+            Z-Wave problem nodes: {{ zwave_summary }}
+
+            Stale last_seen devices: {{ stale_summary }}
+
+            Unavailable update entities: {{ integration_summary }}
+
+            Threshold: {{ states('input_number.device_connectivity_last_seen_threshold_hours') | int(24) }} hours
+
+  - alias: "device_connectivity_issue_alert_reset"
+    id: "device_connectivity_issue_alert_reset"
+    description: "Reset connectivity alert flag once all monitored entities recover"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.device_connectivity_has_issues
+        to: "off"
+        for:
+          minutes: 30
+    action:
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.device_connectivity_alert_sent
+      - service: persistent_notification.dismiss
+        data:
+          notification_id: device_connectivity_alert

--- a/tests/test_device_connectivity_templates.py
+++ b/tests/test_device_connectivity_templates.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEVICE_HEALTH_YAML = ROOT / "packages" / "device_health.yaml"
+FIXED_NOW = datetime(2026, 6, 4, 12, 0, 0)
+
+
+class Entity:
+    def __init__(self, entity_id: str, state, name: str | None = None, attributes=None):
+        self.entity_id = entity_id
+        self.state = state
+        self.name = name or entity_id
+        self.attributes = attributes or {}
+
+
+class StatesProxy:
+    def __init__(self, entities, state_map=None):
+        self._entities = list(entities)
+        self._state_map = state_map or {}
+
+    def __call__(self, entity_id):
+        return self._state_map.get(entity_id)
+
+    def __iter__(self):
+        return iter(self._entities)
+
+    def __getattr__(self, domain):
+        prefix = f"{domain}."
+        return [entity for entity in self._entities if entity.entity_id.startswith(prefix)]
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text())
+
+
+def device_health_sensor(sensor_name: str):
+    template_blocks = load_yaml(DEVICE_HEALTH_YAML)["template"]
+    for block in template_blocks:
+        for sensor in block.get("sensor", []):
+            if sensor["name"] == sensor_name:
+                return sensor
+    raise AssertionError(f"device health sensor {sensor_name!r} not found")
+
+
+def render_template(template_string: str, *, entities=None, state_map=None):
+    env = Environment(trim_blocks=True, lstrip_blocks=True)
+    states = StatesProxy(entities or [], state_map=state_map)
+
+    def as_timestamp(value):
+        if isinstance(value, datetime):
+            return value.timestamp()
+        if value in (None, "", "unknown", "unavailable"):
+            raise ValueError(f"invalid timestamp source: {value!r}")
+        return datetime.fromisoformat(str(value)).timestamp()
+
+    env.globals.update(
+        states=states,
+        as_timestamp=as_timestamp,
+        now=lambda: FIXED_NOW,
+        state_attr=lambda entity_id, attr: None,
+    )
+    return env.from_string(template_string).render()
+
+
+def test_device_connectivity_zwave_problem_sensor_counts_non_healthy_nodes():
+    sensor = device_health_sensor("Device Connectivity Z-Wave Problems")
+    rendered = render_template(
+        sensor["state"],
+        entities=[
+            Entity("sensor.kitchen_node_status", "alive", "Kitchen Node Status"),
+            Entity("sensor.office_node_status", "dead", "Office Node Status"),
+            Entity("sensor.bedroom_node_status", "unknown", "Bedroom Node Status"),
+            Entity("sensor.hallway_last_seen", FIXED_NOW.isoformat(), "Hallway Last Seen"),
+        ],
+    )
+
+    assert rendered.strip() == "2"
+
+
+def test_device_connectivity_stale_last_seen_sensor_ignores_invalid_values_and_flags_old_devices():
+    sensor = device_health_sensor("Device Connectivity Stale Last Seen")
+    rendered = render_template(
+        sensor["state"],
+        entities=[
+            Entity(
+                "sensor.front_door_last_seen",
+                (FIXED_NOW - timedelta(hours=30)).isoformat(),
+                "Front Door Last Seen",
+            ),
+            Entity(
+                "sensor.office_last_seen",
+                (FIXED_NOW - timedelta(hours=6)).isoformat(),
+                "Office Last Seen",
+            ),
+            Entity("sensor.guest_room_last_seen", "unknown", "Guest Room Last Seen"),
+            Entity("sensor.zwave_gateway_node_status", "alive", "Z-Wave Gateway Node Status"),
+        ],
+        state_map={"input_number.device_connectivity_last_seen_threshold_hours": "24"},
+    )
+
+    assert rendered.strip() == "1"
+
+
+def test_device_connectivity_integration_problem_sensor_counts_unavailable_update_entities_only():
+    sensor = device_health_sensor("Device Connectivity Integration Problems")
+    rendered = render_template(
+        sensor["state"],
+        entities=[
+            Entity("update.home_assistant_core_update", "off", "Home Assistant Core Update"),
+            Entity("update.z_wave_js_update", "unavailable", "Z-Wave JS Update"),
+            Entity("update.matter_server_update", "unknown", "Matter Server Update"),
+            Entity("sensor.random_last_seen", (FIXED_NOW - timedelta(hours=48)).isoformat(), "Random Last Seen"),
+        ],
+    )
+
+    assert rendered.strip() == "2"


### PR DESCRIPTION
## Summary
- extend `packages/device_health.yaml` with conservative connectivity monitoring helpers and alerts
- watch Z-Wave `_node_status` sensors, stale `_last_seen` sensors, and unavailable `update` entities
- add focused template tests and README notes for the new monitoring scope

## Testing
- pytest tests/test_device_connectivity_templates.py tests/test_entity_state_validation.py tests/test_camera_payload_guards.py
- python - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('packages/device_health.yaml').read_text())
print('YAML OK: packages/device_health.yaml')
PY

## Notes
- keeps scope deliberately low-risk: no dashboard changes, no live HA reloads, no Wi-Fi/Bluetooth expansion
- Wi-Fi/Bluetooth/dashboard work can follow in later issues if needed

Closes #71
