### PR TITLE
fix(weather): normalize forecast cache seam

### DIFF
--- a/dashboards/window_ventilation.yaml
+++ b/dashboards/window_ventilation.yaml
@@ -54,21 +54,12 @@ views:
             name: "Indoor humidity"
           - entity: sensor.window_ventilation_indoor_dew_point
             name: "Indoor dew point"
-          - type: attribute
-            entity: weather.forecast_home
-            attribute: temperature
+          - entity: sensor.weather_outdoor_temperature
             name: "Outdoor temperature"
-            suffix: "°F"
-          - type: attribute
-            entity: weather.forecast_home
-            attribute: humidity
+          - entity: sensor.weather_outdoor_humidity
             name: "Outdoor humidity"
-            suffix: "%"
-          - type: attribute
-            entity: weather.forecast_home
-            attribute: dew_point
+          - entity: sensor.weather_outdoor_dew_point
             name: "Outdoor dew point"
-            suffix: "°F"
 
       - type: entities
         title: "Rain and HVAC context"

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -174,18 +174,12 @@ mqtt:
       value_template: "{{ now().isoformat() }}"
       json_attributes_topic: "home/weather/hourly_forecast"
       unique_id: "weather_hourly_forecast"
-      availability_topic: "home/weather/hourly_forecast"
-      payload_available: "{"
-      payload_not_available: ""
 
     - name: "Weather Daily Forecast"
       state_topic: "home/weather/daily_forecast"
       value_template: "{{ now().isoformat() }}"
       json_attributes_topic: "home/weather/daily_forecast"
       unique_id: "weather_daily_forecast"
-      availability_topic: "home/weather/daily_forecast"
-      payload_available: "{"
-      payload_not_available: ""
 template:
   - sensor:
       - name: "Weather Last Updated"
@@ -296,5 +290,5 @@ template:
           {% else %}
             {{ state_attr('weather.forecast_home', 'temperature') | default('unknown') }}
           {% endif %}
-        unit_of_measurement: "°C"
+        unit_of_measurement: "°F"
         device_class: temperature

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -121,26 +121,38 @@ automation:
           entity_id: weather.forecast_home
         response_variable: daily_forecast
 
-      # Publish forecast data to MQTT topics
+      # Publish normalized forecast data to MQTT topics. weather.get_forecasts
+      # returns a response keyed by source entity; downstream sensors should only
+      # depend on this package's stable top-level forecast attribute.
       - service: mqtt.publish
         data:
           topic: "home/weather/hourly_forecast"
           payload: >
-            {% if hourly_forecast is defined %}
-              {{ hourly_forecast | tojson }}
-            {% else %}
-              {"forecast": []}
-            {% endif %}
+            {% set source = 'weather.forecast_home' %}
+            {% set payload = hourly_forecast.get(source, {}) if hourly_forecast is defined and hourly_forecast is mapping else {} %}
+            {% set forecast = payload.get('forecast', []) if payload is mapping else [] %}
+            {{ {
+              'source_entity': source,
+              'forecast_type': 'hourly',
+              'retrieved_at': now().isoformat(),
+              'forecast_count': forecast | count,
+              'forecast': forecast,
+            } | tojson }}
 
       - service: mqtt.publish
         data:
           topic: "home/weather/daily_forecast"
           payload: >
-            {% if daily_forecast is defined %}
-              {{ daily_forecast | tojson }}
-            {% else %}
-              {"forecast": []}
-            {% endif %}
+            {% set source = 'weather.forecast_home' %}
+            {% set payload = daily_forecast.get(source, {}) if daily_forecast is defined and daily_forecast is mapping else {} %}
+            {% set forecast = payload.get('forecast', []) if payload is mapping else [] %}
+            {{ {
+              'source_entity': source,
+              'forecast_type': 'daily',
+              'retrieved_at': now().isoformat(),
+              'forecast_count': forecast | count,
+              'forecast': forecast,
+            } | tojson }}
       - service: input_datetime.set_datetime
         target:
           entity_id: input_datetime.weather_last_updated
@@ -180,13 +192,39 @@ template:
         unique_id: weather_last_updated
         state: "{{ states('input_datetime.weather_last_updated') | default('unknown') }}"
 
