### PR TITLE
fix(climate): map mini graph binary states

### DIFF
--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -99,6 +99,11 @@ views:
           extrema: true
         lower_bound_secondary: 0
         upper_bound_secondary: 1
+        state_map:
+          - value: "off"
+            label: "Inactive"
+          - value: "on"
+            label: "Active"
         entities:
           - entity: sensor.dining_room_thermostat_temperature
             name: "Dining room"
@@ -140,6 +145,11 @@ views:
           labels_secondary: true
           points: false
           extrema: true
+        state_map:
+          - value: "off"
+            label: "Inactive"
+          - value: "on"
+            label: "Active"
         entities:
           - entity: sensor.thermostat_vocs
             name: "VOC"

--- a/tests/test_climate_dashboard.py
+++ b/tests/test_climate_dashboard.py
@@ -41,6 +41,13 @@ def entity_ids(card):
     return [entity["entity"] for entity in card["entities"]]
 
 
+def assert_binary_state_map(card):
+    assert card["state_map"] == [
+        {"value": "off", "label": "Inactive"},
+        {"value": "on", "label": "Active"},
+    ]
+
+
 def test_climate_activity_helpers_derive_from_thermostat_hvac_action():
     heating = named_template("binary_sensor", "Climate Heating Active")
     cooling = named_template("binary_sensor", "Climate Cooling Active")
@@ -72,6 +79,7 @@ def test_temperature_trends_use_mini_graph_with_average_and_hvac_activity():
     assert card["hours_to_show"] == 24
     assert card["lower_bound_secondary"] == 0
     assert card["upper_bound_secondary"] == 1
+    assert_binary_state_map(card)
     assert entity_ids(card) == [
         "sensor.dining_room_thermostat_temperature",
         "sensor.master_bedroom_sensor_temperature",
@@ -89,6 +97,7 @@ def test_air_quality_trends_use_mini_graph_with_hvac_activity():
     card = graph_card("Air quality trends")
 
     assert card["hours_to_show"] == 24
+    assert_binary_state_map(card)
     assert entity_ids(card) == [
         "sensor.thermostat_vocs",
         "sensor.thermostat_carbon_dioxide",


### PR DESCRIPTION
## Summary
- Adds `state_map` entries to both climate mini-graph cards so `off`/`on` HVAC helper history is converted to numeric graph values.
- Preserves the existing temperature, indoor average, outdoor, VOC, CO2, heating, and cooling series.
- Extends dashboard regression tests to require the binary-sensor mapping.

## Binary-sensor rendering note
`custom:mini-graph-card` needs card-level `state_map` configuration for non-numeric `binary_sensor` history. These cards now map `off` to the first graph value and `on` to the second graph value, labeled `Inactive`/`Active`, so the HVAC helper traces can render instead of leaving the card spinning.

## Validation
- `python - <<'PY' ...` YAML syntax parse for all tracked `*.yaml`/`*.yml`: passed
- `python -m pytest tests/test_climate_dashboard.py`: 4 passed
- `python -m pytest`: 44 passed
- `git diff --check`: passed
- `python -m homeassistant --version`: not available in this worker environment (`No module named homeassistant`), so a full HA config check was not run here. Static YAML and repository tests were run instead.

Closes #132
