### PR TITLE
fix(climate): preserve schedule setpoints across restart

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -42,6 +42,10 @@ homeassistant:
       cool_away: &cool_away 78
 
 # Helper entities for temperature setpoints
+#
+# Do not set `initial` on schedule setpoint helpers. Home Assistant restores
+# input_number state across restarts only when `initial` is omitted; setting it
+# here would overwrite UI-tuned schedule values on every restart.
 input_number:
   climate_heat_morning:
     name: "Climate Heat - Morning"
@@ -50,7 +54,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:thermometer-chevron-up
-    initial: *heat_morning
 
   climate_heat_day:
     name: "Climate Heat - Daytime"
@@ -59,7 +62,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:thermometer
-    initial: *heat_day
 
   climate_heat_bedtime:
     name: "Climate Heat - Bedtime"
@@ -68,7 +70,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:thermometer-chevron-up
-    initial: *heat_bedtime
 
   climate_heat_sleep:
     name: "Climate Heat - Sleep"
@@ -77,7 +78,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:thermometer-chevron-down
-    initial: *heat_sleep
 
   climate_heat_away:
     name: "Climate Heat - Away"
@@ -86,7 +86,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:thermometer-low
-    initial: *heat_away
 
   climate_cool_morning:
     name: "Climate Cool - Morning"
@@ -95,7 +94,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:snowflake
-    initial: *cool_morning
 
   climate_cool_day:
     name: "Climate Cool - Daytime"
@@ -104,7 +102,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:snowflake
-    initial: *cool_day
 
   climate_cool_bedtime:
     name: "Climate Cool - Bedtime"
@@ -113,7 +110,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:snowflake
-    initial: *cool_bedtime
 
   climate_cool_sleep:
     name: "Climate Cool - Sleep"
@@ -122,7 +118,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:snowflake
-    initial: *cool_sleep
 
   climate_cool_away:
     name: "Climate Cool - Away"
@@ -131,7 +126,6 @@ input_number:
     step: 1
     unit_of_measurement: "°F"
     icon: mdi:snowflake-thermometer
-    initial: *cool_away
 
   climate_extreme_heat_threshold:
     name: "Climate Extreme Heat Threshold"

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -26,6 +26,28 @@ def binary_sensor(name):
     raise AssertionError(f"binary sensor {name!r} not found")
 
 
+SCHEDULE_SETPOINT_HELPERS = {
+    "climate_heat_morning",
+    "climate_heat_day",
+    "climate_heat_bedtime",
+    "climate_heat_sleep",
+    "climate_heat_away",
+    "climate_cool_morning",
+    "climate_cool_day",
+    "climate_cool_bedtime",
+    "climate_cool_sleep",
+    "climate_cool_away",
+}
+
+
+def test_climate_schedule_setpoint_helpers_restore_last_ui_value():
+    config = load_climate()
+
+    for helper in SCHEDULE_SETPOINT_HELPERS:
+        assert helper in config["input_number"]
+        assert "initial" not in config["input_number"][helper]
+
+
 def test_extreme_heat_helpers_are_configurable_in_fahrenheit():
     config = load_climate()
 


### PR DESCRIPTION
## Summary
- Remove explicit `initial` values from the climate schedule input_number helpers so Home Assistant restores UI-tuned state after restart.
- Leave the existing helper entity IDs and automation reads intact for morning/day/bedtime/sleep/away and extreme-heat overlay flows.
- Add a regression test that all schedule setpoint helpers omit `initial`.

## Persistence note
Home Assistant restores `input_number` state across restarts when no YAML `initial` is provided. These helpers are runtime-tunable schedule setpoints, so omitting `initial` prevents values like `input_number.climate_cool_day` from reverting to the packaged `*cool_day` default on boot.

## Validation
- `python - <<'PY' ... yaml.safe_load(packages/climate_control.yaml) ... PY`
- `pytest tests/test_climate_extreme_heat_overlay.py::test_climate_schedule_setpoint_helpers_restore_last_ui_value -q`
- `pytest -q` (39 passed)
- Home Assistant config check not run locally; repo workflow uses frenck/action-home-assistant in GitHub Actions and no safe local `hass --script check_config` environment is provided.

Closes #120