### PR TITLE
Fix: externalize trusted proxy configuration

### DIFF
--- a/.github/CI-README.md
+++ b/.github/CI-README.md
@@ -52,7 +52,7 @@ The `.github/yamllint-config.yaml` file contains custom rules optimized for Home
 
 The workflow creates dummy versions of:
 - SERVICE_ACCOUNT.json
-- secrets.yaml (if used)
+- secrets.yaml with non-sensitive placeholder values for committed `!secret` references
 
 This allows validation without exposing sensitive information in the repository.
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -23,6 +23,9 @@ jobs:
             "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dummy.iam.gserviceaccount.com"
           }' > SERVICE_ACCOUNT.json
+
+          # Create dummy secrets required by committed !secret references.
+          printf '%s\n' 'trusted_proxy_cidr: "192.0.2.0/24"' > secrets.yaml
           
           # Create any other required files/directories
           mkdir -p .storage

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -15,9 +15,9 @@ scene: !include scenes.yaml
 http:
   use_x_forwarded_for: true
   trusted_proxies:
-    # Interim issue #93 fix: trust only the current server-VLAN CIDR until
-    # Cloudflare tunnel traffic is bound to a single stable proxy IP.
-    - 10.10.50.0/24
+    # trusted_proxy_cidr preserves the interim issue #93 server-VLAN trust
+    # while keeping deployment-specific proxy topology out of version control.
+    - !secret trusted_proxy_cidr
 
 google_assistant:
   project_id: homeassistant-32654

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -1,0 +1,11 @@
+# secrets.yaml.example
+#
+# Copy this file to secrets.yaml in the live Home Assistant config directory
+# and replace placeholders with deployment-local values. secrets.yaml is ignored
+# by git so private topology and credentials are not committed.
+
+# Home Assistant http.trusted_proxies entry used when use_x_forwarded_for is
+# enabled. Set this to the current trusted reverse-proxy CIDR/IP for the
+# Cloudflare Tunnel / server-VLAN path until that traffic is bound to a
+# narrower stable proxy source.
+trusted_proxy_cidr: "REPLACE_WITH_TRUSTED_PROXY_CIDR_OR_IP"


### PR DESCRIPTION
## Summary
- replaces the committed `http.trusted_proxies` CIDR with `!secret trusted_proxy_cidr`
- adds `secrets.yaml.example` documenting the local secret expected for the current issue #93 interim proxy trust
- updates the GitHub Actions config-check preparation to generate a dummy `secrets.yaml` value for the committed `!secret` reference

## Validation
- reviewed `README.md` and `DEVELOPMENT.md`
- parsed changed YAML with a Home Assistant tag-aware loader and verified `configuration.yaml` no longer contains the committed proxy CIDR
- `git diff --check`
- `python3 -m pytest -q tests/test_camera_payload_guards.py tests/test_device_connectivity_templates.py` (8 passed)
- Docker Home Assistant config check using the repo's documented safe command pattern and dummy secrets/service account: passed

## Notes
- Full `python3 -m pytest -q` currently reports one unrelated existing failure in `tests/test_entity_state_validation.py::test_good_night_dishwasher_availability_handles_empty_and_none_states`; this change does not touch routines or that test path.
- Before deploying this PR to a live HA config, `secrets.yaml` must define `trusted_proxy_cidr` with the current trusted proxy CIDR/IP.

Closes #81
