### PR TITLE
feat(climate): add mobile climate dashboard

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -16,6 +16,12 @@ lovelace:
       icon: mdi:window-open-variant
       show_in_sidebar: false
       filename: dashboards/window_ventilation.yaml
+    climate-control:
+      mode: yaml
+      title: "Climate Control"
+      icon: mdi:thermostat-auto
+      show_in_sidebar: true
+      filename: dashboards/climate_control.yaml
 
 automation: !include_dir_merge_list automation
 input_boolean: !include_dir_merge_named input_boolean

--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -1,0 +1,251 @@
+# dashboards/climate_control.yaml
+#
+# Mobile-first operator view for climate control.
+#
+# This dashboard is YAML-managed from configuration.yaml. It intentionally uses
+# native Lovelace cards only: the climate system is household infrastructure, so
+# the control surface should stay portable and low-dependency.
+
+title: "Climate Control"
+views:
+  - title: "Climate"
+    path: "climate-control"
+    icon: mdi:thermostat-auto
+    badges: []
+    cards:
+      - type: markdown
+        title: "Climate now"
+        content: >-
+          {% set action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
+          {% set mode = state_attr('climate.dining_room_thermostat', 'hvac_mode') | default(states('climate.dining_room_thermostat'), true) %}
+          {% set current = state_attr('climate.dining_room_thermostat', 'current_temperature') %}
+          {% set low = state_attr('climate.dining_room_thermostat', 'target_temp_low') %}
+          {% set high = state_attr('climate.dining_room_thermostat', 'target_temp_high') %}
+          {% set people = states('zone.home') | int(0) %}
+          {% set automation = is_state('input_boolean.climate_automation_enabled', 'on') %}
+          {% set guest = is_state('input_boolean.mode_guest', 'on') %}
+          {% set hot_day = is_state('binary_sensor.climate_extreme_heat_day', 'on') %}
+          {% set precool = is_state('input_boolean.climate_extreme_heat_precool_active', 'on') %}
+
+          ## {{ current if current is not none else states('sensor.dining_room_thermostat_temperature') }}°F · {{ action | replace('_', ' ') | title }}
+
+          **Target band:** {{ low if low is not none else '—' }}–{{ high if high is not none else '—' }}°F  
+          **Mode:** {{ mode | replace('_', ' ') | title }}  
+          **Automation:** {{ 'On' if automation else 'Off' }} · **Home:** {{ people }} · **Guest:** {{ 'On' if guest else 'Off' }}
+
+          {% if precool %}
+          🧊 **Extreme-heat pre-cool is active now.** Cooling is temporarily biased lower until the restore path runs.
+          {% elif hot_day and automation %}
+          ☀️ **Extreme heat day detected.** The overlay can pre-cool during the afternoon window when occupancy, guest mode, or pre-arrival allows it.
+          {% elif not automation %}
+          ⚠️ **Climate automation is disabled.** The thermostat can still be controlled manually, but schedule/away/overlay automations will not manage it.
+          {% else %}
+          ✅ **Normal schedule behavior is in charge.**
+          {% endif %}
+
+      - type: thermostat
+        entity: climate.dining_room_thermostat
+        name: "Dining Room Thermostat"
+
+      - type: grid
+        title: "Quick status"
+        columns: 2
+        square: false
+        cards:
+          - type: tile
+            entity: input_boolean.climate_automation_enabled
+            name: "Automation"
+            icon: mdi:thermostat-auto
+            vertical: true
+            tap_action:
+              action: toggle
+          - type: tile
+            entity: input_boolean.climate_extreme_heat_overlay_enabled
+            name: "Heat overlay"
+            icon: mdi:sun-thermometer
+            vertical: true
+            tap_action:
+              action: toggle
+          - type: tile
+            entity: binary_sensor.climate_extreme_heat_day
+            name: "Hot day"
+            icon: mdi:white-balance-sunny
+            vertical: true
+          - type: tile
+            entity: input_boolean.climate_extreme_heat_precool_active
+            name: "Pre-cool active"
+            icon: mdi:snowflake-alert
+            vertical: true
+          - type: tile
+            entity: zone.home
+            name: "People home"
+            icon: mdi:home-account
+            vertical: true
+          - type: tile
+            entity: input_boolean.mode_guest
+            name: "Guest mode"
+            icon: mdi:account-heart
+            vertical: true
+
+      - type: conditional
+        conditions:
+          - entity: input_boolean.climate_extreme_heat_precool_active
+            state: "on"
+        card:
+          type: markdown
+          title: "Pre-cool active"
+          content: >-
+            ## 🧊 Cooling ahead of the heat
+
+            The extreme-heat overlay is currently active. The thermostat target
+            high should be the daytime cooling setpoint minus the configured
+            pre-cool offset, bounded by the automation package.
+
+            **Configured offset:** {{ states('input_number.climate_extreme_heat_precool_offset') }}°F  
+            **Normal daytime cool target:** {{ states('input_number.climate_cool_day') }}°F  
+            **Expected active cool target:** {{ [states('input_number.climate_cool_day') | float(76) - states('input_number.climate_extreme_heat_precool_offset') | float(1), 65] | max }}°F
+
+      - type: entities
+        title: "Quick actions"
+        show_header_toggle: false
+        entities:
+          - entity: input_boolean.climate_automation_enabled
+            name: "Climate automation enabled"
+          - entity: input_boolean.climate_extreme_heat_overlay_enabled
+            name: "Allow extreme-heat overlay"
+          - entity: input_number.climate_cool_day
+            name: "Daytime cooling target"
+          - entity: input_number.climate_cool_bedtime
+            name: "Bedtime cooling target"
+          - entity: input_number.climate_heat_morning
+            name: "Morning heating target"
+          - entity: input_number.climate_heat_sleep
+            name: "Sleep heating target"
+
+      - type: markdown
+        title: "Today / expected behavior"
+        content: >-
+          {% set hot_day = is_state('binary_sensor.climate_extreme_heat_day', 'on') %}
+          {% set overlay = is_state('input_boolean.climate_extreme_heat_overlay_enabled', 'on') %}
+          {% set automation = is_state('input_boolean.climate_automation_enabled', 'on') %}
+          {% set occupied = states('zone.home') | int(0) > 0 %}
+          {% set guest = is_state('input_boolean.mode_guest', 'on') %}
+          {% set prearrival = is_state('binary_sensor.climate_pre_arrival_expected', 'on') %}
+          {% set forecast_high = state_attr('binary_sensor.climate_extreme_heat_day', 'forecast_high_f') %}
+          {% set threshold = states('input_number.climate_extreme_heat_threshold') %}
+
+          {% if hot_day %}
+          ## ☀️ Extreme heat is expected
+          {% else %}
+          ## Mild enough for normal climate scheduling
+          {% endif %}
+
+          **Forecast high:** {{ forecast_high if forecast_high not in [none, '', 'unknown'] else 'unknown' }}°F  
+          **Extreme-heat threshold:** {{ threshold }}°F  
+          **Overlay armed:** {{ 'Yes' if overlay else 'No' }}  
+          **Automation enabled:** {{ 'Yes' if automation else 'No' }}
+
+          {% if automation and overlay and hot_day and (occupied or guest or prearrival) %}
+          Expected behavior: afternoon pre-cool may run or remain active while the house is occupied, guest mode is on, or an eligible resident is approaching home.
+          {% elif automation and overlay and hot_day %}
+          Expected behavior: hot-day logic is armed, but the overlay waits for occupancy, guest mode, or a fresh pre-arrival signal before applying cooling bias.
+          {% elif automation and not hot_day %}
+          Expected behavior: normal schedule setpoints apply; no hot-day cooling bias is expected.
+          {% elif not automation %}
+          Expected behavior: no schedule, away, or hot-day automation will apply until automation is enabled again.
+          {% else %}
+          Expected behavior: check overlay and automation toggles before expecting pre-cool behavior.
+          {% endif %}
+
+      - type: grid
+        title: "Schedule tuning"
+        columns: 1
+        square: false
+        cards:
+          - type: entities
+            title: "Cooling setpoints"
+            show_header_toggle: false
+            entities:
+              - entity: input_number.climate_cool_morning
+                name: "Morning"
+              - entity: input_number.climate_cool_day
+                name: "Daytime"
+              - entity: input_number.climate_cool_bedtime
+                name: "Bedtime"
+              - entity: input_number.climate_cool_sleep
+                name: "Sleep"
+              - entity: input_number.climate_cool_away
+                name: "Away"
+          - type: entities
+            title: "Heating setpoints"
+            show_header_toggle: false
+            entities:
+              - entity: input_number.climate_heat_morning
+                name: "Morning"
+              - entity: input_number.climate_heat_day
+                name: "Daytime"
+              - entity: input_number.climate_heat_bedtime
+                name: "Bedtime"
+              - entity: input_number.climate_heat_sleep
+                name: "Sleep"
+              - entity: input_number.climate_heat_away
+                name: "Away"
+
+      - type: entities
+        title: "Extreme heat tuning"
+        show_header_toggle: false
+        entities:
+          - entity: binary_sensor.climate_extreme_heat_day
+            name: "Extreme heat day"
+          - type: attribute
+            entity: binary_sensor.climate_extreme_heat_day
+            attribute: forecast_high_f
+            name: "Forecast high"
+            suffix: "°F"
+          - entity: input_number.climate_extreme_heat_threshold
+            name: "Extreme heat threshold"
+          - entity: input_number.climate_extreme_heat_precool_offset
+            name: "Pre-cool offset"
+          - entity: input_boolean.climate_extreme_heat_precool_active
+            name: "Pre-cool active"
+          - entity: binary_sensor.climate_pre_arrival_expected
+            name: "Pre-arrival expected"
+
+      - type: entities
+        title: "Diagnostics / why"
+        show_header_toggle: false
+        entities:
+          - type: attribute
+            entity: climate.dining_room_thermostat
+            attribute: hvac_action
+            name: "Current HVAC action"
+          - type: attribute
+            entity: climate.dining_room_thermostat
+            attribute: target_temp_low
+            name: "Active heat target"
+            suffix: "°F"
+          - type: attribute
+            entity: climate.dining_room_thermostat
+            attribute: target_temp_high
+            name: "Active cool target"
+            suffix: "°F"
+          - entity: sensor.dining_room_thermostat_temperature
+            name: "Indoor temperature"
+          - entity: sensor.thermostat_humidity
+            name: "Indoor humidity"
+          - entity: zone.home
+            name: "People home"
+          - entity: input_boolean.mode_guest
+            name: "Guest mode"
+          - type: attribute
+            entity: binary_sensor.climate_extreme_heat_day
+            attribute: decision_scope
+            name: "Hot-day decision scope"
+          - type: attribute
+            entity: binary_sensor.climate_pre_arrival_expected
+            attribute: expected_people
+            name: "Expected arrivals"
+          - type: attribute
+            entity: binary_sensor.climate_pre_arrival_expected
+            attribute: reason
+            name: "Pre-arrival rule"


### PR DESCRIPTION
## Summary
- Adds a dedicated YAML-managed Climate Control dashboard exposed in the sidebar.
- Uses native Lovelace cards only: markdown status panels, thermostat, mobile-friendly tile/grid status, focused quick actions, schedule tuning, extreme-heat tuning, and diagnostics.
- Separates the information hierarchy into current runtime state, today/expected behavior, quick controls, configured schedule values, and "why" diagnostics for hot-day/pre-arrival behavior.

## Design notes
- Mobile-first layout favors short stacked sections and two-column tiles for thumb-friendly status checks.
- The top status panel explains whether normal schedule, disabled automation, hot-day overlay, or active pre-cool behavior is currently relevant.
- Schedule tuning is intentionally split into cooling and heating groups so configured future values are distinct from the active thermostat targets.
- No custom card dependency was added; this stays boring in the way infrastructure should be boring.

## Validation
- `python3` YAML parse with Home Assistant custom-tag loader for `configuration.yaml` and `dashboards/climate_control.yaml`
- `docker run --rm -v "$PWD":/config ghcr.io/home-assistant/home-assistant:stable hass --script check_config -c /config`

Closes #124
