### PR TITLE
feat(weather): add window ventilation advisor

### DIFF
--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -1,0 +1,336 @@
+# packages/window_ventilation.yaml
+#
+# Advisory window ventilation recommendations using indoor/outdoor comfort,
+# moisture, rain forecast, HVAC state, and household-relative air-quality context.
+#
+# v1 is advisory only: dedicated window-contact coverage is not confirmed.
+#
+# Entity mapping is based on GitHub issue #103 triage/recon:
+# - weather.forecast_home attributes: temperature, humidity, dew_point
+# - sensor.precipitation_forecast_next_hour / sensor.condition_forecast_next_hour
+# - sensor.dining_room_thermostat_temperature and sensor.thermostat_humidity,
+#   with climate.dining_room_thermostat current attributes as fallback context
+# - sensor.thermostat_carbon_dioxide / sensor.thermostat_vocs
+
+input_boolean:
+  window_ventilation_advisor_enabled:
+    name: "Window Ventilation Advisor"
+    icon: mdi:window-open-variant
+    initial: true
+
+input_number:
+  window_ventilation_cooler_delta:
+    name: "Window Ventilation Cooler Delta"
+    min: 1
+    max: 10
+    step: 0.5
+    unit_of_measurement: "°F"
+    icon: mdi:thermometer-chevron-down
+    initial: 3
+
+  window_ventilation_max_outdoor_dew_point:
+    name: "Window Ventilation Max Outdoor Dew Point"
+    min: 45
+    max: 70
+    step: 1
+    unit_of_measurement: "°F"
+    icon: mdi:water-thermometer
+    initial: 60
+
+  window_ventilation_winter_threshold:
+    name: "Window Ventilation Winter Threshold"
+    min: 35
+    max: 65
+    step: 1
+    unit_of_measurement: "°F"
+    icon: mdi:snowflake-thermometer
+    initial: 55
+
+  window_ventilation_high_indoor_humidity:
+    name: "Window Ventilation High Indoor Humidity"
+    min: 40
+    max: 70
+    step: 1
+    unit_of_measurement: "%"
+    icon: mdi:water-percent
+    initial: 58
+
+input_text:
+  window_ventilation_active_notification_tag:
+    name: "Window Ventilation Active Notification Tag"
+    initial: "window-ventilation-advisor"
+    max: 100
+
+sensor:
+  - platform: statistics
+    name: "Window Ventilation CO2 Baseline"
+    unique_id: window_ventilation_co2_baseline
+    entity_id: sensor.thermostat_carbon_dioxide
+    state_characteristic: mean
+    max_age:
+      hours: 24
+    sampling_size: 288
+
+  - platform: statistics
+    name: "Window Ventilation VOC Baseline"
+    unique_id: window_ventilation_voc_baseline
+    entity_id: sensor.thermostat_vocs
+    state_characteristic: mean
+    max_age:
+      hours: 24
+    sampling_size: 288
+
+template:
+  - sensor:
+      - name: "Window Ventilation Indoor Dew Point"
+        unique_id: window_ventilation_indoor_dew_point
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: >
+          {% set invalid = ['unknown', 'unavailable', '', none] %}
+          {% set temp_sensor = states('sensor.dining_room_thermostat_temperature') %}
+          {% set humidity_sensor = states('sensor.thermostat_humidity') %}
+          {{ (temp_sensor not in invalid or state_attr('climate.dining_room_thermostat', 'current_temperature') is not none)
+             and (humidity_sensor not in invalid or state_attr('climate.dining_room_thermostat', 'current_humidity') is not none) }}
+        state: >
+          {% set invalid = ['unknown', 'unavailable', '', none] %}
+          {% set temp_sensor = states('sensor.dining_room_thermostat_temperature') %}
+          {% set humidity_sensor = states('sensor.thermostat_humidity') %}
+          {% set temp_f = (temp_sensor | float(none)) if temp_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_temperature') | float) %}
+          {% set humidity = (humidity_sensor | float(none)) if humidity_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_humidity') | float) %}
+          {# Approximate dew point from indoor thermostat temperature/humidity. #}
+          {{ (temp_f - ((100 - humidity) * 0.36)) | round(1) }}
+
+      - name: "Window Ventilation Recommendation"
+        unique_id: window_ventilation_recommendation
+        icon: >
+          {% if this.state == 'open' %}
+            mdi:window-open-variant
+          {% elif this.state == 'close' %}
+            mdi:window-closed-variant
+          {% else %}
+            mdi:window-closed
+          {% endif %}
+        state: >
+          {% set invalid = ['unknown', 'unavailable', '', none] %}
+          {% set temp_sensor = states('sensor.dining_room_thermostat_temperature') %}
+          {% set humidity_sensor = states('sensor.thermostat_humidity') %}
+          {% set indoor = (temp_sensor | float(none)) if temp_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_temperature') | float(none)) %}
+          {% set indoor_humidity = (humidity_sensor | float(none)) if humidity_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_humidity') | float(none)) %}
+          {% set outdoor = state_attr('weather.forecast_home', 'temperature') | float(none) %}
+          {% set outdoor_dew = state_attr('weather.forecast_home', 'dew_point') | float(none) %}
+          {% set indoor_dew = states('sensor.window_ventilation_indoor_dew_point') | float(none) %}
+          {% set rain = states('sensor.precipitation_forecast_next_hour') | float(0) %}
+          {% set condition = states('sensor.condition_forecast_next_hour') %}
+          {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
+          {% set cooler_delta = states('input_number.window_ventilation_cooler_delta') | float(3) %}
+          {% set max_dew = states('input_number.window_ventilation_max_outdoor_dew_point') | float(60) %}
+          {% set winter_threshold = states('input_number.window_ventilation_winter_threshold') | float(55) %}
+          {% set high_humidity = states('input_number.window_ventilation_high_indoor_humidity') | float(58) %}
+          {% set co2 = states('sensor.thermostat_carbon_dioxide') | float(0) %}
+          {% set voc = states('sensor.thermostat_vocs') | float(0) %}
+          {% set co2_base = states('sensor.window_ventilation_co2_baseline') | float(0) %}
+          {% set voc_base = states('sensor.window_ventilation_voc_baseline') | float(0) %}
+          {% set raining = rain > 0.1 or condition in ['rainy', 'pouring', 'snowy-rainy'] %}
+          {% set hvac_running = hvac_action in ['heating', 'cooling'] %}
+          {% set data_ready = indoor is not none and outdoor is not none and outdoor_dew is not none and indoor_dew is not none %}
+          {% set outdoor_cooler = data_ready and (indoor - outdoor) >= cooler_delta %}
+          {% set outdoor_drier = data_ready and outdoor_dew <= max_dew and outdoor_dew <= (indoor_dew + 2) %}
+          {% set mild_open = outdoor_cooler and outdoor_drier and not raining and not hvac_running %}
+          {% set co2_relative = co2_base > 0 and co2 >= 900 and co2 >= (co2_base + 175) %}
+          {% set co2_outlier = co2_base > 0 and co2 >= 1400 and co2 >= (co2_base + 100) %}
+          {% set voc_relative = voc_base > 0 and voc >= 250 and voc >= (voc_base * 1.35) %}
+          {% set voc_outlier = voc_base > 0 and voc >= 650 and voc >= (voc_base * 1.15) %}
+          {% set humidity_reason = indoor_humidity is not none and indoor_humidity >= high_humidity and outdoor_drier %}
+          {% set air_quality_reason = co2_relative or voc_relative or co2_outlier or voc_outlier %}
+          {% set winter_mode = outdoor is not none and outdoor < winter_threshold %}
+          {% if not data_ready %}
+            neutral
+          {% elif raining or hvac_running or outdoor_dew >= (max_dew + 5) %}
+            close
+          {% elif winter_mode %}
+            {% if not hvac_running and not raining and outdoor_drier and (air_quality_reason or humidity_reason) %}
+              open
+            {% else %}
+              neutral
+            {% endif %}
+          {% elif mild_open %}
+            open
+          {% elif not outdoor_cooler or not outdoor_drier %}
+            close
+          {% else %}
+            neutral
+          {% endif %}
+        attributes:
+          advisory_only: true
+          mode: >
+            {% set outdoor = state_attr('weather.forecast_home', 'temperature') | float(none) %}
+            {% set winter_threshold = states('input_number.window_ventilation_winter_threshold') | float(55) %}
+            {% if outdoor is not none and outdoor < winter_threshold %}
+              winter_purge
+            {% else %}
+              comfort
+            {% endif %}
+          indoor_temperature: "{{ states('sensor.dining_room_thermostat_temperature') }}"
+          outdoor_temperature: "{{ state_attr('weather.forecast_home', 'temperature') }}"
+          indoor_dew_point: "{{ states('sensor.window_ventilation_indoor_dew_point') }}"
+          outdoor_dew_point: "{{ state_attr('weather.forecast_home', 'dew_point') }}"
+          precipitation_next_hour: "{{ states('sensor.precipitation_forecast_next_hour') }}"
+          hvac_action: "{{ state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) }}"
+          co2_current: "{{ states('sensor.thermostat_carbon_dioxide') }}"
+          co2_baseline: "{{ states('sensor.window_ventilation_co2_baseline') }}"
+          voc_current: "{{ states('sensor.thermostat_vocs') }}"
+          voc_baseline: "{{ states('sensor.window_ventilation_voc_baseline') }}"
+
+      - name: "Window Ventilation Reason"
+        unique_id: window_ventilation_reason
+        icon: mdi:text-box-search-outline
+        state: >
+          {% set invalid = ['unknown', 'unavailable', '', none] %}
+          {% set rec = states('sensor.window_ventilation_recommendation') %}
+          {% set mode = state_attr('sensor.window_ventilation_recommendation', 'mode') | trim %}
+          {% set temp_sensor = states('sensor.dining_room_thermostat_temperature') %}
+          {% set humidity_sensor = states('sensor.thermostat_humidity') %}
+          {% set indoor = (temp_sensor | float(none)) if temp_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_temperature') | float(none)) %}
+          {% set indoor_humidity = (humidity_sensor | float(none)) if humidity_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_humidity') | float(none)) %}
+          {% set outdoor = state_attr('weather.forecast_home', 'temperature') | float(none) %}
+          {% set indoor_dew = states('sensor.window_ventilation_indoor_dew_point') | float(none) %}
+          {% set outdoor_dew = state_attr('weather.forecast_home', 'dew_point') | float(none) %}
+          {% set rain = states('sensor.precipitation_forecast_next_hour') | float(0) %}
+          {% set condition = states('sensor.condition_forecast_next_hour') %}
+          {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
+          {% set co2 = states('sensor.thermostat_carbon_dioxide') | float(0) %}
+          {% set voc = states('sensor.thermostat_vocs') | float(0) %}
+          {% set co2_base = states('sensor.window_ventilation_co2_baseline') | float(0) %}
+          {% set voc_base = states('sensor.window_ventilation_voc_baseline') | float(0) %}
+          {% set high_humidity = states('input_number.window_ventilation_high_indoor_humidity') | float(58) %}
+          {% set raining = rain > 0.1 or condition in ['rainy', 'pouring', 'snowy-rainy'] %}
+          {% set hvac_running = hvac_action in ['heating', 'cooling'] %}
+          {% set co2_relative = co2_base > 0 and co2 >= 900 and co2 >= (co2_base + 175) %}
+          {% set voc_relative = voc_base > 0 and voc >= 250 and voc >= (voc_base * 1.35) %}
+          {% if rec == 'open' and mode == 'winter_purge' %}
+            Air out the house for 5-10 minutes: indoor air or humidity is above the home's recent baseline, outdoor dew point is acceptable, and HVAC is idle.
+          {% elif rec == 'open' %}
+            Open windows: outside is {{ (indoor - outdoor) | round(0) }}°F cooler, outdoor dew point is {{ outdoor_dew | round(0) }}°F vs indoor {{ indoor_dew | round(0) }}°F, and no rain or HVAC conflict is active.
+          {% elif rec == 'close' and raining %}
+            Close windows: rain or mixed precipitation is expected within the hour.
+          {% elif rec == 'close' and hvac_running %}
+            Close windows: HVAC is currently {{ hvac_action }}.
+          {% elif rec == 'close' and outdoor_dew is not none and indoor_dew is not none and outdoor_dew > indoor_dew + 2 %}
+            Close windows: outside air is more humid (dew point {{ outdoor_dew | round(0) }}°F vs indoor {{ indoor_dew | round(0) }}°F).
+          {% elif rec == 'close' %}
+            Close windows: outdoor conditions are no longer meaningfully better than indoors.
+          {% elif mode == 'winter_purge' %}
+            Keep windows closed: outside is cold, HVAC/rain and indoor moisture checks do not justify a brief purge right now.
+          {% elif co2_relative or voc_relative %}
+            Neutral: indoor air is above the recent household baseline, but outdoor comfort or HVAC conditions are not favorable enough for a window recommendation.
+          {% elif indoor_humidity is not none and indoor_humidity >= high_humidity %}
+            Neutral: indoor humidity is elevated, but outdoor conditions are not clearly better.
+          {% else %}
+            Neutral: indoor/outdoor comfort, rain, HVAC, and recent air-quality context do not call for a window change.
+          {% endif %}
+
+  - binary_sensor:
+      - name: "Window Ventilation Favorable"
+        unique_id: window_ventilation_favorable
+        icon: mdi:window-open-variant
+        state: "{{ is_state('sensor.window_ventilation_recommendation', 'open') }}"
+
+      - name: "Window Ventilation Unfavorable"
+        unique_id: window_ventilation_unfavorable
+        icon: mdi:window-closed-variant
+        state: "{{ is_state('sensor.window_ventilation_recommendation', 'close') }}"
+
+automation:
+  - alias: "window_ventilation_open_advisory"
+    id: "window_ventilation_open_advisory"
+    description: "Notify on stable open/purge window ventilation recommendation"
+    trigger:
+      - platform: state
+        entity_id: sensor.window_ventilation_recommendation
+        to: "open"
+        for:
+          minutes: 15
+    condition:
+      - condition: state
+        entity_id: input_boolean.window_ventilation_advisor_enabled
+        state: "on"
+      - condition: numeric_state
+        entity_id: zone.home
+        above: 0
+      - condition: time
+        after: "05:00:00"
+        before: "22:00:00"
+    action:
+      - variables:
+          mode: "{{ state_attr('sensor.window_ventilation_recommendation', 'mode') | trim }}"
+          reason: "{{ states('sensor.window_ventilation_reason') }}"
+          tag: "{{ states('input_text.window_ventilation_active_notification_tag') }}"
+      - service: notify.all_mobile_devices
+        data:
+          title: >
+            {% if mode == 'winter_purge' %}
+              Window Ventilation: Brief Airing
+            {% else %}
+              Window Ventilation: Open Windows
+            {% endif %}
+          message: "{{ reason }}"
+          data:
+            tag: "{{ tag }}"
+            when: "{{ now().timestamp() | int }}"
+            priority: "normal"
+            ttl: 0
+
+  - alias: "window_ventilation_close_advisory"
+    id: "window_ventilation_close_advisory"
+    description: "Notify on stable close window ventilation recommendation"
+    trigger:
+      - platform: state
+        entity_id: sensor.window_ventilation_recommendation
+        to: "close"
+        for:
+          minutes: 7
+    condition:
+      - condition: state
+        entity_id: input_boolean.window_ventilation_advisor_enabled
+        state: "on"
+      - condition: numeric_state
+        entity_id: zone.home
+        above: 0
+      - condition: time
+        after: "05:00:00"
+        before: "22:00:00"
+    action:
+      - variables:
+          reason: "{{ states('sensor.window_ventilation_reason') }}"
+          tag: "{{ states('input_text.window_ventilation_active_notification_tag') }}"
+      - service: notify.all_mobile_devices
+        data:
+          title: "Window Ventilation: Close Windows"
+          message: "{{ reason }}"
+          data:
+            tag: "{{ tag }}"
+            when: "{{ now().timestamp() | int }}"
+            priority: "normal"
+            ttl: 0
+
+  - alias: "window_ventilation_neutral_clear_notification"
+    id: "window_ventilation_neutral_clear_notification"
+    description: "Clear the active advisory notification when conditions settle"
+    trigger:
+      - platform: state
+        entity_id: sensor.window_ventilation_recommendation
+        to: "neutral"
+        for:
+          minutes: 5
+    condition:
+      - condition: state
+        entity_id: input_boolean.window_ventilation_advisor_enabled
+        state: "on"
+    action:
+      - service: notify.all_mobile_devices
+        data:
+          message: "clear_notification"
+          data:
+            tag: "{{ states('input_text.window_ventilation_active_notification_tag') }}"

--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -284,10 +284,11 @@ automation:
 
   - alias: "window_ventilation_close_advisory"
     id: "window_ventilation_close_advisory"
-    description: "Notify on stable close window ventilation recommendation"
+    description: "Notify when a stable open recommendation becomes close"
     trigger:
       - platform: state
         entity_id: sensor.window_ventilation_recommendation
+        from: "open"
         to: "close"
         for:
           minutes: 7

--- a/tests/test_entity_state_validation.py
+++ b/tests/test_entity_state_validation.py
@@ -52,6 +52,14 @@ def normalize_bool(value):
     raise AssertionError(f"expected boolean-like render, got {value!r}")
 
 
+def routine_variables(script_name: str):
+    sequence = load_yaml(ROUTINES_YAML)["script"][script_name]["sequence"]
+    for step in sequence:
+        if "variables" in step:
+            return step["variables"]
+    raise AssertionError(f"script {script_name!r} has no variables step")
+
+
 def weather_automation(automation_id: str):
     for automation in load_yaml(WEATHER_YAML)["automation"]:
         if automation["id"] == automation_id:
@@ -93,7 +101,7 @@ def test_weather_refresh_treats_empty_and_none_last_updated_as_invalid():
 
 
 def test_good_night_dishwasher_availability_handles_empty_and_none_states():
-    variables = load_yaml(ROUTINES_YAML)["script"]["good_night"]["sequence"][0]["variables"]
+    variables = routine_variables("good_night")
     template_string = variables["is_dishwasher_available"]
 
     for invalid_value in ("unknown", "unavailable", "", None):

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "window_ventilation.yaml"
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def sensor_names(package):
+    names = []
+    for block in package["template"]:
+        for sensor in block.get("sensor", []):
+            names.append(sensor["name"])
+    return names
+
+
+def automation_by_id(package, automation_id):
+    for automation in package["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def test_window_ventilation_required_entities_are_defined():
+    package = load_package()
+
+    assert "Window Ventilation Indoor Dew Point" in sensor_names(package)
+    assert "Window Ventilation Recommendation" in sensor_names(package)
+    assert "Window Ventilation Reason" in sensor_names(package)
+
+    binary_names = [
+        sensor["name"]
+        for block in package["template"]
+        for sensor in block.get("binary_sensor", [])
+    ]
+    assert "Window Ventilation Favorable" in binary_names
+    assert "Window Ventilation Unfavorable" in binary_names
+
+
+def test_window_ventilation_uses_household_relative_air_quality_baselines():
+    package = load_package()
+    statistic_sensors = package["sensor"]
+
+    assert {
+        sensor["entity_id"] for sensor in statistic_sensors
+    } == {"sensor.thermostat_carbon_dioxide", "sensor.thermostat_vocs"}
+    assert all(sensor["platform"] == "statistics" for sensor in statistic_sensors)
+    assert all(sensor["state_characteristic"] == "mean" for sensor in statistic_sensors)
+
+    package_text = PACKAGE.read_text()
+    assert "sensor.window_ventilation_co2_baseline" in package_text
+    assert "sensor.window_ventilation_voc_baseline" in package_text
+    assert "co2 >= 1400" in package_text
+    assert "co2_base > 0 and co2 >= 1400" in package_text
+    assert "voc >= 650" in package_text
+    assert "voc_base > 0 and voc >= 650" in package_text
+    assert "sensor.temperature_forecast_high_today" not in package_text
+
+
+def test_window_ventilation_notifications_are_advisory_and_gated():
+    package = load_package()
+
+    open_advisory = automation_by_id(package, "window_ventilation_open_advisory")
+    close_advisory = automation_by_id(package, "window_ventilation_close_advisory")
+    neutral_clear = automation_by_id(
+        package, "window_ventilation_neutral_clear_notification"
+    )
+
+    assert open_advisory["trigger"][0]["for"] == {"minutes": 15}
+    assert close_advisory["trigger"][0]["for"] == {"minutes": 7}
+
+    for automation in (open_advisory, close_advisory):
+        conditions = automation["condition"]
+        assert {
+            condition["condition"] for condition in conditions
+        } >= {"state", "numeric_state", "time"}
+        assert any(
+            condition.get("entity_id") == "zone.home" and condition.get("above") == 0
+            for condition in conditions
+        )
+        assert automation["action"][-1]["service"] == "notify.all_mobile_devices"
+
+    assert neutral_clear["action"][0]["data"]["message"] == "clear_notification"

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -86,3 +86,23 @@ def test_window_ventilation_notifications_are_advisory_and_gated():
         assert automation["action"][-1]["service"] == "notify.all_mobile_devices"
 
     assert neutral_clear["action"][0]["data"]["message"] == "clear_notification"
+
+
+def test_window_ventilation_close_advisory_only_fires_after_open_advisory():
+    package = load_package()
+    close_advisory = automation_by_id(package, "window_ventilation_close_advisory")
+    trigger = close_advisory["trigger"][0]
+
+    assert trigger["from"] == "open"
+    assert trigger["to"] == "close"
+
+
+def test_window_ventilation_neutral_to_close_does_not_match_close_advisory():
+    package = load_package()
+    close_advisory = automation_by_id(package, "window_ventilation_close_advisory")
+    trigger = close_advisory["trigger"][0]
+
+    assert not (
+        trigger.get("from") in (None, "neutral")
+        and trigger["to"] == "close"
+    )


### PR DESCRIPTION
## Summary
- Adds `packages/window_ventilation.yaml`, an advisory-only window ventilation recommendation package with `open` / `close` / `neutral` sensors and reason text.
- Uses indoor/outdoor temperature, computed indoor dew point, outdoor dew point, next-hour rain/condition, HVAC action, and household-relative CO2/VOC statistics baselines.
- Keeps winter behavior conservative: defaults closed/neutral and only recommends a brief 5-10 minute purge when moisture or baseline-relative air-quality context justifies it.
- Adds focused tests for the package and updates an existing routine test to find the variables block by content instead of by stale sequence index.

## Entity mappings / assumptions
Based on issue #103 triage/recon, this uses existing entities only:
- `weather.forecast_home` attributes: `temperature`, `humidity`, `dew_point`
- `sensor.precipitation_forecast_next_hour`
- `sensor.condition_forecast_next_hour`
- `sensor.dining_room_thermostat_temperature`
- `sensor.thermostat_humidity`, with `climate.dining_room_thermostat.current_humidity` as fallback context
- `climate.dining_room_thermostat` attribute `hvac_action`
- `sensor.thermostat_carbon_dioxide`
- `sensor.thermostat_vocs`
- `zone.home`
- `notify.all_mobile_devices`

The package intentionally does not depend on `sensor.temperature_forecast_high_today` because issue #103 noted that sensor is currently suspect/unit-broken. v1 remains advisory-only because window-contact coverage is not confirmed.

## Validation
- `python3` YAML parse over top-level, `packages/`, and `input_boolean/` YAML: 22 files parsed
- `python3 -m py_compile tests/*.py`: passed
- `python3 -m pytest -q`: 14 passed
- `hass --script check_config --config .`: skipped because `hass` is not installed in this worker environment; no live Home Assistant reload/restart was attempted
- Independent staged-diff review: passed after removing raw-only CO2/VOC purge eligibility

Closes #103
