### PR TITLE
feat: add secure house sanity check

### DIFF
--- a/packages/presence.yaml
+++ b/packages/presence.yaml
@@ -68,6 +68,11 @@ automation:
       - service: light.turn_off
         target:
           entity_id: all
+      # Notify only if away-mode security did not settle as expected.
+      - delay: "00:00:15"
+      - service: script.secure_house_sanity_check
+        data:
+          check_context: "away"
 
   - alias: "presence_someone_returned"
     id: "presence_someone_returned"

--- a/packages/routines.yaml
+++ b/packages/routines.yaml
@@ -309,3 +309,10 @@ script:
           - service: alarm_control_panel.alarm_arm_night
             target:
               entity_id: alarm_control_panel.home_alarm
+
+      # Final security sanity check: alert only if the house is still not
+      # secure after Good Night has had a moment to run its arm/lock handlers.
+      - delay: "00:00:15"
+      - service: script.secure_house_sanity_check
+        data:
+          check_context: "night"

--- a/packages/security_sanity.yaml
+++ b/packages/security_sanity.yaml
@@ -1,0 +1,236 @@
+# packages/security_sanity.yaml
+#
+# Security sanity check workflow
+#
+# Features:
+# - Reusable secure-house sanity check script for routines and presence
+# - Aggregates front door, garage door, and alarm mismatches into one alert
+# - Notification actions remediate only when explicitly selected
+# - Guest mode is documented as an intentional advisory exception
+
+script:
+  secure_house_sanity_check:
+    alias: "Secure House Sanity Check"
+    description: >
+      Check front door, garage door, and alarm state for a securing context and
+      send one actionable notification only when the house is not fully secure.
+    mode: parallel
+    fields:
+      check_context:
+        name: "Security context"
+        description: "Expected security mode: night or away"
+        example: "night"
+        default: "night"
+        selector:
+          select:
+            options:
+              - "night"
+              - "away"
+    sequence:
+      - variables:
+          security_context: "{{ check_context | default('night') }}"
+          expected_alarm_state: >
+            {{ 'armed_away' if security_context == 'away' else 'armed_night' }}
+          expected_alarm_label: >
+            {{ 'away' if security_context == 'away' else 'night' }}
+          is_guest_mode: "{{ is_state('input_boolean.mode_guest', 'on') }}"
+          front_door_state: "{{ states('lock.front_door') }}"
+          garage_door_state: "{{ states('cover.garage_door') }}"
+          alarm_state: "{{ states('alarm_control_panel.home_alarm') }}"
+          garage_obstructed: >
+            {{ is_state('binary_sensor.garage_door_obstruction', 'on') }}
+          front_door_needs_lock: "{{ front_door_state != 'locked' }}"
+          garage_needs_close: "{{ garage_door_state != 'closed' }}"
+          alarm_needs_arm: "{{ alarm_state != expected_alarm_state }}"
+          security_findings: >
+            {% set findings = namespace(items=[]) %}
+            {% if front_door_state != 'locked' %}
+              {% set findings.items = findings.items +
+                ['Front door is ' ~ front_door_state ~ ' instead of locked.'] %}
+            {% endif %}
+            {% if garage_door_state != 'closed' %}
+              {% set garage_note = 'Garage door is ' ~ garage_door_state ~
+                ' instead of closed.' %}
+              {% if is_state('binary_sensor.garage_door_obstruction', 'on') %}
+                {% set garage_note = garage_note ~
+                  ' Obstruction is detected; remote close may be skipped.' %}
+              {% endif %}
+              {% set findings.items = findings.items + [garage_note] %}
+            {% endif %}
+            {% if alarm_state != expected_alarm_state %}
+              {% set findings.items = findings.items +
+                ['Alarm is ' ~ alarm_state ~ ' instead of armed ' ~
+                 expected_alarm_label ~ '.'] %}
+            {% endif %}
+            {{ findings.items | join('\n') }}
+          mismatch_count: >
+            {{ (1 if front_door_state != 'locked' else 0) +
+               (1 if garage_door_state != 'closed' else 0) +
+               (1 if alarm_state != expected_alarm_state else 0) }}
+          notification_tag: >
+            secure-house-{{ security_context }}-{{ (now().timestamp() * 1000) |
+            int }}-{{ range(0, 999) | random }}
+          context_label: >
+            {{ 'Everyone left' if security_context == 'away' else 'Good Night' }}
+          guest_mode_note: >
+            {% if is_guest_mode %}
+            Guest Mode is on, so this alert is advisory and may reflect an
+            intentional exception.
+            {% endif %}
+
+      - if:
+          - condition: template
+            value_template: "{{ mismatch_count | int > 0 }}"
+        then:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: >
+                      {{ is_state('binary_sensor.garage_door_obstruction', 'off') }}
+                sequence:
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Secure House Check"
+                      message: >
+                        {{ context_label }} found {{ mismatch_count }} security
+                        item{{ '' if mismatch_count | int == 1 else 's' }} to
+                        review:
+                        {{ security_findings }}
+                        {{ guest_mode_note }}
+                      data:
+                        tag: "{{ notification_tag }}"
+                        when: "{{ now().timestamp() | int }}"
+                        priority: "high"
+                        ttl: 0
+                        actions:
+                          - action: "secure_house_lock_front_door"
+                            title: "Lock Door"
+                          - action: "secure_house_close_garage"
+                            title: "Close Garage"
+                          - action: "secure_house_arm_{{ security_context }}"
+                            title: "Arm {{ expected_alarm_label | title }}"
+                          - action: "secure_house_acknowledge"
+                            title: "Acknowledge"
+            default:
+              - service: notify.all_mobile_devices
+                data:
+                  title: "Secure House Check"
+                  message: >
+                    {{ context_label }} found {{ mismatch_count }} security
+                    item{{ '' if mismatch_count | int == 1 else 's' }} to
+                    review:
+                    {{ security_findings }}
+                    {{ guest_mode_note }}
+                  data:
+                    tag: "{{ notification_tag }}"
+                    when: "{{ now().timestamp() | int }}"
+                    priority: "high"
+                    ttl: 0
+                    actions:
+                      - action: "secure_house_lock_front_door"
+                        title: "Lock Door"
+                      - action: "secure_house_arm_{{ security_context }}"
+                        title: "Arm {{ expected_alarm_label | title }}"
+                      - action: "secure_house_acknowledge"
+                        title: "Acknowledge"
+
+      - service: logbook.log
+        data:
+          name: "Secure House Check"
+          message: >
+            {{ context_label }} check completed with {{ mismatch_count }}
+            mismatch{{ '' if mismatch_count | int == 1 else 'es' }}.
+
+automation:
+  - alias: "secure_house_notification_actions"
+    id: "secure_house_notification_actions"
+    description: "Handle explicit remediation actions from secure-house alerts"
+    trigger:
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: secure_house_lock_front_door
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: secure_house_close_garage
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: secure_house_arm_night
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: secure_house_arm_away
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: secure_house_acknowledge
+    action:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ trigger.event.data.action == 'secure_house_lock_front_door' }}
+            sequence:
+              - service: lock.lock
+                target:
+                  entity_id: lock.front_door
+
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ trigger.event.data.action == 'secure_house_close_garage' }}
+            sequence:
+              - if:
+                  - condition: state
+                    entity_id: binary_sensor.garage_door_obstruction
+                    state: "off"
+                then:
+                  - service: cover.close_cover
+                    target:
+                      entity_id: cover.garage_door
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Secure House Check"
+                      message: "Closing garage door remotely..."
+                      data:
+                        tag: "secure-house-garage-closing"
+                else:
+                  - service: notify.all_mobile_devices
+                    data:
+                      title: "Secure House Check"
+                      message: >
+                        Garage door close skipped because obstruction is
+                        currently detected.
+                      data:
+                        tag: "secure-house-garage-obstructed"
+                        priority: "high"
+
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ trigger.event.data.action == 'secure_house_arm_night' }}
+            sequence:
+              - service: alarm_control_panel.alarm_arm_night
+                target:
+                  entity_id: alarm_control_panel.home_alarm
+
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ trigger.event.data.action == 'secure_house_arm_away' }}
+            sequence:
+              - service: alarm_control_panel.alarm_arm_away
+                target:
+                  entity_id: alarm_control_panel.home_alarm
+
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ trigger.event.data.action == 'secure_house_acknowledge' }}
+            sequence:
+              - service: logbook.log
+                data:
+                  name: "Secure House Check"
+                  message: "Secure-house alert acknowledged from notification."

