### PR TITLE
feat(ui): add ventilation advisor dashboard

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -8,6 +8,15 @@ default_config:
 frontend:
   themes: !include_dir_merge_named themes
 
+lovelace:
+  dashboards:
+    window-ventilation:
+      mode: yaml
+      title: "Ventilation Advisor"
+      icon: mdi:window-open-variant
+      show_in_sidebar: false
+      filename: dashboards/window_ventilation.yaml
+
 automation: !include_dir_merge_list automation
 input_boolean: !include_dir_merge_named input_boolean
 scene: !include scenes.yaml

--- a/dashboards/window_ventilation.yaml
+++ b/dashboards/window_ventilation.yaml
@@ -1,0 +1,116 @@
+# dashboards/window_ventilation.yaml
+#
+# Focused operator view for the window ventilation advisor.
+#
+# This dashboard is wired from configuration.yaml as a YAML-managed Lovelace
+# dashboard with show_in_sidebar: false. That keeps it available by direct URL
+# without promoting another item into the default sidebar.
+
+title: "Ventilation Advisor"
+views:
+  - title: "Window Ventilation"
+    path: "ventilation-advisor"
+    icon: mdi:window-open-variant
+    badges: []
+    cards:
+      - type: markdown
+        title: "Current advice"
+        content: >-
+          ## {{ states('sensor.window_ventilation_recommendation') | title }}
+
+          **Mode:** {{ state_attr('sensor.window_ventilation_recommendation', 'mode') }}
+
+          {{ states('sensor.window_ventilation_reason') }}
+
+          _This is advisory-only. It does not confirm individual window-contact
+          state or change HVAC behavior._
+
+      - type: entities
+        title: "Advisor status"
+        show_header_toggle: false
+        entities:
+          - entity: input_boolean.window_ventilation_advisor_enabled
+            name: "Advisor notifications enabled"
+          - entity: sensor.window_ventilation_recommendation
+            name: "Recommendation"
+          - entity: sensor.window_ventilation_reason
+            name: "Reason"
+          - type: attribute
+            entity: sensor.window_ventilation_recommendation
+            attribute: mode
+            name: "Mode"
+          - entity: binary_sensor.window_ventilation_favorable
+            name: "Favorable for opening"
+          - entity: binary_sensor.window_ventilation_unfavorable
+            name: "Unfavorable / close windows"
+
+      - type: entities
+        title: "Comfort and dew point context"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.dining_room_thermostat_temperature
+            name: "Indoor temperature"
+          - entity: sensor.thermostat_humidity
+            name: "Indoor humidity"
+          - entity: sensor.window_ventilation_indoor_dew_point
+            name: "Indoor dew point"
+          - type: attribute
+            entity: weather.forecast_home
+            attribute: temperature
+            name: "Outdoor temperature"
+            suffix: "°F"
+          - type: attribute
+            entity: weather.forecast_home
+            attribute: humidity
+            name: "Outdoor humidity"
+            suffix: "%"
+          - type: attribute
+            entity: weather.forecast_home
+            attribute: dew_point
+            name: "Outdoor dew point"
+            suffix: "°F"
+
+      - type: entities
+        title: "Rain and HVAC context"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.precipitation_forecast_next_hour
+            name: "Precipitation next hour"
+          - entity: sensor.condition_forecast_next_hour
+            name: "Next-hour condition"
+          - entity: climate.dining_room_thermostat
+            name: "Thermostat"
+          - type: attribute
+            entity: climate.dining_room_thermostat
+            attribute: hvac_action
+            name: "HVAC action"
+          - type: attribute
+            entity: climate.dining_room_thermostat
+            attribute: hvac_mode
+            name: "HVAC mode"
+
+      - type: entities
+        title: "Air quality current vs baseline"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.thermostat_carbon_dioxide
+            name: "CO2 current"
+          - entity: sensor.window_ventilation_co2_baseline
+            name: "CO2 24h baseline"
+          - entity: sensor.thermostat_vocs
+            name: "VOC current"
+          - entity: sensor.window_ventilation_voc_baseline
+            name: "VOC 24h baseline"
+
+      - type: entities
+        title: "Tuning helpers"
+        show_header_toggle: false
+        entities:
+          - entity: input_number.window_ventilation_cooler_delta
+            name: "Required cooler delta"
+          - entity: input_number.window_ventilation_max_outdoor_dew_point
+            name: "Max outdoor dew point"
+          - entity: input_number.window_ventilation_winter_threshold
+            name: "Winter purge threshold"
+          - entity: input_number.window_ventilation_high_indoor_humidity
+            name: "High indoor humidity threshold"

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,12 +6,13 @@ This directory contains modular packages that group related functionality. Each 
 
 ### Core Functionality
 
