### PR TITLE
feat: add forecast-aware extreme heat HVAC overlay

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -344,6 +344,14 @@ automation:
         entity_id: binary_sensor.climate_extreme_heat_day
         to: "on"
         id: hot_day_detected
+      - platform: numeric_state
+        entity_id: zone.home
+        above: 0
+        id: return_home
+      - platform: state
+        entity_id: input_boolean.mode_guest
+        to: "on"
+        id: guest_mode_enabled
     condition:
       - condition: state
         entity_id: input_boolean.climate_automation_enabled

--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -133,12 +133,88 @@ input_number:
     icon: mdi:snowflake-thermometer
     initial: *cool_away
 
+  climate_extreme_heat_threshold:
+    name: "Climate Extreme Heat Threshold"
+    min: 85
+    max: 110
+    step: 1
+    unit_of_measurement: "°F"
+    icon: mdi:thermometer-alert
+    initial: 95
+
+  climate_extreme_heat_precool_offset:
+    name: "Climate Extreme Heat Pre-cool Offset"
+    min: 0
+    max: 2
+    step: 1
+    unit_of_measurement: "°F"
+    icon: mdi:snowflake-thermometer
+    initial: 1
+
 # State tracking helpers
 input_boolean:
   climate_automation_enabled:
     name: "Climate Automation"
     icon: mdi:thermostat-auto
     initial: true
