### PR TITLE
fix(window-ventilation): retain full-day air quality baselines

### DIFF
--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -63,6 +63,9 @@ input_text:
     max: 100
 
 sensor:
+  # Ecobee thermostat CO2/VOC updates arrive roughly every 30 seconds. A
+  # 24-hour statistics window therefore needs about 2,880 samples; keep 3,600
+  # so max_age, not sampling_size, controls the day-scale household baseline.
   - platform: statistics
     name: "Window Ventilation CO2 Baseline"
     unique_id: window_ventilation_co2_baseline
@@ -70,7 +73,7 @@ sensor:
     state_characteristic: mean
     max_age:
       hours: 24
-    sampling_size: 288
+    sampling_size: 3600
 
   - platform: statistics
     name: "Window Ventilation VOC Baseline"
@@ -79,7 +82,7 @@ sensor:
     state_characteristic: mean
     max_age:
       hours: 24
-    sampling_size: 288
+    sampling_size: 3600
 
 template:
   - sensor:

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -51,6 +51,9 @@ def test_window_ventilation_uses_household_relative_air_quality_baselines():
     } == {"sensor.thermostat_carbon_dioxide", "sensor.thermostat_vocs"}
     assert all(sensor["platform"] == "statistics" for sensor in statistic_sensors)
     assert all(sensor["state_characteristic"] == "mean" for sensor in statistic_sensors)
+    assert all(sensor["max_age"] == {"hours": 24} for sensor in statistic_sensors)
+    assert all(sensor["sampling_size"] >= 2880 for sensor in statistic_sensors)
+    assert all(sensor["sampling_size"] == 3600 for sensor in statistic_sensors)
 
     package_text = PACKAGE.read_text()
     assert "sensor.window_ventilation_co2_baseline" in package_text


### PR DESCRIPTION
## Summary
- Fixes the window ventilation CO2/VOC baseline-retention bug reported in #112.
- Raises both statistics baseline sensors from 288 samples to 3,600 samples, enough for the observed ~30-second thermostat cadence to retain a true 24-hour rolling mean with headroom.
- Preserves the existing `max_age: 24 hours`, entity names, and unique IDs so the advisor and dashboard keep their current references.
- Adds an inline comment and regression assertions documenting the cadence/retention relationship, because apparently 24 hours and 288 samples were having a private disagreement.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` for `packages/window_ventilation.yaml` and `dashboards/window_ventilation.yaml` — passed.
- `pytest tests/test_window_ventilation_package.py tests/test_window_ventilation_dashboard.py` — 7 passed.
- `pytest` — 25 passed.
- `git diff --check` — passed.
- `docker run --rm -v "$(pwd):/config" homeassistant/home-assistant:stable hass -c /config --script check_config` after creating CI-style dummy `SERVICE_ACCOUNT.json` and `.storage/` — passed.

Fixes #112
