### PR TITLE
Fix climate restart occupied resync

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -1022,3 +1022,173 @@ automation:
                 {{ states('input_number.climate_cool_sleep') | float }}
               target_temp_low: >
                 {{ states('input_number.climate_heat_sleep') | float }}
+
+  - alias: "climate_restart_occupied_resync"
+    id: "climate_restart_occupied_resync"
+    description: >
+      On Home Assistant startup, reapply the current occupied or guest climate
+      schedule if the thermostat was restored with stale targets.
+    trigger:
+      - platform: homeassistant
+        event: start
+        id: ha_start
+    condition:
+      - condition: state
+        entity_id: input_boolean.climate_automation_enabled
+        state: "on"
+      - condition: or
+        conditions:
+          - condition: numeric_state
+            entity_id: zone.home
+            above: 0
+          - condition: state
+            entity_id: input_boolean.mode_guest
+            state: "on"
+      # Avoid startup service-call thrash when the live thermostat already
+      # matches the expected band. Ecobee commonly reports half-degree adjusted
+      # targets, so allow a small tolerance around helper values.
+      - condition: template
+        value_template: >
+          {% set current = now().strftime('%H:%M:%S') %}
+          {% set weekday = now().weekday() %}
+          {% set morning = (
+            (weekday < 5 and '05:00:00' <= current < '09:00:00')
+            or (weekday >= 5 and '07:00:00' <= current < '09:00:00')
+          ) %}
+          {% set extreme_heat = (
+            is_state('input_boolean.climate_extreme_heat_overlay_enabled', 'on')
+            and is_state('binary_sensor.climate_extreme_heat_day', 'on')
+            and '12:59:00' <= current < '18:00:00'
+          ) %}
+          {% if morning %}
+            {% set expected_high = states('input_number.climate_cool_morning') | float(none) %}
+            {% set expected_low = states('input_number.climate_heat_morning') | float(none) %}
+          {% elif extreme_heat %}
+            {% set day = states('input_number.climate_cool_day') | float(none) %}
+            {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %}
+            {% set expected_high = ([day - offset, 65] | max) if day is not none else none %}
+            {% set expected_low = states('input_number.climate_heat_day') | float(none) %}
+          {% elif '09:00:00' <= current < '21:00:00' %}
+            {% set expected_high = states('input_number.climate_cool_day') | float(none) %}
+            {% set expected_low = states('input_number.climate_heat_day') | float(none) %}
+          {% elif '21:00:00' <= current < '22:30:00' %}
+            {% set expected_high = states('input_number.climate_cool_bedtime') | float(none) %}
+            {% set expected_low = states('input_number.climate_heat_bedtime') | float(none) %}
+          {% else %}
+            {% set expected_high = states('input_number.climate_cool_sleep') | float(none) %}
+            {% set expected_low = states('input_number.climate_heat_sleep') | float(none) %}
+          {% endif %}
+          {% set actual_high = state_attr('climate.dining_room_thermostat', 'target_temp_high') | float(none) %}
+          {% set actual_low = state_attr('climate.dining_room_thermostat', 'target_temp_low') | float(none) %}
+          {{ expected_high is not none and expected_low is not none and (
+            states('climate.dining_room_thermostat') != 'heat_cool'
+            or actual_high is none
+            or actual_low is none
+            or ((actual_high - expected_high) | abs > 0.6)
+            or ((actual_low - expected_low) | abs > 0.6)
+          ) }}
+    action:
+      - service: climate.set_hvac_mode
+        target:
+          entity_id: climate.dining_room_thermostat
+        data:
+          hvac_mode: heat_cool
+      - choose:
+          # Morning (5:00-8:59 weekdays, 7:00-8:59 weekends)
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: and
+                    conditions:
+                      - condition: time
+                        after: "05:00:00"
+                        before: "09:00:00"
+                      - condition: time
+                        weekday:
+                          - mon
+                          - tue
+                          - wed
+                          - thu
+                          - fri
+                  - condition: and
+                    conditions:
+                      - condition: time
+                        after: "07:00:00"
+                        before: "09:00:00"
+                      - condition: time
+                        weekday:
+                          - sat
+                          - sun
+            sequence:
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {{ states('input_number.climate_cool_morning') | float }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_morning') | float }}
+          # Extreme heat overlay window (13:00-17:59) wins over normal day.
+          - conditions:
+              - condition: state
+                entity_id: input_boolean.climate_extreme_heat_overlay_enabled
+                state: "on"
+              - condition: state
+                entity_id: binary_sensor.climate_extreme_heat_day
+                state: "on"
+              - condition: time
+                after: "12:59:00"
+                before: "18:00:00"
+            sequence:
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {% set day = states('input_number.climate_cool_day') | float %}
+                    {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %}
+                    {{ [day - offset, 65] | max }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_day') | float }}
+              - service: input_boolean.turn_on
+                target:
+                  entity_id: input_boolean.climate_extreme_heat_precool_active
+          # Daytime (9:00-20:59)
+          - conditions:
+              - condition: time
+                after: "09:00:00"
+                before: "21:00:00"
+            sequence:
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {{ states('input_number.climate_cool_day') | float }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_day') | float }}
+          # Bedtime (21:00-22:29)
+          - conditions:
+              - condition: time
+                after: "21:00:00"
+                before: "22:30:00"
+            sequence:
+              - service: climate.set_temperature
+                target:
+                  entity_id: climate.dining_room_thermostat
+                data:
+                  target_temp_high: >
+                    {{ states('input_number.climate_cool_bedtime') | float }}
+                  target_temp_low: >
+                    {{ states('input_number.climate_heat_bedtime') | float }}
+        # Default: Sleep temps (22:30-04:59)
+        default:
+          - service: climate.set_temperature
+            target:
+              entity_id: climate.dining_room_thermostat
+            data:
+              target_temp_high: >
+                {{ states('input_number.climate_cool_sleep') | float }}
+              target_temp_low: >
+                {{ states('input_number.climate_heat_sleep') | float }}
+    mode: single

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -312,3 +312,54 @@ def test_precool_restore_overlay_end_restores_away_prearrival_targets():
         for step in sequence
         if step.get("service") == "climate.set_temperature"
     )
+
+
+def test_restart_resync_runs_on_start_only_when_occupied_or_guest_and_stale():
+    item = automation("climate_restart_occupied_resync")
+    text = CLIMATE.read_text()
+
+    assert item["trigger"] == [
+        {"platform": "homeassistant", "event": "start", "id": "ha_start"}
+    ]
+    assert any(
+        condition.get("entity_id") == "input_boolean.climate_automation_enabled"
+        and condition.get("state") == "on"
+        for condition in item["condition"]
+    )
+    occupancy_condition = next(
+        condition for condition in item["condition"] if condition.get("condition") == "or"
+    )
+    assert {
+        (condition.get("condition"), condition.get("entity_id"), condition.get("above"), condition.get("state"))
+        for condition in occupancy_condition["conditions"]
+    } == {
+        ("numeric_state", "zone.home", 0, None),
+        ("state", "input_boolean.mode_guest", None, "on"),
+    }
+    stale_guard = next(
+        condition for condition in item["condition"] if condition.get("condition") == "template"
+    )
+    assert "target_temp_high" in stale_guard["value_template"]
+    assert "target_temp_low" in stale_guard["value_template"]
+    assert "states('climate.dining_room_thermostat') != 'heat_cool'" in stale_guard["value_template"]
+    assert "climate_cool_away" not in text.split("id: \"climate_restart_occupied_resync\"", 1)[1]
+
+
+def test_restart_resync_selects_current_occupied_schedule_and_overlay():
+    item = automation("climate_restart_occupied_resync")
+    branches = item["action"][1]["choose"]
+    branch_text = [str(branch) for branch in branches]
+    default_text = str(item["action"][1]["default"])
+
+    assert len(branches) == 4
+    assert "climate_cool_morning" in branch_text[0]
+    assert "climate_heat_morning" in branch_text[0]
+    assert "binary_sensor.climate_extreme_heat_day" in branch_text[1]
+    assert "day - offset" in branch_text[1]
+    assert "input_boolean.climate_extreme_heat_precool_active" in branch_text[1]
+    assert "climate_cool_day" in branch_text[2]
+    assert "climate_heat_day" in branch_text[2]
+    assert "climate_cool_bedtime" in branch_text[3]
+    assert "climate_heat_bedtime" in branch_text[3]
+    assert "climate_cool_sleep" in default_text
+    assert "climate_heat_sleep" in default_text


### PR DESCRIPTION
## Summary
- Add a Home Assistant startup resync automation that reapplies the current occupied/guest climate schedule when someone is already home after restart.
- Preserve away/pre-arrival behavior by gating the path to occupied/guest state only and keeping the existing return-home and pre-arrival automations unchanged.
- Add a stale-target guard with Ecobee half-degree tolerance to avoid unnecessary startup `climate.set_temperature` thrash.

## Validation
- `python -m pytest tests/test_climate_extreme_heat_overlay.py::test_restart_resync_runs_on_start_only_when_occupied_or_guest_and_stale tests/test_climate_extreme_heat_overlay.py::test_restart_resync_selects_current_occupied_schedule_and_overlay -q` (RED first: failed because automation was absent)
- `python -m pytest tests/test_climate_extreme_heat_overlay.py -q` (13 passed)
- `python -m pytest -q` (47 passed)
- YAML parse for `packages/climate_control.yaml` and Python compile for `tests/test_climate_extreme_heat_overlay.py`

Closes #136