-| Package                | Description                                                |
-|------------------------|------------------------------------------------------------|
-| `cameras.yaml`         | Camera integration with motion detection and notifications |
-| `presence.yaml`        | Presence detection and related automations                 |
-| `security_lights.yaml` | Security-focused lighting automations                      |
-| `weather.yaml`         | Weather data processing and event monitoring               |
+| Package                     | Description                                                        |
+|-----------------------------|--------------------------------------------------------------------|
+| `cameras.yaml`              | Camera integration with motion detection and notifications         |
+| `presence.yaml`             | Presence detection and related automations                         |
+| `security_lights.yaml`      | Security-focused lighting automations                              |
+| `weather.yaml`              | Weather data processing and event monitoring                       |
+| `window_ventilation.yaml`   | Advisory window ventilation recommendations and notification logic |
 
 ### Daily Living
 

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION = ROOT / "configuration.yaml"
+DASHBOARD = ROOT / "dashboards" / "window_ventilation.yaml"
+
+
+def load_dashboard():
+    return yaml.safe_load(DASHBOARD.read_text())
+
+
+def entity_refs(cards):
+    refs = []
+    for card in cards:
+        if "entity" in card:
+            refs.append(card["entity"])
+        for row in card.get("entities", []):
+            if isinstance(row, str):
+                refs.append(row)
+            elif isinstance(row, dict) and "entity" in row:
+                refs.append(row["entity"])
+    return refs
+
+
+def test_window_ventilation_dashboard_is_yaml_managed_and_hidden():
+    config_text = CONFIGURATION.read_text()
+
+    assert "lovelace:" in config_text
+    assert "window-ventilation:" in config_text
+    assert "mode: yaml" in config_text
+    assert "filename: dashboards/window_ventilation.yaml" in config_text
+    assert "show_in_sidebar: false" in config_text
+
+
+def test_window_ventilation_dashboard_surfaces_required_context():
+    dashboard = load_dashboard()
+    cards = dashboard["views"][0]["cards"]
+    refs = set(entity_refs(cards))
+    markdown = "\n".join(
+        card.get("content", "") for card in cards if card.get("type") == "markdown"
+    )
+
+    assert dashboard["title"] == "Ventilation Advisor"
+    assert dashboard["views"][0]["path"] == "ventilation-advisor"
+
+    required_entities = {
+        "input_boolean.window_ventilation_advisor_enabled",
+        "sensor.window_ventilation_recommendation",
+        "sensor.window_ventilation_reason",
+        "binary_sensor.window_ventilation_favorable",
+        "binary_sensor.window_ventilation_unfavorable",
+        "sensor.dining_room_thermostat_temperature",
+        "sensor.thermostat_humidity",
+        "sensor.window_ventilation_indoor_dew_point",
+        "weather.forecast_home",
+        "sensor.precipitation_forecast_next_hour",
+        "sensor.condition_forecast_next_hour",
+        "climate.dining_room_thermostat",
+        "sensor.thermostat_carbon_dioxide",
+        "sensor.window_ventilation_co2_baseline",
+        "sensor.thermostat_vocs",
+        "sensor.window_ventilation_voc_baseline",
+        "input_number.window_ventilation_cooler_delta",
+        "input_number.window_ventilation_max_outdoor_dew_point",
+        "input_number.window_ventilation_winter_threshold",
+        "input_number.window_ventilation_high_indoor_humidity",
+    }
+    assert required_entities <= refs
+    assert "state_attr('sensor.window_ventilation_recommendation', 'mode')" in markdown
+    assert "advisory-only" in markdown
+
+    attribute_rows = [
+        row
+        for card in cards
+        for row in card.get("entities", [])
+        if isinstance(row, dict) and row.get("type") == "attribute"
+    ]
+    assert {row["attribute"] for row in attribute_rows} >= {
+        "mode",
+        "temperature",
+        "humidity",
+        "dew_point",
+        "hvac_action",
+        "hvac_mode",
+    }


### PR DESCRIPTION
## Summary
- Adds a YAML-managed, hidden Lovelace dashboard for the window ventilation advisor.
- Surfaces recommendation, reason text, mode, indoor/outdoor comfort, dew point, rain/HVAC, CO2/VOC baseline context, and tuning helpers.
- Documents the package in the packages README and adds regression tests for dashboard wiring/content.

## Validation
- `python -m pytest` — 18 passed
- Python YAML parse of `configuration.yaml` with Home Assistant tag-tolerant loader and `dashboards/window_ventilation.yaml` — passed
- `git diff --cached --check` — passed before commit
- Home Assistant live reload/restart not run; no live HA services called. Local `hass`/`homeassistant` command is not installed in this environment, and the repo only provides the GitHub Actions config-check path.

Refs #105
