### PR TITLE
Fix climate HVAC activity ribbon visualization

### DIFF
--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -94,16 +94,8 @@ views:
         show:
           legend: true
           labels: true
-          labels_secondary: false
           points: false
           extrema: true
-        lower_bound_secondary: 0
-        upper_bound_secondary: 1
-        state_map:
-          - value: "off"
-            label: "Inactive"
-          - value: "on"
-            label: "Active"
         entities:
           - entity: sensor.dining_room_thermostat_temperature
             name: "Dining room"
@@ -118,18 +110,50 @@ views:
           - entity: sensor.weather_outdoor_temperature
             name: "Outdoor"
             color: "#42a5f5"
+
+      - type: custom:mini-graph-card
+        name: "HVAC activity ribbon"
+        hours_to_show: 24
+        points_per_hour: 4
+        hour24: true
+        animate: false
+        height: 48
+        line_width: 1
+        lower_bound_secondary: 0
+        upper_bound_secondary: 1
+        state_map:
+          - value: "off"
+            label: "Inactive"
+          - value: "on"
+            label: "Active"
+        show:
+          name: true
+          icon: false
+          state: false
+          legend: true
+          labels: false
+          labels_secondary: false
+          points: false
+          extrema: false
+        entities:
           - entity: binary_sensor.climate_heating_active
             name: "Heating"
-            color: "#ef5350"
+            color: "rgba(239, 83, 80, 0.35)"
             y_axis: secondary
             aggregate_func: max
+            show_line: false
+            show_fill: true
+            show_points: false
             show_state: false
             smoothing: false
           - entity: binary_sensor.climate_cooling_active
             name: "Cooling"
-            color: "#29b6f6"
+            color: "rgba(41, 182, 246, 0.35)"
             y_axis: secondary
             aggregate_func: max
+            show_line: false
+            show_fill: true
+            show_points: false
             show_state: false
             smoothing: false
 
@@ -145,11 +169,6 @@ views:
           labels_secondary: true
           points: false
           extrema: true
-        state_map:
-          - value: "off"
-            label: "Inactive"
-          - value: "on"
-            label: "Active"
         entities:
           - entity: sensor.thermostat_vocs
             name: "VOC"
@@ -158,18 +177,6 @@ views:
             name: "CO2"
             color: "#66bb6a"
             y_axis: secondary
-          - entity: binary_sensor.climate_heating_active
-            name: "Heating"
-            color: "#ef5350"
-            aggregate_func: max
-            show_state: false
-            smoothing: false
-          - entity: binary_sensor.climate_cooling_active
-            name: "Cooling"
-            color: "#29b6f6"
-            aggregate_func: max
-            show_state: false
-            smoothing: false
 
       - type: grid
         title: "Schedule tuning"

--- a/tests/test_climate_dashboard.py
+++ b/tests/test_climate_dashboard.py
@@ -72,40 +72,56 @@ def test_average_indoor_temperature_uses_dining_room_and_bedroom():
     assert "/ 2" in sensor["state"]
 
 
-def test_temperature_trends_use_mini_graph_with_average_and_hvac_activity():
+def test_temperature_trends_use_mini_graph_with_average_indoor_temperature():
     card = graph_card("Temperature trends")
 
     assert "history-graph" not in DASHBOARD.read_text()
     assert card["hours_to_show"] == 24
-    assert card["lower_bound_secondary"] == 0
-    assert card["upper_bound_secondary"] == 1
-    assert_binary_state_map(card)
+    assert "lower_bound" not in card
+    assert "upper_bound" not in card
+    assert "lower_bound_secondary" not in card
+    assert "upper_bound_secondary" not in card
     assert entity_ids(card) == [
         "sensor.dining_room_thermostat_temperature",
         "sensor.master_bedroom_sensor_temperature",
         "sensor.average_indoor_temperature",
         "sensor.weather_outdoor_temperature",
+    ]
+
+
+def test_hvac_activity_uses_dedicated_filled_ribbon_card():
+    card = graph_card("HVAC activity ribbon")
+
+    assert card["hours_to_show"] == 24
+    assert card["height"] == 48
+    assert card["lower_bound_secondary"] == 0
+    assert card["upper_bound_secondary"] == 1
+    assert_binary_state_map(card)
+    assert entity_ids(card) == [
         "binary_sensor.climate_heating_active",
         "binary_sensor.climate_cooling_active",
     ]
-    activity_entities = card["entities"][-2:]
-    assert all(entity["y_axis"] == "secondary" for entity in activity_entities)
-    assert all(entity["aggregate_func"] == "max" for entity in activity_entities)
+    assert card["show"]["labels"] is False
+    assert card["show"]["labels_secondary"] is False
+    for entity in card["entities"]:
+        assert entity["y_axis"] == "secondary"
+        assert entity["aggregate_func"] == "max"
+        assert entity["show_line"] is False
+        assert entity["show_fill"] is True
+        assert entity["show_points"] is False
+        assert entity["show_state"] is False
+        assert entity["smoothing"] is False
+        assert entity["color"].startswith("rgba(")
 
 
-def test_air_quality_trends_use_mini_graph_with_hvac_activity():
+def test_air_quality_trends_keep_voc_and_co2_axes_without_hvac_trace_noise():
     card = graph_card("Air quality trends")
 
     assert card["hours_to_show"] == 24
-    assert_binary_state_map(card)
+    assert "state_map" not in card
     assert entity_ids(card) == [
         "sensor.thermostat_vocs",
         "sensor.thermostat_carbon_dioxide",
-        "binary_sensor.climate_heating_active",
-        "binary_sensor.climate_cooling_active",
     ]
     co2 = card["entities"][1]
-    activity_entities = card["entities"][-2:]
     assert co2["y_axis"] == "secondary"
-    assert all(entity["aggregate_func"] == "max" for entity in activity_entities)
-    assert all(entity["show_state"] is False for entity in activity_entities)


### PR DESCRIPTION
## Summary
- moves HVAC heating/cooling history out of the primary temperature and air-quality mini-graphs so they no longer render as distracting 0/1 traces
- adds a compact dedicated `HVAC activity ribbon` mini-graph card directly below the temperature trends card
- keeps explicit `off`/`on` `state_map` and uses `lower_bound_secondary` / `upper_bound_secondary` on the ribbon-only 0..1 helper axis

## Visualization choice
This PR uses the fallback dedicated HVAC ribbon card rather than forcing an in-card band into the temperature graph. The temperature chart can now keep its natural temperature scale, and the air-quality card can keep CO2 on the secondary axis without competing with binary HVAC helper values. The ribbon still uses mini-graph-card fill-only series (`show_line: false`, `show_fill: true`) so active heating/cooling reads as contextual bands instead of plain bottom-pinned traces.

## Validation
- `python3 -m pytest tests/test_climate_dashboard.py -q` → 5 passed
- `python3 -m pytest -q` → 45 passed
- `python3 - <<'PY' ... yaml.safe_load('dashboards/climate_control.yaml') ... PY` → dashboard YAML parsed
- HA-tag tolerant YAML parse across repo → 37 YAML files parsed
- `git diff --check` → clean
- independent reviewer subagent → passed, no security concerns or logic errors

Closes #134
