### PR TITLE
feat: add Good Night garage door check

### DIFF
--- a/packages/routines.yaml
+++ b/packages/routines.yaml
@@ -25,7 +25,13 @@ script:
           is_dishwasher_running: >
             {{ is_dishwasher_available and
                dishwasher_state == "run" }}
-
+          garage_door_state: "{{ states('cover.garage_door') }}"
+          is_garage_open: "{{ garage_door_state == 'open' }}"
+          has_garage_obstruction: >
+            {{ is_state('binary_sensor.garage_door_obstruction', 'on') }}
+          garage_notification_tag: >
+            good-night-garage-door-{{ (now().timestamp() * 1000) | int }}-{{ range(0,
+            999) | random }}
       # Always: Turn on bedside lamps to 50% with a nice transition
       - service: light.turn_on
         target:
@@ -58,6 +64,96 @@ script:
             target:
               entity_id:
                 - remote.tv_living_room
+
+      # If garage door is open: prompt before continuing with the rest of the
+      # routine
+      - if:
+          - condition: template
+            value_template: "{{ is_garage_open }}"
+        then:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ not has_garage_obstruction }}"
+                sequence:
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Good Night Routine"
+                      message: >
+                        Garage door is still open. Close it now before Good
+                        Night continues?
+                      data:
+                        tag: "{{ garage_notification_tag }}"
+                        when: "{{ now().timestamp() | int }}"
+                        priority: "high"
+                        ttl: 0
+                        actions:
+                          - action: "good_night_close_garage_door"
+                            title: "Close Door"
+                          - action: "good_night_continue"
+                            title: "Continue"
+            default:
+              - service: notify.all_mobile_devices
+                data:
+                  title: "Good Night Routine"
+                  message: >
+                    Garage door is still open, but obstruction is detected so
+                    remote close is unavailable. Close it manually, continue, or
+                    Good Night will continue shortly.
+                  data:
+                    tag: "{{ garage_notification_tag }}"
+                    when: "{{ now().timestamp() | int }}"
+                    priority: "high"
+                    ttl: 0
+                    actions:
+                      - action: "good_night_continue"
+                        title: "Continue"
+
+          - wait_for_trigger:
+              - platform: event
+                event_type: mobile_app_notification_action
+                event_data:
+                  action: good_night_close_garage_door
+              - platform: event
+                event_type: mobile_app_notification_action
+                event_data:
+                  action: good_night_continue
+              - platform: state
+                entity_id: cover.garage_door
+                to: "closed"
+            continue_on_timeout: true
+            timeout: "00:03:00"
+
+          - service: notify.all_mobile_devices
+            data:
+              message: "clear_notification"
+              data:
+                tag: "{{ garage_notification_tag }}"
+
+          - if:
+              - condition: template
+                value_template: >
+                  {{ wait.trigger is defined and
+                     wait.trigger.platform == 'event' and
+                     wait.trigger.event.data.action == 'good_night_close_garage_door' }}
+            then:
+              - if:
+                  - condition: state
+                    entity_id: binary_sensor.garage_door_obstruction
+                    state: "off"
+                then:
+                  - service: cover.close_cover
+                    target:
+                      entity_id: cover.garage_door
+                else:
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Good Night Routine"
+                      message: >
+                        Garage door is still open, but obstruction is now
+                        detected so remote close was skipped.
+                      data:
+                        priority: "high"
 
       # Main logic branch for dishwasher state
       - choose:

--- a/packages/routines.yaml
+++ b/packages/routines.yaml
@@ -57,6 +57,13 @@ script:
             {{ operation in ['run', 'delayedstart', 'pause'] or
                (progress > 0 and progress < 100) or
                (finish is not none and finish > now()) }}
