### PR TITLE
fix: align device connectivity Z-Wave entity references

### DIFF
--- a/packages/device_health.yaml
+++ b/packages/device_health.yaml
@@ -342,14 +342,14 @@ template:
         unique_id: device_connectivity_summary
         state: >
           {{
-            states('sensor.device_connectivity_zwave_problems') | int(0)
+            states('sensor.device_connectivity_z_wave_problems') | int(0)
             + states('sensor.device_connectivity_stale_last_seen') | int(0)
             + states('sensor.device_connectivity_integration_problems') | int(0)
           }}
         unit_of_measurement: "issues"
         attributes:
           zwave_problem_nodes: >
-            {{ state_attr('sensor.device_connectivity_zwave_problems', 'problem_nodes') }}
+            {{ state_attr('sensor.device_connectivity_z_wave_problems', 'problem_nodes') }}
           stale_devices: >
             {{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}
           integration_problems: >
@@ -550,10 +550,10 @@ automation:
           entity_id: input_boolean.device_connectivity_alert_sent
       - variables:
           total_issues: "{{ states('sensor.device_connectivity_summary') | int(0) }}"
-          zwave_count: "{{ states('sensor.device_connectivity_zwave_problems') | int(0) }}"
+          zwave_count: "{{ states('sensor.device_connectivity_z_wave_problems') | int(0) }}"
           stale_count: "{{ states('sensor.device_connectivity_stale_last_seen') | int(0) }}"
           integration_count: "{{ states('sensor.device_connectivity_integration_problems') | int(0) }}"
-          zwave_summary: "{{ state_attr('sensor.device_connectivity_zwave_problems', 'problem_nodes') }}"
+          zwave_summary: "{{ state_attr('sensor.device_connectivity_z_wave_problems', 'problem_nodes') }}"
           stale_summary: "{{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}"
           integration_summary: "{{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}"
       - service: notify.all_mobile_devices


### PR DESCRIPTION
## Summary
- update `sensor.device_connectivity_summary` to read the live Z-Wave entity slug `sensor.device_connectivity_z_wave_problems`
- update `automation.device_connectivity_issue_alert` variables/attributes to use the same entity id
- leave Good Night files untouched; this fix only changes `packages/device_health.yaml`

## Validation
- `python3` YAML parse of `packages/device_health.yaml`
- Home Assistant config check in `ghcr.io/home-assistant/home-assistant:stable`
- `git diff -- packages/routines.yaml packages/remotes.yaml` (no Good Night collateral changes)
- repo search confirms no remaining `sensor.device_connectivity_zwave_problems` references

## Live reviewer verification
1. Pull this branch onto the HA `dev` checkout and restart/reload via the established operator path.
2. Confirm `sensor.device_connectivity_summary` still reflects Z-Wave + stale-last-seen + integration counts.
3. Confirm `automation.device_connectivity_issue_alert` no longer reports an unknown entity in Spook repairs.
4. Verify the prior live entity still exists as `sensor.device_connectivity_z_wave_problems`.

Closes #98
