### PR TITLE
fix(weather): migrate normalized seam to NWS

### DIFF
--- a/dashboards/window_ventilation.yaml
+++ b/dashboards/window_ventilation.yaml
@@ -66,7 +66,7 @@ views:
         show_header_toggle: false
         entities:
           - entity: sensor.precipitation_forecast_next_hour
-            name: "Precipitation next hour"
+            name: "Rain probability next hour"
           - entity: sensor.condition_forecast_next_hour
             name: "Next-hour condition"
           - entity: climate.dining_room_thermostat

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -4,8 +4,16 @@
 #
 # Features:
 # - Event-based triggers instead of time-pattern polling
-# - Cache weather forecasts to reduce API calls
-# - Maintain forecast predictions for the next hour and day
+# - Cache NWS forecasts to reduce API calls
+# - Maintain normalized forecast predictions for the next hour and day/night period
+#
+# NWS source entities verified from the live integration:
+# - weather.nws_home_kmle
+# - sensor.nws_41_17166991853366_96_04711058392532_kmle_temperature
+# - sensor.nws_41_17166991853366_96_04711058392532_kmle_relative_humidity
+# - sensor.nws_41_17166991853366_96_04711058392532_kmle_dew_point
+# If the auxiliary NWS current-condition sensors are disabled in HA, enable them
+# before expecting the normalized current-condition seam below to populate.
 
 # Input variables for controlling refresh frequency
 input_number:
@@ -21,13 +29,13 @@ input_number:
 automation:
   - alias: "Rain Forecast Alert"
     id: "notification_rain_forecast"
-    description: "Multi-source rain detection and notification"
+    description: "NWS-backed rain probability and condition notification"
     trigger:
-      # Primary: Precipitation amount sensor
+      # Primary: NWS precipitation probability sensor (percent chance)
       - platform: numeric_state
         entity_id: sensor.precipitation_forecast_next_hour
-        above: 0.1
-        id: "precipitation_trigger"
+        above: 30
+        id: "precipitation_probability_trigger"
       # Backup: Condition-based detection
       - platform: state
         entity_id: sensor.condition_forecast_next_hour
@@ -37,9 +45,9 @@ automation:
           - "snowy"
           - "snowy-rainy"
         id: "condition_trigger"
-      # Fallback: Main weather entity
+      # Fallback: Main NWS weather entity
       - platform: state
-        entity_id: weather.forecast_home
+        entity_id: weather.nws_home_kmle
         to:
           - "rainy"
           - "pouring"
@@ -70,25 +78,26 @@ automation:
       - action: notify.mobile_app_brian_phone
         data:
           message: >
-            {% if trigger.id == 'precipitation_trigger' %}
-              ☔ Rain expected in the next hour: {{ states('sensor.precipitation_forecast_next_hour') }}mm
+            {% if trigger.id == 'precipitation_probability_trigger' %}
+              ☔ Rain chance in the next hour: {{ states('sensor.precipitation_forecast_next_hour') }}%
             {% elif trigger.id == 'condition_trigger' %}
               ☔ {{ states('sensor.condition_forecast_next_hour') | title }} weather expected in the next hour
             {% else %}
-              ☔ {{ states('weather.forecast_home') | title }} weather conditions expected
+              ☔ {{ states('weather.nws_home_kmle') | title }} weather conditions expected
             {% endif %}
           title: "Rain Alert"
     mode: single
+
   - alias: "weather_data_refresh"
     id: "weather_data_refresh"
-    description: "Update weather data"
+    description: "Update NWS-backed normalized weather data"
     trigger:
       # Time-based backup trigger (fixed at 15 minutes)
       - platform: time_pattern
         minutes: "/15"
       # Event-based trigger for weather alerts
       - platform: state
-        entity_id: weather.forecast_home
+        entity_id: weather.nws_home_kmle
         attribute: weather_alert
         to: "true"
     condition:
