### PR TITLE
feat(climate): add generic pre-arrival recovery

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -180,6 +180,10 @@ input_boolean:
     icon: mdi:snowflake-alert
     initial: false
 
+  climate_pre_arrival_recovery_active:
+    name: "Climate Pre-arrival Recovery Active"
+    icon: mdi:home-import-outline
+
 template:
   - binary_sensor:
       - name: "Climate Extreme Heat Day"
@@ -477,12 +481,6 @@ automation:
         entity_id: input_boolean.mode_guest
         to: "on"
         id: guest_mode_enabled
-      - platform: state
-        entity_id: binary_sensor.climate_pre_arrival_expected
-        to: "on"
-        for:
-          minutes: 2
-        id: prearrival_expected
     condition:
       - condition: state
         entity_id: input_boolean.climate_automation_enabled
@@ -499,9 +497,9 @@ automation:
       - condition: time
         after: "12:59:00"
         before: "18:00:00"
-      # Occupied/guest path preserves the original overlay. Pre-arrival may
-      # also apply while nobody is home when a fresh aggregate person/proximity
-      # signal says an eligible resident is heading home soon.
+      # Occupied/guest path preserves the original overlay. Generic
+      # pre-arrival recovery applies this offset separately as an enhancement
+      # when nobody is home but inbound evidence is fresh.
       - condition: or
         conditions:
           - condition: numeric_state
@@ -509,9 +507,6 @@ automation:
             above: 0
           - condition: state
             entity_id: input_boolean.mode_guest
-            state: "on"
-          - condition: state
-            entity_id: binary_sensor.climate_pre_arrival_expected
             state: "on"
     action:
       - service: climate.set_hvac_mode
@@ -532,6 +527,152 @@ automation:
       - service: input_boolean.turn_on
         target:
           entity_id: input_boolean.climate_extreme_heat_precool_active