+
+  climate_extreme_heat_overlay_enabled:
+    name: "Climate Extreme Heat Overlay"
+    icon: mdi:sun-thermometer
+    initial: true
+
+  climate_extreme_heat_precool_active:
+    name: "Climate Extreme Heat Pre-cool Active"
+    icon: mdi:snowflake-alert
+    initial: false
+
+template:
+  - binary_sensor:
+      - name: "Climate Extreme Heat Day"
+        unique_id: climate_extreme_heat_day
+        icon: mdi:sun-thermometer
+        availability: >
+          {% set daily_state = states('sensor.weather_daily_forecast') %}
+          {% set threshold = states('input_number.climate_extreme_heat_threshold') | float(none) %}
+          {{ daily_state not in ['unknown', 'unavailable', '', none] and threshold is not none }}
+        state: >
+          {#
+            NWS twice-daily forecast periods in this deployment expose
+            temperature values in Fahrenheit. Use the normalized forecast
+            attribute directly instead of the older derived high-temp helper
+            so the hot-day decision is not dependent on ambiguous units.
+          #}
+          {% set threshold = states('input_number.climate_extreme_heat_threshold') | float(95) %}
+          {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
+          {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+          {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
+          {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
+          {% set ns = namespace(high=none) %}
+          {% for period in forecast[:2] %}
+            {% set temp = period.temperature | float(none) %}
+            {% if temp is not none and (ns.high is none or temp > ns.high) %}
+              {% set ns.high = temp %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.high is not none and ns.high >= threshold }}
+        attributes:
+          forecast_high_f: >
+            {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
+            {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+            {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
+            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
+            {% set ns = namespace(high=none) %}
+            {% for period in forecast[:2] %}
+              {% set temp = period.temperature | float(none) %}
+              {% if temp is not none and (ns.high is none or temp > ns.high) %}
+                {% set ns.high = temp %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.high if ns.high is not none else 'unknown' }}
+          threshold_f: "{{ states('input_number.climate_extreme_heat_threshold') | float(95) }}"
+          forecast_source: "sensor.weather_daily_forecast"
+          forecast_unit_assumption: "NWS forecast temperature attribute is Fahrenheit"
+          decision_scope: "maximum temperature from the first two twice-daily periods"
 
 # Automations
 automation:
@@ -255,6 +331,129 @@ automation:
             {{ states('input_number.climate_cool_day') | float }}
           target_temp_low: >
             {{ states('input_number.climate_heat_day') | float }}
+
+  - alias: "climate_extreme_heat_precool_apply"
+    id: "climate_extreme_heat_precool_apply"
+    description: >
+      Apply a one-time daytime cooling offset on validated extreme-heat days.
+    trigger:
+      - platform: time
+        at: "13:00:00"
+        id: overlay_window_start
+      - platform: state
+        entity_id: binary_sensor.climate_extreme_heat_day
+        to: "on"
+        id: hot_day_detected
+    condition:
+      - condition: state
+        entity_id: input_boolean.climate_automation_enabled
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.climate_extreme_heat_overlay_enabled
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.climate_extreme_heat_day
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.climate_extreme_heat_precool_active
+        state: "off"
+      - condition: time
+        after: "12:59:00"
+        before: "18:00:00"
+      # Not away: someone is home, or guest mode is intentionally preserving
+      # occupied-house behavior while residents may be absent.
+      - condition: or
+        conditions:
+          - condition: numeric_state
+            entity_id: zone.home
+            above: 0
+          - condition: state
+            entity_id: input_boolean.mode_guest
+            state: "on"
+    action:
+      - service: climate.set_hvac_mode
+        target:
+          entity_id: climate.dining_room_thermostat
+        data:
+          hvac_mode: heat_cool
+      - service: climate.set_temperature
+        target:
+          entity_id: climate.dining_room_thermostat
+        data:
+          target_temp_high: >
+            {% set day = states('input_number.climate_cool_day') | float %}
+            {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %}
+            {{ [day - offset, 65] | max }}
+          target_temp_low: >
+            {{ states('input_number.climate_heat_day') | float }}
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.climate_extreme_heat_precool_active
+    mode: single
+
+  - alias: "climate_extreme_heat_precool_restore"
+    id: "climate_extreme_heat_precool_restore"
+    description: >
+      End the bounded extreme-heat pre-cool overlay and restore daytime targets.
+    trigger:
+      - platform: time
+        at: "18:00:00"
+        id: overlay_window_end
+      - platform: state
+        entity_id: input_boolean.climate_extreme_heat_overlay_enabled
+        to: "off"
+        id: overlay_disabled
+      - platform: state
+        entity_id: input_boolean.climate_automation_enabled
+        to: "off"
+        id: climate_disabled
+      - platform: numeric_state
+        entity_id: zone.home
+        below: 1
+        for:
+          minutes: 5
+        id: away_started
+    condition:
+      - condition: state
+        entity_id: input_boolean.climate_extreme_heat_precool_active
+        state: "on"
+    action:
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.climate_extreme_heat_precool_active
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ trigger.id != 'away_started' }}"
+              - condition: state
+                entity_id: input_boolean.climate_automation_enabled
+                state: "on"
+              - condition: or
+                conditions:
+                  - condition: numeric_state
+                    entity_id: zone.home
+                    above: 0
+                  - condition: state
+                    entity_id: input_boolean.mode_guest
+                    state: "on"
+              - condition: time
+                after: "09:00:00"
+                before: "21:00:00"
+            sequence:
+              - service: climate.set_hvac_mode
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  hvac_mode: heat_cool
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {{ states('input_number.climate_cool_day') | float }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_day') | float }}
+    mode: single
 
   - alias: "climate_schedule_bedtime"
     id: "climate_schedule_bedtime"

--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -344,10 +344,6 @@ automation:
         entity_id: binary_sensor.climate_extreme_heat_day
         to: "on"
         id: hot_day_detected
-      - platform: numeric_state
-        entity_id: zone.home
-        above: 0
-        id: return_home
       - platform: state
         entity_id: input_boolean.mode_guest
         to: "on"
@@ -619,6 +615,33 @@ automation:
                     {{ states('input_number.climate_cool_morning') | float }}
                   target_temp_low: >
                     {{ states('input_number.climate_heat_morning') | float }}
+          # Extreme heat overlay window (13:00-17:59). Handle return-home here
+          # instead of in a second zone.home automation so this path is not
+          # order-dependent with the normal daytime restore.
+          - conditions:
+              - condition: state
+                entity_id: input_boolean.climate_extreme_heat_overlay_enabled
+                state: "on"
+              - condition: state
+                entity_id: binary_sensor.climate_extreme_heat_day
+                state: "on"
+              - condition: time
+                after: "12:59:00"
+                before: "18:00:00"
+            sequence:
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {% set day = states('input_number.climate_cool_day') | float %}
+                    {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %}
+                    {{ [day - offset, 65] | max }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_day') | float }}
+              - service: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.climate_extreme_heat_precool_active
           # Daytime (9:00-20:59)
           - conditions:
               - condition: time

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIMATE = ROOT / "packages" / "climate_control.yaml"
+
+
+def load_climate():
+    return yaml.safe_load(CLIMATE.read_text())
+
+
+def automation(automation_id):
+    for item in load_climate()["automation"]:
+        if item["id"] == automation_id:
+            return item
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def binary_sensor(name):
+    for block in load_climate()["template"]:
+        for sensor in block.get("binary_sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"binary sensor {name!r} not found")
+
+
+def test_extreme_heat_helpers_are_configurable_in_fahrenheit():
+    config = load_climate()
+
+    threshold = config["input_number"]["climate_extreme_heat_threshold"]
+    offset = config["input_number"]["climate_extreme_heat_precool_offset"]
+
+    assert threshold["unit_of_measurement"] == "°F"
+    assert threshold["initial"] == 95
+    assert offset["unit_of_measurement"] == "°F"
+    assert offset["min"] == 0
+    assert offset["max"] == 2
+    assert offset["initial"] == 1
+    assert config["input_boolean"]["climate_extreme_heat_overlay_enabled"]["initial"] is True
+    assert config["input_boolean"]["climate_extreme_heat_precool_active"]["initial"] is False
+
+
+def test_extreme_heat_day_uses_validated_daily_forecast_attributes_not_derived_sensor():
+    sensor = binary_sensor("Climate Extreme Heat Day")
+    state = sensor["state"]
+    attrs = sensor["attributes"]
+
+    assert "state_attr('sensor.weather_daily_forecast', 'forecast')" in state
+    assert "state_attr('sensor.weather_daily_forecast', source_entity)" in state
+    assert "forecast[:2]" in state
+    assert "period.temperature" in state
+    assert "input_number.climate_extreme_heat_threshold" in state
+    assert "sensor.temperature_forecast_high_today" not in state
+    assert attrs["forecast_source"] == "sensor.weather_daily_forecast"
+    assert "Fahrenheit" in attrs["forecast_unit_assumption"]
+
+
+def test_precool_apply_is_bounded_occupied_and_one_shot():
+    item = automation("climate_extreme_heat_precool_apply")
+    text = CLIMATE.read_text()
+
+    assert {trigger.get("id") for trigger in item["trigger"]} == {
+        "overlay_window_start",
+        "hot_day_detected",
+    }
+    assert any(trigger.get("at") == "13:00:00" for trigger in item["trigger"])
+    assert "before: \"18:00:00\"" in text
+    assert "binary_sensor.climate_extreme_heat_day" in text
+    assert "input_boolean.climate_extreme_heat_precool_active" in text
+    assert "state: \"off\"" in text
+    assert "zone.home" in text
+    assert "input_boolean.mode_guest" in text
+    assert "day - offset" in text
+    assert "input_boolean.turn_on" in text
+
+
+def test_precool_restore_returns_day_targets_without_fighting_away_mode():
+    item = automation("climate_extreme_heat_precool_restore")
+    text = CLIMATE.read_text()
+
+    assert any(trigger.get("at") == "18:00:00" for trigger in item["trigger"])
+    assert any(trigger.get("id") == "away_started" for trigger in item["trigger"])
+    assert "trigger.id != 'away_started'" in text
+    assert "input_boolean.turn_off" in text
+    assert "states('input_number.climate_cool_day')" in text
+    assert "states('input_number.climate_heat_day')" in text

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -64,6 +64,8 @@ def test_precool_apply_is_bounded_occupied_and_one_shot():
     assert {trigger.get("id") for trigger in item["trigger"]} == {
         "overlay_window_start",
         "hot_day_detected",
+        "return_home",
+        "guest_mode_enabled",
     }
     assert any(trigger.get("at") == "13:00:00" for trigger in item["trigger"])
     assert "before: \"18:00:00\"" in text
@@ -74,6 +76,32 @@ def test_precool_apply_is_bounded_occupied_and_one_shot():
     assert "input_boolean.mode_guest" in text
     assert "day - offset" in text
     assert "input_boolean.turn_on" in text
+
+
+def test_precool_apply_rearms_when_occupied_mid_window_without_churn():
+    item = automation("climate_extreme_heat_precool_apply")
+
+    return_home = next(
+        trigger for trigger in item["trigger"] if trigger.get("id") == "return_home"
+    )
+    guest_enabled = next(
+        trigger for trigger in item["trigger"] if trigger.get("id") == "guest_mode_enabled"
+    )
+
+    assert return_home["platform"] == "numeric_state"
+    assert return_home["entity_id"] == "zone.home"
+    assert return_home["above"] == 0
+    assert guest_enabled == {
+        "platform": "state",
+        "entity_id": "input_boolean.mode_guest",
+        "to": "on",
+        "id": "guest_mode_enabled",
+    }
+    assert any(
+        condition.get("entity_id") == "input_boolean.climate_extreme_heat_precool_active"
+        and condition.get("state") == "off"
+        for condition in item["condition"]
+    )
 
 
 def test_precool_restore_returns_day_targets_without_fighting_away_mode():

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -64,7 +64,6 @@ def test_precool_apply_is_bounded_occupied_and_one_shot():
     assert {trigger.get("id") for trigger in item["trigger"]} == {
         "overlay_window_start",
         "hot_day_detected",
-        "return_home",
         "guest_mode_enabled",
     }
     assert any(trigger.get("at") == "13:00:00" for trigger in item["trigger"])
@@ -78,19 +77,14 @@ def test_precool_apply_is_bounded_occupied_and_one_shot():
     assert "input_boolean.turn_on" in text
 
 
-def test_precool_apply_rearms_when_occupied_mid_window_without_churn():
+def test_precool_apply_rearms_for_guest_mode_without_return_home_race():
     item = automation("climate_extreme_heat_precool_apply")
 
-    return_home = next(
-        trigger for trigger in item["trigger"] if trigger.get("id") == "return_home"
-    )
     guest_enabled = next(
         trigger for trigger in item["trigger"] if trigger.get("id") == "guest_mode_enabled"
     )
 
-    assert return_home["platform"] == "numeric_state"
-    assert return_home["entity_id"] == "zone.home"
-    assert return_home["above"] == 0
+    assert "return_home" not in {trigger.get("id") for trigger in item["trigger"]}
     assert guest_enabled == {
         "platform": "state",
         "entity_id": "input_boolean.mode_guest",
@@ -102,6 +96,53 @@ def test_precool_apply_rearms_when_occupied_mid_window_without_churn():
         and condition.get("state") == "off"
         for condition in item["condition"]
     )
+
+
+def test_return_home_deactivate_applies_extreme_heat_overlay_before_day_restore():
+    apply = automation("climate_extreme_heat_precool_apply")
+    deactivate = automation("climate_away_mode_deactivate")
+    extreme_heat_branch = deactivate["action"][1]["choose"][1]
+    daytime_branch = deactivate["action"][1]["choose"][2]
+
+    assert not any(
+        trigger.get("entity_id") == "zone.home" for trigger in apply["trigger"]
+    )
+    assert deactivate["trigger"] == [
+        {"platform": "numeric_state", "entity_id": "zone.home", "above": 0}
+    ]
+    assert any(
+        condition.get("entity_id") == "input_boolean.climate_extreme_heat_overlay_enabled"
+        and condition.get("state") == "on"
+        for condition in extreme_heat_branch["conditions"]
+    )
+    assert any(
+        condition.get("entity_id") == "binary_sensor.climate_extreme_heat_day"
+        and condition.get("state") == "on"
+        for condition in extreme_heat_branch["conditions"]
+    )
+    assert any(
+        condition.get("condition") == "time"
+        and condition.get("after") == "12:59:00"
+        and condition.get("before") == "18:00:00"
+        for condition in extreme_heat_branch["conditions"]
+    )
+
+    set_temperature_steps = [
+        step
+        for step in extreme_heat_branch["sequence"]
+        if step.get("service") == "climate.set_temperature"
+    ]
+    assert len(set_temperature_steps) == 1
+    assert "day - offset" in set_temperature_steps[0]["data"]["target_temp_high"]
+    assert any(
+        step.get("service") == "input_boolean.turn_on"
+        and step.get("target", {}).get("entity_id")
+        == "input_boolean.climate_extreme_heat_precool_active"
+        for step in extreme_heat_branch["sequence"]
+    )
+    assert daytime_branch["conditions"] == [
+        {"condition": "time", "after": "09:00:00", "before": "21:00:00"}
+    ]
 
 
 def test_precool_restore_returns_day_targets_without_fighting_away_mode():


### PR DESCRIPTION
## Summary
- Adds a narrow extreme-heat HVAC overlay to `packages/climate_control.yaml` with UI-configurable enablement, Fahrenheit threshold, and 0-2°F pre-cool offset.
- Derives `binary_sensor.climate_extreme_heat_day` directly from the normalized `sensor.weather_daily_forecast` forecast attribute, documenting the NWS Fahrenheit assumption and bypassing `sensor.temperature_forecast_high_today` for the control decision.
- Applies the offset once during a bounded 13:00-18:00 window only when climate automation is enabled and the house is occupied or guest mode is active, then restores daytime schedule targets at window end without fighting away mode.
- Adds focused regression coverage for helper semantics, forecast-source selection, one-shot churn protection, away/guest handling, and restoration behavior.

## Verification
- `python3` YAML parse for `packages/climate_control.yaml` and `packages/weather.yaml`
- `pytest -q` (29 passed)
- `docker run --rm -v "$PWD":/config ghcr.io/home-assistant/home-assistant:stable hass -c /config --script check_config`
- `git diff --check`

## High-temp sensor note
`weather.yaml` already exposes `sensor.temperature_forecast_high_today` as `°F` on this branch, but this implementation deliberately bypasses that derived helper for HVAC thresholding. The new hot-day decision reads the validated normalized daily forecast attribute directly, using the first two NWS twice-daily forecast periods and comparing their Fahrenheit temperatures to `input_number.climate_extreme_heat_threshold`.

Closes #115