@@ -105,21 +114,21 @@ automation:
             {{ time_diff > min_interval }}
           {% endif %}
     action:
-      # Get the hourly forecast
+      # Get the NWS hourly forecast
       - service: weather.get_forecasts
         data:
           type: hourly
         target:
-          entity_id: weather.forecast_home
+          entity_id: weather.nws_home_kmle
         response_variable: hourly_forecast
 
-      # Get the daily forecast
+      # NWS supports twice_daily in this deployment; daily returns 500.
       - service: weather.get_forecasts
         data:
-          type: daily
+          type: twice_daily
         target:
-          entity_id: weather.forecast_home
-        response_variable: daily_forecast
+          entity_id: weather.nws_home_kmle
+        response_variable: twice_daily_forecast
 
       # Publish normalized forecast data to MQTT topics. weather.get_forecasts
       # returns a response keyed by source entity; downstream sensors should only
@@ -128,7 +137,7 @@ automation:
         data:
           topic: "home/weather/hourly_forecast"
           payload: >
-            {% set source = 'weather.forecast_home' %}
+            {% set source = 'weather.nws_home_kmle' %}
             {% set payload = hourly_forecast.get(source, {}) if hourly_forecast is defined and hourly_forecast is mapping else {} %}
             {% set forecast = payload.get('forecast', []) if payload is mapping else [] %}
             {{ {
@@ -143,12 +152,12 @@ automation:
         data:
           topic: "home/weather/daily_forecast"
           payload: >
-            {% set source = 'weather.forecast_home' %}
-            {% set payload = daily_forecast.get(source, {}) if daily_forecast is defined and daily_forecast is mapping else {} %}
+            {% set source = 'weather.nws_home_kmle' %}
+            {% set payload = twice_daily_forecast.get(source, {}) if twice_daily_forecast is defined and twice_daily_forecast is mapping else {} %}
             {% set forecast = payload.get('forecast', []) if payload is mapping else [] %}
             {{ {
               'source_entity': source,
-              'forecast_type': 'daily',
+              'forecast_type': 'twice_daily',
               'retrieved_at': now().isoformat(),
               'forecast_count': forecast | count,
               'forecast': forecast,
@@ -180,6 +189,7 @@ mqtt:
       value_template: "{{ now().isoformat() }}"
       json_attributes_topic: "home/weather/daily_forecast"
       unique_id: "weather_daily_forecast"
+
 template:
   - sensor:
       - name: "Weather Last Updated"
@@ -191,41 +201,51 @@ template:
         unit_of_measurement: "°F"
         device_class: temperature
         state_class: measurement
-        availability: "{{ state_attr('weather.forecast_home', 'temperature') is not none }}"
-        state: "{{ state_attr('weather.forecast_home', 'temperature') | float(none) | round(1) }}"
+        availability: >
+          {% set value = states('sensor.nws_41_17166991853366_96_04711058392532_kmle_temperature') %}
+          {{ value not in ['unknown', 'unavailable', '', none] }}
+        state: >
+          {{ states('sensor.nws_41_17166991853366_96_04711058392532_kmle_temperature') | float(none) | round(1) }}
 
       - name: "Weather Outdoor Humidity"
         unique_id: weather_outdoor_humidity
         unit_of_measurement: "%"
         device_class: humidity
         state_class: measurement
-        availability: "{{ state_attr('weather.forecast_home', 'humidity') is not none }}"
-        state: "{{ state_attr('weather.forecast_home', 'humidity') | float(none) | round(0) }}"
+        availability: >
+          {% set value = states('sensor.nws_41_17166991853366_96_04711058392532_kmle_relative_humidity') %}
+          {{ value not in ['unknown', 'unavailable', '', none] }}
+        state: >
+          {{ states('sensor.nws_41_17166991853366_96_04711058392532_kmle_relative_humidity') | float(none) | round(0) }}
 
       - name: "Weather Outdoor Dew Point"
         unique_id: weather_outdoor_dew_point
         unit_of_measurement: "°F"
         device_class: temperature
         state_class: measurement
-        availability: "{{ state_attr('weather.forecast_home', 'dew_point') is not none }}"
-        state: "{{ state_attr('weather.forecast_home', 'dew_point') | float(none) | round(1) }}"
+        availability: >
+          {% set value = states('sensor.nws_41_17166991853366_96_04711058392532_kmle_dew_point') %}
+          {{ value not in ['unknown', 'unavailable', '', none] }}
+        state: >
+          {{ states('sensor.nws_41_17166991853366_96_04711058392532_kmle_dew_point') | float(none) | round(1) }}
 
       - name: "Condition forecast next hour"
         unique_id: weather_forecast_condition_next_hour
         state: >
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% set source_entity = state_attr('sensor.weather_hourly_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
           {% if sensor_state not in invalid_states %}
             {% set direct_forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
-            {% set source_payload = state_attr('sensor.weather_hourly_forecast', 'weather.forecast_home') %}
+            {% set source_payload = state_attr('sensor.weather_hourly_forecast', source_entity) %}
             {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {{ forecast[0].condition | default('unknown') }}
             {% else %}
-              {{ states('weather.forecast_home') | default('unknown') }}
+              {{ states('weather.nws_home_kmle') | default('unknown') }}
             {% endif %}
           {% else %}
-            {{ states('weather.forecast_home') | default('unknown') }}
+            {{ states('weather.nws_home_kmle') | default('unknown') }}
           {% endif %}
 
       - name: "Condition forecast today"
@@ -233,17 +253,18 @@ template:
         state: >
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
           {% if sensor_state not in invalid_states %}
             {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
-            {% set source_payload = state_attr('sensor.weather_daily_forecast', 'weather.forecast_home') %}
+            {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
             {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
               {{ forecast[0].condition | default('unknown') }}
             {% else %}
-              {{ states('weather.forecast_home') | default('unknown') }}
+              {{ states('weather.nws_home_kmle') | default('unknown') }}
             {% endif %}
           {% else %}
-            {{ states('weather.forecast_home') | default('unknown') }}
+            {{ states('weather.nws_home_kmle') | default('unknown') }}
           {% endif %}
 
       - name: "Precipitation forecast next hour"
@@ -251,44 +272,45 @@ template:
         state: >
           {% set sensor_state = states('sensor.weather_hourly_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% set source_entity = state_attr('sensor.weather_hourly_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
           {% if sensor_state not in invalid_states %}
             {% set direct_forecast = state_attr('sensor.weather_hourly_forecast', 'forecast') %}
-            {% set source_payload = state_attr('sensor.weather_hourly_forecast', 'weather.forecast_home') %}
+            {% set source_payload = state_attr('sensor.weather_hourly_forecast', source_entity) %}
             {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
             {% if forecast is defined and forecast is not none and forecast | length > 0 %}
-              {% if forecast[0].precipitation is defined %}
-                {{ forecast[0].precipitation | float(0) | round(2) }}
-              {% else %}
-                0
-              {% endif %}
+              {{ forecast[0].precipitation_probability | default(0) | float(0) | round(0) }}
             {% else %}
               0
             {% endif %}
           {% else %}
             0
           {% endif %}
-        unit_of_measurement: "mm"
+        unit_of_measurement: "%"
 
       - name: "Temperature forecast high today"
         unique_id: weather_forecast_temperature_high_today
         state: >
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
+          {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
           {% if sensor_state not in invalid_states %}
             {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
-            {% set source_payload = state_attr('sensor.weather_daily_forecast', 'weather.forecast_home') %}
+            {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
             {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
-            {% if forecast is defined and forecast is not none and forecast | length > 0 %}
-              {% if forecast[0].temperature is defined %}
-                {{ forecast[0].temperature | float | round(1) }}
-              {% else %}
-                {{ state_attr('weather.forecast_home', 'temperature') | default('unknown') }}
+            {% set ns = namespace(high=none) %}
+            {% for period in forecast[:2] %}
+              {% set temp = period.temperature | float(none) %}
+              {% if temp is not none and (ns.high is none or temp > ns.high) %}
+                {% set ns.high = temp %}
               {% endif %}
+            {% endfor %}
+            {% if ns.high is not none %}
+              {{ ns.high | round(1) }}
             {% else %}
-              {{ state_attr('weather.forecast_home', 'temperature') | default('unknown') }}
+              {{ states('sensor.weather_outdoor_temperature') | default('unknown') }}
             {% endif %}
           {% else %}
-            {{ state_attr('weather.forecast_home', 'temperature') | default('unknown') }}
+            {{ states('sensor.weather_outdoor_temperature') | default('unknown') }}
           {% endif %}
         unit_of_measurement: "°F"
         device_class: temperature

--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -122,7 +122,7 @@ template:
           {% set outdoor = states('sensor.weather_outdoor_temperature') | float(none) %}
           {% set outdoor_dew = states('sensor.weather_outdoor_dew_point') | float(none) %}
           {% set indoor_dew = states('sensor.window_ventilation_indoor_dew_point') | float(none) %}
-          {% set rain = states('sensor.precipitation_forecast_next_hour') | float(0) %}
+          {% set rain_probability = states('sensor.precipitation_forecast_next_hour') | float(0) %}
           {% set condition = states('sensor.condition_forecast_next_hour') %}
           {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
           {% set cooler_delta = states('input_number.window_ventilation_cooler_delta') | float(3) %}
@@ -133,7 +133,7 @@ template:
           {% set voc = states('sensor.thermostat_vocs') | float(0) %}
           {% set co2_base = states('sensor.window_ventilation_co2_baseline') | float(0) %}
           {% set voc_base = states('sensor.window_ventilation_voc_baseline') | float(0) %}
-          {% set raining = rain > 0.1 or condition in ['rainy', 'pouring', 'snowy-rainy'] %}
+          {% set raining = rain_probability >= 30 or condition in ['rainy', 'pouring', 'snowy-rainy'] %}
           {% set hvac_running = hvac_action in ['heating', 'cooling'] %}
           {% set data_ready = indoor is not none and outdoor is not none and outdoor_dew is not none and indoor_dew is not none %}
           {% set outdoor_cooler = data_ready and (indoor - outdoor) >= cooler_delta %}
@@ -177,7 +177,7 @@ template:
           outdoor_temperature: "{{ states('sensor.weather_outdoor_temperature') }}"
           indoor_dew_point: "{{ states('sensor.window_ventilation_indoor_dew_point') }}"
           outdoor_dew_point: "{{ states('sensor.weather_outdoor_dew_point') }}"
-          precipitation_next_hour: "{{ states('sensor.precipitation_forecast_next_hour') }}"
+          rain_probability_next_hour: "{{ states('sensor.precipitation_forecast_next_hour') }}"
           hvac_action: "{{ state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) }}"
           co2_current: "{{ states('sensor.thermostat_carbon_dioxide') }}"
           co2_baseline: "{{ states('sensor.window_ventilation_co2_baseline') }}"
@@ -198,7 +198,7 @@ template:
           {% set outdoor = states('sensor.weather_outdoor_temperature') | float(none) %}
           {% set indoor_dew = states('sensor.window_ventilation_indoor_dew_point') | float(none) %}
           {% set outdoor_dew = states('sensor.weather_outdoor_dew_point') | float(none) %}
-          {% set rain = states('sensor.precipitation_forecast_next_hour') | float(0) %}
+          {% set rain_probability = states('sensor.precipitation_forecast_next_hour') | float(0) %}
           {% set condition = states('sensor.condition_forecast_next_hour') %}
           {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
           {% set co2 = states('sensor.thermostat_carbon_dioxide') | float(0) %}
@@ -206,7 +206,7 @@ template:
           {% set co2_base = states('sensor.window_ventilation_co2_baseline') | float(0) %}
           {% set voc_base = states('sensor.window_ventilation_voc_baseline') | float(0) %}
           {% set high_humidity = states('input_number.window_ventilation_high_indoor_humidity') | float(58) %}
-          {% set raining = rain > 0.1 or condition in ['rainy', 'pouring', 'snowy-rainy'] %}
+          {% set raining = rain_probability >= 30 or condition in ['rainy', 'pouring', 'snowy-rainy'] %}
           {% set hvac_running = hvac_action in ['heating', 'cooling'] %}
           {% set co2_relative = co2_base > 0 and co2 >= 900 and co2 >= (co2_base + 175) %}
           {% set voc_relative = voc_base > 0 and voc >= 250 and voc >= (voc_base * 1.35) %}

--- a/tests/test_weather_forecast_cache.py
+++ b/tests/test_weather_forecast_cache.py
@@ -39,9 +39,9 @@ def test_weather_forecast_cache_publishes_normalized_top_level_payloads():
 
     for payload, forecast_type in (
         (hourly_payload, "hourly"),
-        (daily_payload, "daily"),
+        (daily_payload, "twice_daily"),
     ):
-        assert "source = 'weather.forecast_home'" in payload
+        assert "source = 'weather.nws_home_kmle'" in payload
         assert "payload =" in payload
         assert "payload.get('forecast', [])" in payload
         assert "'forecast': forecast" in payload
@@ -49,13 +49,23 @@ def test_weather_forecast_cache_publishes_normalized_top_level_payloads():
         assert f"'forecast_type': '{forecast_type}'" in payload
 
 
+def test_weather_refresh_uses_nws_hourly_and_twice_daily_forecasts():
+    forecast_calls = [
+        action for action in weather_refresh_action()
+        if action.get("service") == "weather.get_forecasts"
+    ]
+
+    assert [call["data"]["type"] for call in forecast_calls] == ["hourly", "twice_daily"]
+    assert all(call["target"]["entity_id"] == "weather.nws_home_kmle" for call in forecast_calls)
+
+
 def test_weather_derivative_sensors_accept_normalized_and_legacy_cache_shapes():
     weather_text = WEATHER.read_text()
 
     assert "state_attr('sensor.weather_hourly_forecast', 'forecast')" in weather_text
-    assert "state_attr('sensor.weather_hourly_forecast', 'weather.forecast_home')" in weather_text
     assert "state_attr('sensor.weather_daily_forecast', 'forecast')" in weather_text
-    assert "state_attr('sensor.weather_daily_forecast', 'weather.forecast_home')" in weather_text
+    assert "state_attr('sensor.weather_hourly_forecast', source_entity)" in weather_text
+    assert "state_attr('sensor.weather_daily_forecast', source_entity)" in weather_text
 
 
 def mqtt_sensor(name):
@@ -67,16 +77,25 @@ def mqtt_sensor(name):
 
 def test_weather_package_exposes_current_condition_seam_sensors():
     expected = {
-        "Weather Outdoor Temperature": "weather_outdoor_temperature",
-        "Weather Outdoor Humidity": "weather_outdoor_humidity",
-        "Weather Outdoor Dew Point": "weather_outdoor_dew_point",
+        "Weather Outdoor Temperature": (
+            "weather_outdoor_temperature",
+            "sensor.nws_41_17166991853366_96_04711058392532_kmle_temperature",
+        ),
+        "Weather Outdoor Humidity": (
+            "weather_outdoor_humidity",
+            "sensor.nws_41_17166991853366_96_04711058392532_kmle_relative_humidity",
+        ),
+        "Weather Outdoor Dew Point": (
+            "weather_outdoor_dew_point",
+            "sensor.nws_41_17166991853366_96_04711058392532_kmle_dew_point",
+        ),
     }
 
-    for name, unique_id in expected.items():
+    for name, (unique_id, source_entity) in expected.items():
         sensor = template_sensor(name)
         assert sensor["unique_id"] == unique_id
-        assert "weather.forecast_home" in sensor["availability"]
-        assert "weather.forecast_home" in sensor["state"]
+        assert source_entity in sensor["availability"]
+        assert source_entity in sensor["state"]
 
 
 def test_forecast_mqtt_sensors_do_not_require_literal_open_brace_availability_payload():
@@ -95,4 +114,12 @@ def test_temperature_forecast_high_today_uses_deployment_fahrenheit_units():
     sensor = template_sensor("Temperature forecast high today")
 
     assert sensor["unit_of_measurement"] == "°F"
-    assert "forecast[0].temperature | float | round(1)" in sensor["state"]
+    assert "forecast[:2]" in sensor["state"]
+    assert "ns.high" in sensor["state"]
+
+
+def test_precipitation_next_hour_uses_nws_probability_semantics():
+    sensor = template_sensor("Precipitation forecast next hour")
+
+    assert sensor["unit_of_measurement"] == "%"
+    assert "precipitation_probability" in sensor["state"]

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -86,6 +86,13 @@ def test_window_ventilation_dashboard_surfaces_required_context():
         "hvac_mode",
     }
 
+    assert any(
+        row.get("entity") == "sensor.precipitation_forecast_next_hour"
+        and row.get("name") == "Rain probability next hour"
+        for card in cards
+        for row in card.get("entities", [])
+        if isinstance(row, dict)
+    )
     assert not any(
         row.get("entity") == "weather.forecast_home"
         for card in cards

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -64,6 +64,8 @@ def test_window_ventilation_uses_household_relative_air_quality_baselines():
     assert "states('sensor.weather_outdoor_dew_point')" in package_text
     assert "state_attr('weather.forecast_home', 'temperature')" not in package_text
     assert "state_attr('weather.forecast_home', 'dew_point')" not in package_text
+    assert "rain_probability >= 30" in package_text
+    assert "rain > 0.1" not in package_text
 
 
 def test_window_ventilation_notifications_are_advisory_and_gated():


### PR DESCRIPTION
## Summary
- Rewire the normalized weather seam from `weather.forecast_home` to live NWS source `weather.nws_home_kmle`.
- Use NWS `hourly` plus `twice_daily` forecast payloads while preserving the existing MQTT-backed normalized forecast entities.
- Source current outdoor temperature, humidity, and dew point from the verified NWS auxiliary sensors.
- Treat `sensor.precipitation_forecast_next_hour` as NWS rain probability (%) and update ventilation/dashboard consumers accordingly.

## Tests
- `python3 -m pytest -q`
- YAML parse check for `packages/weather.yaml`, `packages/window_ventilation.yaml`, and `dashboards/window_ventilation.yaml`

## Live post-deploy verification notes
After deploying/reloading this package through the normal reviewed Home Assistant path, verify:
- `sensor.weather_hourly_forecast.attributes.source_entity == weather.nws_home_kmle`
- `sensor.weather_daily_forecast.attributes.source_entity == weather.nws_home_kmle`
- `sensor.weather_daily_forecast.attributes.forecast_type == twice_daily`
- `sensor.weather_outdoor_temperature`, `sensor.weather_outdoor_humidity`, and `sensor.weather_outdoor_dew_point` reflect the NWS auxiliary sensors rather than stale met.no values
- `sensor.condition_forecast_next_hour` and `sensor.precipitation_forecast_next_hour` populate from the NWS hourly payload; precipitation is now percent probability
- `sensor.temperature_forecast_high_today` produces a reasonable high from the first two twice-daily periods
- `sensor.window_ventilation_recommendation` remains available and interprets rain probability using the 30% threshold

Closes #110
