### PR TITLE
fix(climate): trigger pre-arrival template from proximity inputs

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -228,6 +228,31 @@ template:
           forecast_unit_assumption: "NWS forecast temperature attribute is Fahrenheit"
           decision_scope: "maximum temperature from the first two twice-daily periods"
 
+  - trigger:
+      # Trigger-based template entity with explicit inputs. The pre-arrival
+      # decision previously used dynamically constructed entity IDs inside the
+      # template body; live verification showed Home Assistant did not reliably
+      # re-render it when the raw person/proximity states changed.
+      - platform: homeassistant
+        event: start
+        id: ha_start
+      - platform: state
+        entity_id:
+          - person.brian
+          - person.hester
+          - sensor.home_brian_distance
+          - sensor.home_brian_direction_of_travel
+          - sensor.home_hester_distance
+          - sensor.home_hester_direction_of_travel
+          - input_number.climate_precool_arrival_distance_ft
+          - input_number.climate_precool_arrival_signal_max_age
+        id: prearrival_input_changed
+      # Time ticks allow fresh inbound signals to age out even if the proximity
+      # integration stops publishing before the abandoned-trip restore window.
+      - platform: time_pattern
+        minutes: "/1"
+        id: prearrival_signal_age_tick
+    binary_sensor:
       - name: "Climate Pre-arrival Expected"
         unique_id: climate_pre_arrival_expected
         icon: mdi:home-import-outline

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -26,6 +26,14 @@ def binary_sensor(name):
     raise AssertionError(f"binary sensor {name!r} not found")
 
 
+def template_block_for_binary_sensor(name):
+    for block in load_climate()["template"]:
+        for sensor in block.get("binary_sensor", []):
+            if sensor["name"] == name:
+                return block
+    raise AssertionError(f"template block for binary sensor {name!r} not found")
+
+
 SCHEDULE_SETPOINT_HELPERS = {
     "climate_heat_morning",
     "climate_heat_day",
@@ -187,6 +195,36 @@ def test_precool_prearrival_helpers_use_person_level_proximity_abstractions():
     assert "climate_precool_arrival_distance_ft" in state
     assert sensor["attributes"]["eligible_people"] == "Brian, Hester"
     assert "To add another climate pre-arrival person" in text
+
+
+def test_precool_prearrival_template_has_explicit_update_triggers():
+    block = template_block_for_binary_sensor("Climate Pre-arrival Expected")
+    triggers = block["trigger"]
+
+    state_trigger = next(
+        trigger for trigger in triggers if trigger.get("id") == "prearrival_input_changed"
+    )
+    triggered_entities = set(state_trigger["entity_id"])
+
+    assert state_trigger["platform"] == "state"
+    assert {
+        "person.brian",
+        "person.hester",
+        "sensor.home_brian_distance",
+        "sensor.home_brian_direction_of_travel",
+        "sensor.home_hester_distance",
+        "sensor.home_hester_direction_of_travel",
+        "input_number.climate_precool_arrival_distance_ft",
+        "input_number.climate_precool_arrival_signal_max_age",
+    }.issubset(triggered_entities)
+    assert any(
+        trigger.get("platform") == "homeassistant" and trigger.get("event") == "start"
+        for trigger in triggers
+    )
+    assert any(
+        trigger.get("platform") == "time_pattern" and trigger.get("minutes") == "/1"
+        for trigger in triggers
+    )
 
 
 def test_precool_apply_can_start_from_debounced_prearrival_expectation():


### PR DESCRIPTION
## Summary
- Converts the pre-arrival climate gate into a trigger-based template entity with explicit person/proximity/helper inputs.
- Adds a one-minute age tick so stale inbound proximity signals can age out and cancel abandoned pre-arrival cycles.
- Adds regression coverage that the gate is wired to the raw inputs instead of relying on implicit dynamic-template dependency tracking.

Closes #122

## Test Plan
- pytest -q
- python3 YAML parse of all repository .yaml files with Home Assistant tag-tolerant loader
- git diff --check

## Notes
- No live Home Assistant reload/restart or service calls were performed.