--- a/tests/test_security_sanity.py
+++ b/tests/test_security_sanity.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SECURITY = ROOT / "packages" / "security_sanity.yaml"
+ROUTINES = ROOT / "packages" / "routines.yaml"
+PRESENCE = ROOT / "packages" / "presence.yaml"
+
+
+def load_yaml(path):
+    return yaml.safe_load(path.read_text())
+
+
+def automation_by_id(package, automation_id):
+    for automation in package["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def script_step_services(script):
+    return [step.get("service") for step in script["sequence"] if isinstance(step, dict)]
+
+
+def test_secure_house_sanity_script_aggregates_and_stays_notify_first():
+    package = load_yaml(SECURITY)
+    script = package["script"]["secure_house_sanity_check"]
+    text = SECURITY.read_text()
+
+    assert script["mode"] == "parallel"
+    assert "check_context" in script["fields"]
+    assert "lock.front_door" in text
+    assert "cover.garage_door" in text
+    assert "alarm_control_panel.home_alarm" in text
+    assert "findings.items | join" in text
+    assert "mismatch_count | int > 0" in text
+    assert "1 if front_door_state != 'locked' else 0" in text
+    assert "Guest Mode is on" in text
+
+    services = script_step_services(script)
+    assert "notify.all_mobile_devices" in text
+    assert "lock.lock" not in services
+    assert "cover.close_cover" not in services
+    assert "alarm_control_panel.alarm_arm_night" not in services
+    assert "alarm_control_panel.alarm_arm_away" not in services
+
+
+def test_secure_house_actions_require_explicit_notification_events():
+    package = load_yaml(SECURITY)
+    automation = automation_by_id(package, "secure_house_notification_actions")
+    text = SECURITY.read_text()
+
+    assert {trigger["event_data"]["action"] for trigger in automation["trigger"]} == {
+        "secure_house_lock_front_door",
+        "secure_house_close_garage",
+        "secure_house_arm_night",
+        "secure_house_arm_away",
+        "secure_house_acknowledge",
+    }
+    assert "binary_sensor.garage_door_obstruction" in text
+    assert "lock.lock" in text
+    assert "cover.close_cover" in text
+    assert "alarm_control_panel.alarm_arm_night" in text
+    assert "alarm_control_panel.alarm_arm_away" in text
+
+
+def test_good_night_invokes_secure_house_check_after_routine_sequence():
+    package = load_yaml(ROUTINES)
+    sequence = package["script"]["good_night"]["sequence"]
+
+    assert sequence[-2] == {"delay": "00:00:15"}
+    assert sequence[-1] == {
+        "service": "script.secure_house_sanity_check",
+        "data": {"check_context": "night"},
+    }
+
+
+def test_everyone_left_invokes_same_secure_house_check():
+    package = load_yaml(PRESENCE)
+    automation = automation_by_id(package, "presence_everyone_left")
+
+    assert automation["condition"] == [
+        {
+            "condition": "state",
+            "entity_id": "input_boolean.mode_guest",
+            "state": "off",
+        }
+    ]
+    assert automation["action"][-2] == {"delay": "00:00:15"}
+    assert automation["action"][-1] == {
+        "service": "script.secure_house_sanity_check",
+        "data": {"check_context": "away"},
+    }


### PR DESCRIPTION
## Summary
- Adds `script.secure_house_sanity_check` in `packages/security_sanity.yaml` to evaluate `lock.front_door`, `cover.garage_door`, and `alarm_control_panel.home_alarm` for night/away contexts.
- Aggregates all mismatches into one `notify.all_mobile_devices` alert and stays notification-only unless a mobile notification action is explicitly tapped.
- Wires the check into Good Night after the routine settles, and into the everyone-left automation after away-mode settling.

## Trigger paths implemented
- Good Night path: `script.good_night` waits 15 seconds after its final alarm-arm step, then calls `script.secure_house_sanity_check` with `check_context: night`.
- Everyone-left path: `automation.presence_everyone_left` keeps its existing guest-mode guard, waits 15 seconds after away actions, then calls the same script with `check_context: away`.

## Notification actions implemented
- `secure_house_lock_front_door` -> locks `lock.front_door`.
- `secure_house_close_garage` -> closes `cover.garage_door` only when `binary_sensor.garage_door_obstruction` is `off`; otherwise it sends a high-priority skipped-close notice.
- `secure_house_arm_night` -> arms `alarm_control_panel.home_alarm` night.
- `secure_house_arm_away` -> arms `alarm_control_panel.home_alarm` away.
- `secure_house_acknowledge` -> records an acknowledgement in the logbook.

## Caveats
- The existing `garage_door_open_too_long_warning` workflow is unchanged and remains the dedicated long-open guardrail.
- Guest Mode is explicitly called out in the notification as an advisory intentional-exception context; the everyone-left automation still does not run while guest mode is on.
- I did not run a full Home Assistant config check because this workspace does not have `hass` installed and the card did not provide a known-safe containerized config-check command/environment. Static YAML/package validation and regression tests were run instead.

## Verification
- `python3 -m pytest` -> 35 passed.
- Parsed changed YAML with PyYAML: `packages/security_sanity.yaml`, `packages/routines.yaml`, and `packages/presence.yaml`.

Closes #114
