### PR TITLE
feat(climate): use mini graph trend cards

### DIFF
--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -2,9 +2,8 @@
 #
 # Mobile-first operator view for climate control.
 #
-# This dashboard is YAML-managed from configuration.yaml. It intentionally uses
-# native Lovelace cards only: the climate system is household infrastructure, so
-# the control surface should stay portable and low-dependency.
+# This dashboard is YAML-managed from configuration.yaml. Trend cards use the
+# already-installed mini-graph-card custom card for compact operator history.
 
 title: "Climate Control"
 views:
@@ -86,25 +85,81 @@ views:
         entity: climate.dining_room_thermostat
         name: "Dining Room Thermostat"
 
-      - type: history-graph
-        title: "Temperature trends"
+      - type: custom:mini-graph-card
+        name: "Temperature trends"
         hours_to_show: 24
+        points_per_hour: 4
+        hour24: true
+        animate: false
+        show:
+          legend: true
+          labels: true
+          labels_secondary: false
+          points: false
+          extrema: true
+        lower_bound_secondary: 0
+        upper_bound_secondary: 1
         entities:
           - entity: sensor.dining_room_thermostat_temperature
             name: "Dining room"
+            color: "#f9a825"
           - entity: sensor.master_bedroom_sensor_temperature
             name: "Bedroom"
+            color: "#7e57c2"
+          - entity: sensor.average_indoor_temperature
+            name: "Indoor avg"
+            color: "#26a69a"
+            line_width: 4
           - entity: sensor.weather_outdoor_temperature
             name: "Outdoor"
+            color: "#42a5f5"
+          - entity: binary_sensor.climate_heating_active
+            name: "Heating"
+            color: "#ef5350"
+            y_axis: secondary
+            aggregate_func: max
+            show_state: false
+            smoothing: false
+          - entity: binary_sensor.climate_cooling_active
+            name: "Cooling"
+            color: "#29b6f6"
+            y_axis: secondary
+            aggregate_func: max
+            show_state: false
+            smoothing: false
 
-      - type: history-graph
-        title: "Air quality trends"
+      - type: custom:mini-graph-card
+        name: "Air quality trends"
         hours_to_show: 24
+        points_per_hour: 4
+        hour24: true
+        animate: false
+        show:
+          legend: true
+          labels: true
+          labels_secondary: true
+          points: false
+          extrema: true
         entities:
           - entity: sensor.thermostat_vocs
             name: "VOC"
+            color: "#ab47bc"
           - entity: sensor.thermostat_carbon_dioxide
             name: "CO2"
+            color: "#66bb6a"
+            y_axis: secondary
+          - entity: binary_sensor.climate_heating_active
+            name: "Heating"
+            color: "#ef5350"
+            aggregate_func: max
+            show_state: false
+            smoothing: false
+          - entity: binary_sensor.climate_cooling_active
+            name: "Cooling"
+            color: "#29b6f6"
+            aggregate_func: max
+            show_state: false
+            smoothing: false
 
       - type: grid
         title: "Schedule tuning"

--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -186,6 +186,22 @@ input_boolean:
 
 template:
   - binary_sensor:
+      - name: "Climate Heating Active"
+        unique_id: climate_heating_active
+        icon: mdi:fire
+        state: >
+          {{ state_attr('climate.dining_room_thermostat', 'hvac_action') == 'heating' }}
+        attributes:
+          source: "climate.dining_room_thermostat hvac_action"
+
+      - name: "Climate Cooling Active"
+        unique_id: climate_cooling_active
+        icon: mdi:snowflake
+        state: >
+          {{ state_attr('climate.dining_room_thermostat', 'hvac_action') == 'cooling' }}
+        attributes:
+          source: "climate.dining_room_thermostat hvac_action"
+
       - name: "Climate Extreme Heat Day"
         unique_id: climate_extreme_heat_day
         icon: mdi:sun-thermometer
@@ -231,6 +247,24 @@ template:
           forecast_source: "sensor.weather_daily_forecast"
           forecast_unit_assumption: "NWS forecast temperature attribute is Fahrenheit"
           decision_scope: "maximum temperature from the first two twice-daily periods"
+
+  - sensor:
+      - name: "Average Indoor Temperature"
+        unique_id: average_indoor_temperature
+        device_class: temperature
+        state_class: measurement
+        unit_of_measurement: "°F"
+        icon: mdi:home-thermometer-outline
+        availability: >
+          {{ states('sensor.dining_room_thermostat_temperature') | float(none) is not none
+             and states('sensor.master_bedroom_sensor_temperature') | float(none) is not none }}
+        state: >
+          {% set dining = states('sensor.dining_room_thermostat_temperature') | float(none) %}
+          {% set bedroom = states('sensor.master_bedroom_sensor_temperature') | float(none) %}
+          {{ ((dining + bedroom) / 2) | round(1) if dining is not none and bedroom is not none else 'unknown' }}
+        attributes:
+          source_entities: >
+            sensor.dining_room_thermostat_temperature, sensor.master_bedroom_sensor_temperature
 
   - trigger:
       # Trigger-based template entity with explicit inputs. The pre-arrival

