### PR TITLE
fix: keep only the interim trusted proxy CIDR

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -15,10 +15,9 @@ scene: !include scenes.yaml
 http:
   use_x_forwarded_for: true
   trusted_proxies:
-    - 192.168.86.2
-    - 10.10.50.2
-    - 10.10.50.4
-    - 10.10.50.11
+    # Interim issue #93 fix: trust only the current server-VLAN CIDR until
+    # Cloudflare tunnel traffic is bound to a single stable proxy IP.
+    - 10.10.50.0/24
 
 google_assistant:
   project_id: homeassistant-32654


### PR DESCRIPTION
## Summary
- replace the current individual `http.trusted_proxies` entries with the single interim `10.10.50.0/24` CIDR
- document in `configuration.yaml` that this is the temporary issue #93 workaround until Cloudflare tunnel traffic is bound to one stable proxy IP
- intentionally follow Brian's latest issue comment instead of the older issue body request for a narrow permanent fix

## Validation
- reviewed `README.md` and `DEVELOPMENT.md`
- parsed `configuration.yaml` with a custom YAML loader that tolerates Home Assistant include tags and confirmed `use_x_forwarded_for: true` plus `trusted_proxies: [10.10.50.0/24]`
- GitHub Actions will run the Home Assistant Core Configuration Check on this PR

Closes #93