+      - name: "Weather Outdoor Temperature"
+        unique_id: weather_outdoor_temperature
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: "{{ state_attr('weather.forecast_home', 'temperature') is not none }}"
+        state: "{{ state_attr('weather.forecast_home', 'temperature') | float(none) | round(1) }}"
+
+      - name: "Weather Outdoor Humidity"
+        unique_id: weather_outdoor_humidity
+        unit_of_measurement: "%"
+        device_class: humidity
+        state_class: measurement
+        availability: "{{ state_attr('weather.forecast_home', 'humidity') is not none }}"
+        state: "{{ state_attr('weather.forecast_home', 'humidity') | float(none) | round(0) }}"
+
+      - name: "Weather Outdoor Dew Point"
+        unique_id: weather_outdoor_dew_point
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
+        availability: "{{ state_attr('weather.forecast_home', 'dew_point') is not none }}"
+        state: "{{ state_attr('weather.forecast_home', 'dew_point') | float(none) | round(1) }}"
+
       - name: "Condition forecast next hour"
         unique_id: weather_forecast_condition_next_hour
         state: >
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
           {% if sensor_state not in invalid_states %}
-            {% set forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
+            {% set direct_forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
+            {% set source_payload = state_attr('sensor.weather_hourly_forecast', 'weather.forecast_home') %}
+            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {{ forecast[0].condition | default('unknown') }}
             {% else %}
@@ -202,7 +240,9 @@ template:
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
           {% if sensor_state not in invalid_states %}
-            {% set forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+            {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+            {% set source_payload = state_attr('sensor.weather_daily_forecast', 'weather.forecast_home') %}
+            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {{ forecast[0].condition | default('unknown') }}
             {% else %}
@@ -218,7 +258,9 @@ template:
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
           {% if sensor_state not in invalid_states %}
-            {% set forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
+            {% set direct_forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
+            {% set source_payload = state_attr('sensor.weather_hourly_forecast', 'weather.forecast_home') %}
+            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {% if forecast[0].precipitation is defined %}
                 {{ forecast[0].precipitation | float(0) | round(2) }}
@@ -239,7 +281,9 @@ template:
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
           {% if sensor_state not in invalid_states %}
-            {% set forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+            {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+            {% set source_payload = state_attr('sensor.weather_daily_forecast', 'weather.forecast_home') %}
+            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {% if forecast[0].temperature is defined %}
                 {{ forecast[0].temperature | float | round(1) }}

--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -6,7 +6,8 @@
 # v1 is advisory only: dedicated window-contact coverage is not confirmed.
 #
 # Entity mapping is based on GitHub issue #103 triage/recon:
-# - weather.forecast_home attributes: temperature, humidity, dew_point
+# - normalized weather seam sensors from packages/weather.yaml:
+#   sensor.weather_outdoor_temperature / sensor.weather_outdoor_dew_point
 # - sensor.precipitation_forecast_next_hour / sensor.condition_forecast_next_hour
 # - sensor.dining_room_thermostat_temperature and sensor.thermostat_humidity,
 #   with climate.dining_room_thermostat current attributes as fallback context
@@ -118,8 +119,8 @@ template:
           {% set humidity_sensor = states('sensor.thermostat_humidity') %}
           {% set indoor = (temp_sensor | float(none)) if temp_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_temperature') | float(none)) %}
           {% set indoor_humidity = (humidity_sensor | float(none)) if humidity_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_humidity') | float(none)) %}
-          {% set outdoor = state_attr('weather.forecast_home', 'temperature') | float(none) %}
-          {% set outdoor_dew = state_attr('weather.forecast_home', 'dew_point') | float(none) %}
+          {% set outdoor = states('sensor.weather_outdoor_temperature') | float(none) %}
+          {% set outdoor_dew = states('sensor.weather_outdoor_dew_point') | float(none) %}
           {% set indoor_dew = states('sensor.window_ventilation_indoor_dew_point') | float(none) %}
           {% set rain = states('sensor.precipitation_forecast_next_hour') | float(0) %}
           {% set condition = states('sensor.condition_forecast_next_hour') %}
@@ -165,7 +166,7 @@ template:
         attributes:
           advisory_only: true
           mode: >
-            {% set outdoor = state_attr('weather.forecast_home', 'temperature') | float(none) %}
+            {% set outdoor = states('sensor.weather_outdoor_temperature') | float(none) %}
             {% set winter_threshold = states('input_number.window_ventilation_winter_threshold') | float(55) %}
             {% if outdoor is not none and outdoor < winter_threshold %}
               winter_purge
@@ -173,9 +174,9 @@ template:
               comfort
             {% endif %}
           indoor_temperature: "{{ states('sensor.dining_room_thermostat_temperature') }}"
-          outdoor_temperature: "{{ state_attr('weather.forecast_home', 'temperature') }}"
+          outdoor_temperature: "{{ states('sensor.weather_outdoor_temperature') }}"
           indoor_dew_point: "{{ states('sensor.window_ventilation_indoor_dew_point') }}"
-          outdoor_dew_point: "{{ state_attr('weather.forecast_home', 'dew_point') }}"
+          outdoor_dew_point: "{{ states('sensor.weather_outdoor_dew_point') }}"
           precipitation_next_hour: "{{ states('sensor.precipitation_forecast_next_hour') }}"
           hvac_action: "{{ state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) }}"
           co2_current: "{{ states('sensor.thermostat_carbon_dioxide') }}"
@@ -194,9 +195,9 @@ template:
           {% set humidity_sensor = states('sensor.thermostat_humidity') %}
           {% set indoor = (temp_sensor | float(none)) if temp_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_temperature') | float(none)) %}
           {% set indoor_humidity = (humidity_sensor | float(none)) if humidity_sensor not in invalid else (state_attr('climate.dining_room_thermostat', 'current_humidity') | float(none)) %}
-          {% set outdoor = state_attr('weather.forecast_home', 'temperature') | float(none) %}
+          {% set outdoor = states('sensor.weather_outdoor_temperature') | float(none) %}
           {% set indoor_dew = states('sensor.window_ventilation_indoor_dew_point') | float(none) %}
-          {% set outdoor_dew = state_attr('weather.forecast_home', 'dew_point') | float(none) %}
+          {% set outdoor_dew = states('sensor.weather_outdoor_dew_point') | float(none) %}
           {% set rain = states('sensor.precipitation_forecast_next_hour') | float(0) %}
           {% set condition = states('sensor.condition_forecast_next_hour') %}
           {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}

--- a/tests/test_weather_forecast_cache.py
+++ b/tests/test_weather_forecast_cache.py
@@ -58,6 +58,13 @@ def test_weather_derivative_sensors_accept_normalized_and_legacy_cache_shapes():
     assert "state_attr('sensor.weather_daily_forecast', 'weather.forecast_home')" in weather_text
 
 
+def mqtt_sensor(name):
+    for sensor in load_weather()["mqtt"]["sensor"]:
+        if sensor["name"] == name:
+            return sensor
+    raise AssertionError(f"mqtt sensor {name!r} not found")
+
+
 def test_weather_package_exposes_current_condition_seam_sensors():
     expected = {
         "Weather Outdoor Temperature": "weather_outdoor_temperature",
@@ -70,3 +77,22 @@ def test_weather_package_exposes_current_condition_seam_sensors():
         assert sensor["unique_id"] == unique_id
         assert "weather.forecast_home" in sensor["availability"]
         assert "weather.forecast_home" in sensor["state"]
+
+
+def test_forecast_mqtt_sensors_do_not_require_literal_open_brace_availability_payload():
+    for name, topic in (
+        ("Weather Hourly Forecast", "home/weather/hourly_forecast"),
+        ("Weather Daily Forecast", "home/weather/daily_forecast"),
+    ):
+        sensor = mqtt_sensor(name)
+        assert sensor["state_topic"] == topic
+        assert sensor["json_attributes_topic"] == topic
+        assert sensor.get("availability_topic") != topic
+        assert sensor.get("payload_available") != "{"
+
+
+def test_temperature_forecast_high_today_uses_deployment_fahrenheit_units():
+    sensor = template_sensor("Temperature forecast high today")
+
+    assert sensor["unit_of_measurement"] == "°F"
+    assert "forecast[0].temperature | float | round(1)" in sensor["state"]

--- a/tests/test_weather_forecast_cache.py
+++ b/tests/test_weather_forecast_cache.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WEATHER = ROOT / "packages" / "weather.yaml"
+
+
+def load_weather():
+    return yaml.safe_load(WEATHER.read_text())
+
+
+def weather_refresh_action():
+    for automation in load_weather()["automation"]:
+        if automation["id"] == "weather_data_refresh":
+            return automation["action"]
+    raise AssertionError("weather_data_refresh automation not found")
+
+
+def mqtt_payload_for_topic(topic):
+    for action in weather_refresh_action():
+        if action.get("service") == "mqtt.publish" and action["data"]["topic"] == topic:
+            return action["data"]["payload"]
+    raise AssertionError(f"mqtt publish topic {topic!r} not found")
+
+
+def template_sensor(name):
+    for block in load_weather()["template"]:
+        for sensor in block.get("sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"template sensor {name!r} not found")
+
+
+def test_weather_forecast_cache_publishes_normalized_top_level_payloads():
+    hourly_payload = mqtt_payload_for_topic("home/weather/hourly_forecast")
+    daily_payload = mqtt_payload_for_topic("home/weather/daily_forecast")
+
+    for payload, forecast_type in (
+        (hourly_payload, "hourly"),
+        (daily_payload, "daily"),
+    ):
+        assert "source = 'weather.forecast_home'" in payload
+        assert "payload =" in payload
+        assert "payload.get('forecast', [])" in payload
+        assert "'forecast': forecast" in payload
+        assert "'forecast_count': forecast | count" in payload
+        assert f"'forecast_type': '{forecast_type}'" in payload
+
+
+def test_weather_derivative_sensors_accept_normalized_and_legacy_cache_shapes():
+    weather_text = WEATHER.read_text()
+
+    assert "state_attr('sensor.weather_hourly_forecast', 'forecast')" in weather_text
+    assert "state_attr('sensor.weather_hourly_forecast', 'weather.forecast_home')" in weather_text
+    assert "state_attr('sensor.weather_daily_forecast', 'forecast')" in weather_text
+    assert "state_attr('sensor.weather_daily_forecast', 'weather.forecast_home')" in weather_text
+
+
+def test_weather_package_exposes_current_condition_seam_sensors():
+    expected = {
+        "Weather Outdoor Temperature": "weather_outdoor_temperature",
+        "Weather Outdoor Humidity": "weather_outdoor_humidity",
+        "Weather Outdoor Dew Point": "weather_outdoor_dew_point",
+    }
+
+    for name, unique_id in expected.items():
+        sensor = template_sensor(name)
+        assert sensor["unique_id"] == unique_id
+        assert "weather.forecast_home" in sensor["availability"]
+        assert "weather.forecast_home" in sensor["state"]

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -55,7 +55,9 @@ def test_window_ventilation_dashboard_surfaces_required_context():
         "sensor.dining_room_thermostat_temperature",
         "sensor.thermostat_humidity",
         "sensor.window_ventilation_indoor_dew_point",
-        "weather.forecast_home",
+        "sensor.weather_outdoor_temperature",
+        "sensor.weather_outdoor_humidity",
+        "sensor.weather_outdoor_dew_point",
         "sensor.precipitation_forecast_next_hour",
         "sensor.condition_forecast_next_hour",
         "climate.dining_room_thermostat",
@@ -80,9 +82,13 @@ def test_window_ventilation_dashboard_surfaces_required_context():
     ]
     assert {row["attribute"] for row in attribute_rows} >= {
         "mode",
-        "temperature",
-        "humidity",
-        "dew_point",
         "hvac_action",
         "hvac_mode",
     }
+
+    assert not any(
+        row.get("entity") == "weather.forecast_home"
+        for card in cards
+        for row in card.get("entities", [])
+        if isinstance(row, dict)
+    )

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -60,6 +60,10 @@ def test_window_ventilation_uses_household_relative_air_quality_baselines():
     assert "voc >= 650" in package_text
     assert "voc_base > 0 and voc >= 650" in package_text
     assert "sensor.temperature_forecast_high_today" not in package_text
+    assert "states('sensor.weather_outdoor_temperature')" in package_text
+    assert "states('sensor.weather_outdoor_dew_point')" in package_text
+    assert "state_attr('weather.forecast_home', 'temperature')" not in package_text
+    assert "state_attr('weather.forecast_home', 'dew_point')" not in package_text
 
 
 def test_window_ventilation_notifications_are_advisory_and_gated():


### PR DESCRIPTION
## Summary
- Normalize `weather.get_forecasts` MQTT cache payloads into stable top-level forecast attributes with metadata instead of exposing the raw source-entity keyed response.
- Add guarded current-weather seam sensors for outdoor temperature, humidity, and dew point.
- Point window ventilation logic and dashboard cards at the normalized weather seam instead of direct `weather.forecast_home` current attributes.

## Scope note
This is the first hardening slice for #107. It does not switch providers and does not perform the later met.no -> NWS migration; that remains blocked on live Home Assistant entity/payload verification.

## Validation
- `python3 -m pytest -q` -> 21 passed
- `git diff --check` -> passed
- `python3` YAML/Jinja compile script for `packages/weather.yaml`, `packages/window_ventilation.yaml`, and `dashboards/window_ventilation.yaml` -> YAML OK, templates compile

Refs #107
