### PR TITLE
Fix Good Night remote cancellation and dishwasher checks

### DIFF
--- a/packages/remotes.yaml
+++ b/packages/remotes.yaml
@@ -41,14 +41,17 @@ script:
 
 automation:
   - id: "blueprint_brian_remote"
-    mode: restart
+    mode: parallel
+    max: 10
     alias: "blueprint_brian_remote"
     use_blueprint:
       path: zwave_remote.yaml
       input:
         remote_device: 7208c07c752cc38fd6b147f38261f829
         scene_001_press:
-          - service: script.good_night
+          - service: script.turn_on
+            target:
+              entity_id: script.good_night
         scene_004_press:
           - service: light.turn_on
             data:
@@ -90,14 +93,17 @@ automation:
               entity_id: input_boolean.dimming_lamp_brian
 
   - id: "blueprint_hester_remote"
-    mode: restart
+    mode: parallel
+    max: 10
     alias: "blueprint_hester_remote"
     use_blueprint:
       path: zwave_remote.yaml
       input:
         remote_device: b9e908c896f44c782113acbaf0985571
         scene_001_press:
-          - service: script.good_night
+          - service: script.turn_on
+            target:
+              entity_id: script.good_night
         scene_003_press:
           - service: light.turn_on
             data:

--- a/packages/routines.yaml
+++ b/packages/routines.yaml
@@ -14,19 +14,8 @@ script:
       home"
     mode: restart
     sequence:
-      # Set up variables we'll need
-      - variables:
-          is_mode_guest: "{{ is_state('input_boolean.mode_guest', 'on') }}"
-          dishwasher_state:
-            "{{ states('sensor.kitchen_dishwasher_operation_state') }}"
-          is_dishwasher_available: >
-            {% set invalid_states = ['unknown', 'unavailable', '', none] %}
-            {{ dishwasher_state not in invalid_states }}
-          is_dishwasher_running: >
-            {{ is_dishwasher_available and
-               dishwasher_state == "run" }}
-
-      # Always: Turn on bedside lamps to 50% with a nice transition
+      # First: turn on bedside lamps so the remote press has visible feedback
+      # before any appliance refresh, notification wait, or other slow path.
       - service: light.turn_on
         target:
           entity_id:
@@ -35,6 +24,39 @@ script:
         data:
           brightness_pct: 50
           transition: 3
+
+      # Refresh Home Connect entities before evaluating dishwasher state. These
+      # can otherwise be stale when Good Night starts.
+      - service: homeassistant.update_entity
+        target:
+          entity_id:
+            - sensor.kitchen_dishwasher_operation_state
+            - sensor.kitchen_dishwasher_door
+            - switch.kitchen_dishwasher_power
+            - sensor.kitchen_dishwasher_program_progress
+            - sensor.kitchen_dishwasher_program_finish_time
+      - delay: "00:00:05"
+
+      # Set up variables we'll need after the refresh settles.
+      - variables:
+          is_mode_guest: "{{ is_state('input_boolean.mode_guest', 'on') }}"
+          dishwasher_state: >
+            {{ states('sensor.kitchen_dishwasher_operation_state') }}
+          dishwasher_progress: >
+            {{ states('sensor.kitchen_dishwasher_program_progress') }}
+          dishwasher_finish_time: >
+            {{ states('sensor.kitchen_dishwasher_program_finish_time') }}
+          is_dishwasher_available: >
+            {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+            {{ dishwasher_state not in invalid_states }}
+          is_dishwasher_running: >
+            {% set operation = states('sensor.kitchen_dishwasher_operation_state') %}
+            {% set progress = states('sensor.kitchen_dishwasher_program_progress') | float(-1) %}
+            {% set finish_raw = states('sensor.kitchen_dishwasher_program_finish_time') %}
+            {% set finish = as_datetime(finish_raw) if finish_raw not in ['unavailable', 'unknown', 'none', ''] else none %}
+            {{ operation in ['run', 'delayedstart', 'pause'] or
+               (progress > 0 and progress < 100) or
+               (finish is not none and finish > now()) }}
 
       # Always: Turn off outside lights
       - service: light.turn_off
@@ -150,7 +172,7 @@ script:
               name: "Good Night Routine"
               message: "Waiting for dishwasher to start or user action"
 
-          # Wait for either user action or dishwasher to start
+          # Wait for either user action or dishwasher to enter an active state.
           - wait_for_trigger:
               - platform: event
                 event_type: mobile_app_notification_action
@@ -159,6 +181,12 @@ script:
               - platform: state
                 entity_id: sensor.kitchen_dishwasher_operation_state
                 to: "run"
+              - platform: state
+                entity_id: sensor.kitchen_dishwasher_operation_state
+                to: "delayedstart"
+              - platform: state
+                entity_id: sensor.kitchen_dishwasher_operation_state
+                to: "pause"
             continue_on_timeout: true
             timeout: "00:05:00"
 


### PR DESCRIPTION
## Summary
- Decouple Good Night remote presses from the remote automation run and allow bedroom remote actions to run in parallel so unrelated button presses do not cancel a waiting Good Night routine.
- Turn on bedside lamps as the first Good Night action for immediate visual feedback.
- Refresh Home Connect dishwasher entities before evaluation and treat active dishwasher states/progress/future finish time as running evidence.
- Wait for `run`, `delayedstart`, or `pause` when waiting for the dishwasher to start.

## Investigation
Logbook for 2026-06-05 evening shows:
- 22:29:49 CDT: Brian bedroom remote Scene 001 started Good Night.
- 22:29:49 CDT: Good Night notified and began waiting for dishwasher/user action.
- 22:30:02 CDT: Brian bedroom remote Scene 003 fired.
- 22:30:02 CDT: `script.good_night` turned off essentially at the same instant, before the remote automation logged its new run.

That timing is consistent with the remote automation `mode: restart` cancelling the still-running Good Night call path when the lamp-off button was pressed. The notification action was therefore not the root cause; civilization, as usual, was undone by a perfectly ordinary button.

Fixes #92

## Validation
- Parsed changed YAML with a Home Assistant-aware loader for `!input`.
- Ran `git diff --check`.
- Rendered the updated dishwasher-running template through the live Home Assistant `/api/template` endpoint.