+          garage_door_state: "{{ states('cover.garage_door') }}"
+          is_garage_open: "{{ garage_door_state == 'open' }}"
+          has_garage_obstruction: >
+            {{ is_state('binary_sensor.garage_door_obstruction', 'on') }}
+          garage_notification_tag: >
+            good-night-garage-door-{{ (now().timestamp() * 1000) | int }}-{{ range(0,
+            999) | random }}
 
       # Always: Turn off outside lights
       - service: light.turn_off
@@ -80,6 +87,96 @@ script:
             target:
               entity_id:
                 - remote.tv_living_room
+
+      # If garage door is open: prompt before continuing with the dishwasher
+      # branch so the user can address it first.
+      - if:
+          - condition: template
+            value_template: "{{ is_garage_open }}"
+        then:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ not has_garage_obstruction }}"
+                sequence:
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Good Night Routine"
+                      message: >
+                        Garage door is still open. Close it now before Good
+                        Night continues?
+                      data:
+                        tag: "{{ garage_notification_tag }}"
+                        when: "{{ now().timestamp() | int }}"
+                        priority: "high"
+                        ttl: 0
+                        actions:
+                          - action: "good_night_close_garage_door"
+                            title: "Close Door"
+                          - action: "good_night_continue"
+                            title: "Continue"
+            default:
+              - service: notify.all_mobile_devices
+                data:
+                  title: "Good Night Routine"
+                  message: >
+                    Garage door is still open, but obstruction is detected so
+                    remote close is unavailable. Close it manually, continue, or
+                    Good Night will continue shortly.
+                  data:
+                    tag: "{{ garage_notification_tag }}"
+                    when: "{{ now().timestamp() | int }}"
+                    priority: "high"
+                    ttl: 0
+                    actions:
+                      - action: "good_night_continue"
+                        title: "Continue"
+
+          - wait_for_trigger:
+              - platform: event
+                event_type: mobile_app_notification_action
+                event_data:
+                  action: good_night_close_garage_door
+              - platform: event
+                event_type: mobile_app_notification_action
+                event_data:
+                  action: good_night_continue
+              - platform: state
+                entity_id: cover.garage_door
+                to: "closed"
+            continue_on_timeout: true
+            timeout: "00:03:00"
+
+          - service: notify.all_mobile_devices
+            data:
+              message: "clear_notification"
+              data:
+                tag: "{{ garage_notification_tag }}"
+
+          - if:
+              - condition: template
+                value_template: >
+                  {{ wait.trigger is defined and
+                     wait.trigger.platform == 'event' and
+                     wait.trigger.event.data.action == 'good_night_close_garage_door' }}
+            then:
+              - if:
+                  - condition: state
+                    entity_id: binary_sensor.garage_door_obstruction
+                    state: "off"
+                then:
+                  - service: cover.close_cover
+                    target:
+                      entity_id: cover.garage_door
+                else:
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Good Night Routine"
+                      message: >
+                        Garage door is still open, but obstruction is now
+                        detected so remote close was skipped.
+                      data:
+                        priority: "high"
 
       # Main logic branch for dishwasher state
       - choose:


### PR DESCRIPTION
## Summary
- add a Good Night garage-door prompt before the dishwasher branch runs
- offer a remote close action only when the garage door is open and unobstructed
- re-check the obstruction sensor immediately before closing and continue the routine on close, continue, manual close, or timeout

## Validation
- `python3` YAML parse of `packages/routines.yaml`
- local Docker-based Home Assistant config check after creating the same dummy `SERVICE_ACCOUNT.json` used in CI:
  - `docker run --rm -v "$PWD":/config homeassistant/home-assistant:stable hass -c /config --script check_config`

## Focused manual validation plan
- garage already closed: Good Night skips the garage prompt and preserves current dishwasher behavior
- garage open, no obstruction: notification offers Close Door and Continue; Close Door re-checks obstruction before `cover.close_cover`
- garage open, obstruction on: notification explains remote close is unavailable and does not offer Close Door
- dishwasher unavailable / not running branches still behave as before, including cancel/continue handling from PR #94

Closes #95