+    mode: single
+
+  - alias: "climate_pre_arrival_recovery_apply"
+    id: "climate_pre_arrival_recovery_apply"
+    description: >
+      Restore normal daytime occupied climate targets before an eligible
+      resident arrives, with extreme heat as an optional cooling enhancement.
+    trigger:
+      - platform: homeassistant
+        event: start
+        id: ha_start
+      - platform: state
+        entity_id: binary_sensor.climate_pre_arrival_expected
+        to: "on"
+        for:
+          minutes: 2
+        id: prearrival_expected
+      - platform: time_pattern
+        minutes: "/5"
+        id: prearrival_safety_tick
+    condition:
+      - condition: state
+        entity_id: input_boolean.climate_automation_enabled
+        state: "on"
+      - condition: state
+        entity_id: input_boolean.climate_pre_arrival_recovery_active
+        state: "off"
+      - condition: state
+        entity_id: binary_sensor.climate_pre_arrival_expected
+        state: "on"
+      - condition: numeric_state
+        entity_id: zone.home
+        below: 1
+      - condition: state
+        entity_id: input_boolean.mode_guest
+        state: "off"
+      - condition: time
+        after: "09:00:00"
+        before: "21:00:00"
+    action:
+      - service: climate.set_hvac_mode
+        target:
+          entity_id: climate.dining_room_thermostat
+        data:
+          hvac_mode: heat_cool
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: input_boolean.climate_extreme_heat_overlay_enabled
+                state: "on"
+              - condition: state
+                entity_id: binary_sensor.climate_extreme_heat_day
+                state: "on"
+              - condition: time
+                after: "12:59:00"
+                before: "18:00:00"
+            sequence:
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {% set day = states('input_number.climate_cool_day') | float %}
+                    {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %}
+                    {{ [day - offset, 65] | max }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_day') | float }}
+              - service: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.climate_extreme_heat_precool_active
+        default:
+          - service: climate.set_temperature
+            target:
+              entity_id: climate.dining_room_thermostat
+            data:
+              target_temp_high: >
+                {{ states('input_number.climate_cool_day') | float }}
+              target_temp_low: >
+                {{ states('input_number.climate_heat_day') | float }}
+      - service: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.climate_pre_arrival_recovery_active
+    mode: single
+
+  - alias: "climate_pre_arrival_recovery_restore"
+    id: "climate_pre_arrival_recovery_restore"
+    description: >
+      Clear pre-arrival recovery on arrival or revert to away targets if the
+      inbound signal clears while nobody is home.
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.climate_pre_arrival_expected
+        to: "off"
+        for:
+          minutes: 10
+        id: prearrival_cleared
+      - platform: numeric_state
+        entity_id: zone.home
+        above: 0
+        id: arrived_home
+      - platform: state
+        entity_id: input_boolean.climate_automation_enabled
+        to: "off"
+        id: climate_disabled
+      - platform: state
+        entity_id: input_boolean.mode_guest
+        to: "on"
+        id: guest_mode_enabled
+    condition:
+      - condition: state
+        entity_id: input_boolean.climate_pre_arrival_recovery_active
+        state: "on"
+    action:
+      - service: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.climate_pre_arrival_recovery_active
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ trigger.id == 'prearrival_cleared' }}"
+              - condition: state
+                entity_id: input_boolean.climate_automation_enabled
+                state: "on"
+              - condition: numeric_state
+                entity_id: zone.home
+                below: 1
+              - condition: state
+                entity_id: input_boolean.mode_guest
+                state: "off"
+            sequence:
+              - service: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.climate_extreme_heat_precool_active
+              - service: climate.set_hvac_mode
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  hvac_mode: heat_cool
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {{ states('input_number.climate_cool_away') | float }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_away') | float }}
     mode: single
 
   - alias: "climate_extreme_heat_precool_restore"
@@ -556,31 +697,10 @@ automation:
         for:
           minutes: 5
         id: away_started
-      - platform: state
-        entity_id: binary_sensor.climate_pre_arrival_expected
-        to: "off"
-        for:
-          minutes: 10
-        id: prearrival_cleared
     condition:
       - condition: state
         entity_id: input_boolean.climate_extreme_heat_precool_active
         state: "on"
-      # Only use the pre-arrival clear trigger as an abandoned-trip cancel.
-      # If someone has arrived, let the normal occupied overlay continue until
-      # the existing end-of-window/away-mode restore paths run.
-      - condition: or
-        conditions:
-          - condition: template
-            value_template: "{{ trigger.id != 'prearrival_cleared' }}"
-          - condition: and
-            conditions:
-              - condition: numeric_state
-                entity_id: zone.home
-                below: 1
-              - condition: state
-                entity_id: input_boolean.mode_guest
-                state: "off"
     action:
       - service: input_boolean.turn_off
         target:
@@ -590,7 +710,6 @@ automation:
               - condition: template
                 value_template: >
                   {{ trigger.id in [
-                    'prearrival_cleared',
                     'overlay_window_end',
                     'overlay_disabled',
                     'climate_disabled'

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -70,6 +70,7 @@ def test_extreme_heat_helpers_are_configurable_in_fahrenheit():
     assert offset["initial"] == 1
     assert config["input_boolean"]["climate_extreme_heat_overlay_enabled"]["initial"] is True
     assert config["input_boolean"]["climate_extreme_heat_precool_active"]["initial"] is False
+    assert "initial" not in config["input_boolean"]["climate_pre_arrival_recovery_active"]
 
 
 def test_extreme_heat_day_uses_validated_daily_forecast_attributes_not_derived_sensor():
@@ -95,7 +96,6 @@ def test_precool_apply_is_bounded_occupied_and_one_shot():
         "overlay_window_start",
         "hot_day_detected",
         "guest_mode_enabled",
-        "prearrival_expected",
     }
     assert any(trigger.get("at") == "13:00:00" for trigger in item["trigger"])
     assert "before: \"18:00:00\"" in text
@@ -106,6 +106,7 @@ def test_precool_apply_is_bounded_occupied_and_one_shot():
     assert "input_boolean.mode_guest" in text
     assert "day - offset" in text
     assert "input_boolean.turn_on" in text
+    assert "Generic\n      # pre-arrival recovery applies this offset separately" in text
 
 
 def test_precool_apply_rearms_for_guest_mode_without_return_home_race():
@@ -227,8 +228,8 @@ def test_precool_prearrival_template_has_explicit_update_triggers():
     )
 
 
-def test_precool_apply_can_start_from_debounced_prearrival_expectation():
-    item = automation("climate_extreme_heat_precool_apply")
+def test_generic_prearrival_apply_can_start_from_debounced_expectation():
+    item = automation("climate_pre_arrival_recovery_apply")
 
     prearrival_trigger = next(
         trigger for trigger in item["trigger"] if trigger.get("id") == "prearrival_expected"
@@ -245,14 +246,20 @@ def test_precool_apply_can_start_from_debounced_prearrival_expectation():
     assert "binary_sensor.climate_pre_arrival_expected" in condition_text
     assert "zone.home" in condition_text
     assert "input_boolean.mode_guest" in condition_text
+    assert "input_boolean.climate_pre_arrival_recovery_active" in condition_text
+
+    services = str(item["action"])
+    assert "input_number.climate_cool_day" in services
+    assert "input_number.climate_heat_day" in services
+    assert "binary_sensor.climate_extreme_heat_day" in services
+    assert "day - offset" in services
+    assert "input_boolean.climate_pre_arrival_recovery_active" in services
 
 
 def test_precool_restore_cancels_abandoned_prearrival_to_away_targets():
-    item = automation("climate_extreme_heat_precool_restore")
+    item = automation("climate_pre_arrival_recovery_restore")
     text = CLIMATE.read_text()
 
-    assert any(trigger.get("at") == "18:00:00" for trigger in item["trigger"])
-    assert any(trigger.get("id") == "away_started" for trigger in item["trigger"])
     abandoned = next(
         trigger for trigger in item["trigger"] if trigger.get("id") == "prearrival_cleared"
     )
@@ -266,7 +273,6 @@ def test_precool_restore_cancels_abandoned_prearrival_to_away_targets():
     assert "prearrival_cleared" in text
     assert "input_number.climate_cool_away" in text
     assert "input_number.climate_heat_away" in text
-    assert "trigger.id != 'away_started'" in text
     assert "input_boolean.turn_off" in text
     assert "states('input_number.climate_cool_day')" in text
     assert "states('input_number.climate_heat_day')" in text
@@ -284,7 +290,7 @@ def test_precool_restore_overlay_end_restores_away_prearrival_targets():
     assert "overlay_window_end" in trigger_condition["value_template"]
     assert "overlay_disabled" in trigger_condition["value_template"]
     assert "climate_disabled" in trigger_condition["value_template"]
-    assert "prearrival_cleared" in trigger_condition["value_template"]
+    assert "prearrival_cleared" not in trigger_condition["value_template"]
     assert any(
         condition.get("condition") == "numeric_state"
         and condition.get("entity_id") == "zone.home"


### PR DESCRIPTION
## Summary
- Adds a generic pre-arrival recovery automation that restores daytime occupied heat/cool targets when nobody is home and the aggregate inbound signal is fresh.
- Keeps the existing extreme-heat offset as an optional enhancement layer on top of generic pre-arrival recovery instead of the only pre-arrival path.
- Adds a dedicated restore/cancel path so abandoned trips return to away targets while arrival simply clears the pre-arrival active flag.

## Verification
- python -m pytest -q
- python YAML parse for packages/climate_control.yaml
- git diff --check
- Static diff scan for hardcoded secrets / shell injection / eval / pickle / SQL formatting patterns: no matches
- yamllint not installed in this environment

Closes #126