--- a/tests/test_climate_dashboard.py
+++ b/tests/test_climate_dashboard.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIMATE = ROOT / "packages" / "climate_control.yaml"
+DASHBOARD = ROOT / "dashboards" / "climate_control.yaml"
+
+
+def load_climate():
+    return yaml.safe_load(CLIMATE.read_text())
+
+
+def load_dashboard():
+    return yaml.safe_load(DASHBOARD.read_text())
+
+
+def template_entities(kind):
+    for block in load_climate()["template"]:
+        for entity in block.get(kind, []):
+            yield entity
+
+
+def named_template(kind, name):
+    for entity in template_entities(kind):
+        if entity["name"] == name:
+            return entity
+    raise AssertionError(f"{kind} template {name!r} not found")
+
+
+def graph_card(name):
+    cards = load_dashboard()["views"][0]["cards"]
+    for card in cards:
+        if card.get("type") == "custom:mini-graph-card" and card.get("name") == name:
+            return card
+    raise AssertionError(f"mini graph card {name!r} not found")
+
+
+def entity_ids(card):
+    return [entity["entity"] for entity in card["entities"]]
+
+
+def test_climate_activity_helpers_derive_from_thermostat_hvac_action():
+    heating = named_template("binary_sensor", "Climate Heating Active")
+    cooling = named_template("binary_sensor", "Climate Cooling Active")
+
+    assert heating["unique_id"] == "climate_heating_active"
+    assert cooling["unique_id"] == "climate_cooling_active"
+    assert "state_attr('climate.dining_room_thermostat', 'hvac_action') == 'heating'" in heating["state"]
+    assert "state_attr('climate.dining_room_thermostat', 'hvac_action') == 'cooling'" in cooling["state"]
+
+
+def test_average_indoor_temperature_uses_dining_room_and_bedroom():
+    sensor = named_template("sensor", "Average Indoor Temperature")
+
+    assert sensor["unique_id"] == "average_indoor_temperature"
+    assert sensor["device_class"] == "temperature"
+    assert sensor["state_class"] == "measurement"
+    assert sensor["unit_of_measurement"] == "°F"
+    assert "sensor.dining_room_thermostat_temperature" in sensor["availability"]
+    assert "sensor.master_bedroom_sensor_temperature" in sensor["availability"]
+    assert "sensor.dining_room_thermostat_temperature" in sensor["state"]
+    assert "sensor.master_bedroom_sensor_temperature" in sensor["state"]
+    assert "/ 2" in sensor["state"]
+
+
+def test_temperature_trends_use_mini_graph_with_average_and_hvac_activity():
+    card = graph_card("Temperature trends")
+
+    assert "history-graph" not in DASHBOARD.read_text()
+    assert card["hours_to_show"] == 24
+    assert card["lower_bound_secondary"] == 0
+    assert card["upper_bound_secondary"] == 1
+    assert entity_ids(card) == [
+        "sensor.dining_room_thermostat_temperature",
+        "sensor.master_bedroom_sensor_temperature",
+        "sensor.average_indoor_temperature",
+        "sensor.weather_outdoor_temperature",
+        "binary_sensor.climate_heating_active",
+        "binary_sensor.climate_cooling_active",
+    ]
+    activity_entities = card["entities"][-2:]
+    assert all(entity["y_axis"] == "secondary" for entity in activity_entities)
+    assert all(entity["aggregate_func"] == "max" for entity in activity_entities)
+
+
+def test_air_quality_trends_use_mini_graph_with_hvac_activity():
+    card = graph_card("Air quality trends")
+
+    assert card["hours_to_show"] == 24
+    assert entity_ids(card) == [
+        "sensor.thermostat_vocs",
+        "sensor.thermostat_carbon_dioxide",
+        "binary_sensor.climate_heating_active",
+        "binary_sensor.climate_cooling_active",
+    ]
+    co2 = card["entities"][1]
+    activity_entities = card["entities"][-2:]
+    assert co2["y_axis"] == "secondary"
+    assert all(entity["aggregate_func"] == "max" for entity in activity_entities)
+    assert all(entity["show_state"] is False for entity in activity_entities)


### PR DESCRIPTION
## Summary
- Replace the climate dashboard temperature and air-quality history graphs with `custom:mini-graph-card` trend cards.
- Add template-derived `binary_sensor.climate_heating_active` and `binary_sensor.climate_cooling_active` helpers from the dining room thermostat `hvac_action`.
- Add `sensor.average_indoor_temperature` from dining room + master bedroom temperatures and cover the dashboard/template wiring with regression tests.

## Mini-graph representation
- Temperature uses four temperature traces on the primary axis: dining room, bedroom, indoor average, and outdoor.
- Heating and cooling activity are shown as 0/1 helper traces on the temperature card secondary axis so runtime can be correlated with temperature movement.
- Air quality keeps VOC on the primary axis and CO2 on the secondary axis; HVAC activity helpers are included as compact on/off traces rather than trying to recreate the native thermostat shaded runtime fill. That is the deliberate readability compromise, because mini-graph-card does not provide the same native thermostat history fill treatment.

## Verification
- `python3 -m pytest` — 44 passed
- YAML parse check for `packages/climate_control.yaml` and `dashboards/climate_control.yaml`
- `docker run --rm -v "$PWD":/config homeassistant/home-assistant:stable hass -c /config --script check_config`

Closes #130
