### PR TITLE
feat(climate): refine dashboard trend cards

### DIFF
--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -91,34 +91,6 @@ views:
         points_per_hour: 4
         hour24: true
         animate: false
-        show:
-          legend: true
-          labels: true
-          points: false
-          extrema: true
-        entities:
-          - entity: sensor.dining_room_thermostat_temperature
-            name: "Dining room"
-            color: "#f9a825"
-          - entity: sensor.master_bedroom_sensor_temperature
-            name: "Bedroom"
-            color: "#7e57c2"
-          - entity: sensor.average_indoor_temperature
-            name: "Indoor avg"
-            color: "#26a69a"
-            line_width: 4
-          - entity: sensor.weather_outdoor_temperature
-            name: "Outdoor"
-            color: "#42a5f5"
-
-      - type: custom:mini-graph-card
-        name: "HVAC activity ribbon"
-        hours_to_show: 24
-        points_per_hour: 4
-        hour24: true
-        animate: false
-        height: 48
-        line_width: 1
         lower_bound_secondary: 0
         upper_bound_secondary: 1
         state_map:
@@ -127,15 +99,16 @@ views:
           - value: "on"
             label: "Active"
         show:
-          name: true
-          icon: false
-          state: false
           legend: true
-          labels: false
+          labels: true
           labels_secondary: false
           points: false
-          extrema: false
+          extrema: true
         entities:
+          - entity: sensor.average_indoor_temperature
+            name: "Indoor avg"
+            color: "#26a69a"
+            line_width: 4
           - entity: binary_sensor.climate_heating_active
             name: "Heating"
             color: "rgba(239, 83, 80, 0.35)"
@@ -157,26 +130,76 @@ views:
             show_state: false
             smoothing: false
 
+      - type: entities
+        title: "Room temperatures"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.average_indoor_temperature
+            name: "Indoor average"
+          - entity: sensor.dining_room_thermostat_temperature
+            name: "Dining room"
+          - entity: sensor.master_bedroom_sensor_temperature
+            name: "Master bedroom"
+          - entity: sensor.weather_outdoor_temperature
+            name: "Outdoor"
+
       - type: custom:mini-graph-card
         name: "Air quality trends"
         hours_to_show: 24
         points_per_hour: 4
         hour24: true
         animate: false
+        lower_bound_secondary: 0
+        upper_bound_secondary: 1
+        state_map:
+          - value: "off"
+            label: "Inactive"
+          - value: "on"
+            label: "Active"
         show:
           legend: true
           labels: true
-          labels_secondary: true
+          labels_secondary: false
           points: false
           extrema: true
         entities:
-          - entity: sensor.thermostat_vocs
-            name: "VOC"
-            color: "#ab47bc"
+          - entity: sensor.thermostat_air_quality_index
+            name: "AQI"
+            color: "#ff7043"
+            line_width: 4
+          - entity: binary_sensor.climate_heating_active
+            name: "Heating"
+            color: "rgba(239, 83, 80, 0.35)"
+            y_axis: secondary
+            aggregate_func: max
+            show_line: false
+            show_fill: true
+            show_points: false
+            show_state: false
+            smoothing: false
+          - entity: binary_sensor.climate_cooling_active
+            name: "Cooling"
+            color: "rgba(41, 182, 246, 0.35)"
+            y_axis: secondary
+            aggregate_func: max
+            show_line: false
+            show_fill: true
+            show_points: false
+            show_state: false
+            smoothing: false
+
+      - type: entities
+        title: "Air quality details"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.air_quality_composite_status
+            name: "Composite status"
+          - entity: sensor.thermostat_air_quality_index
+            name: "AQI"
           - entity: sensor.thermostat_carbon_dioxide
             name: "CO2"
-            color: "#66bb6a"
-            y_axis: secondary
+          - entity: sensor.thermostat_vocs
+            name: "VOC"
 
       - type: grid
         title: "Schedule tuning"

--- a/tests/test_climate_dashboard.py
+++ b/tests/test_climate_dashboard.py
@@ -37,6 +37,14 @@ def graph_card(name):
     raise AssertionError(f"mini graph card {name!r} not found")
 
 
+def entities_card(title):
+    cards = load_dashboard()["views"][0]["cards"]
+    for card in cards:
+        if card.get("type") == "entities" and card.get("title") == title:
+            return card
+    raise AssertionError(f"entities card {title!r} not found")
+
+
 def entity_ids(card):
     return [entity["entity"] for entity in card["entities"]]
 
@@ -46,6 +54,18 @@ def assert_binary_state_map(card):
         {"value": "off", "label": "Inactive"},
         {"value": "on", "label": "Active"},
     ]
+
+
+def assert_hvac_activity_entities(card):
+    for entity in card["entities"][1:]:
+        assert entity["y_axis"] == "secondary"
+        assert entity["aggregate_func"] == "max"
+        assert entity["show_line"] is False
+        assert entity["show_fill"] is True
+        assert entity["show_points"] is False
+        assert entity["show_state"] is False
+        assert entity["smoothing"] is False
+        assert entity["color"].startswith("rgba(")
 
 
 def test_climate_activity_helpers_derive_from_thermostat_hvac_action():
@@ -72,56 +92,60 @@ def test_average_indoor_temperature_uses_dining_room_and_bedroom():
     assert "/ 2" in sensor["state"]
 
 
-def test_temperature_trends_use_mini_graph_with_average_indoor_temperature():
+def test_temperature_trends_use_average_indoor_with_hvac_activity_correlation():
     card = graph_card("Temperature trends")
 
     assert "history-graph" not in DASHBOARD.read_text()
     assert card["hours_to_show"] == 24
-    assert "lower_bound" not in card
-    assert "upper_bound" not in card
-    assert "lower_bound_secondary" not in card
-    assert "upper_bound_secondary" not in card
-    assert entity_ids(card) == [
-        "sensor.dining_room_thermostat_temperature",
-        "sensor.master_bedroom_sensor_temperature",
-        "sensor.average_indoor_temperature",
-        "sensor.weather_outdoor_temperature",
-    ]
-
-
-def test_hvac_activity_uses_dedicated_filled_ribbon_card():
-    card = graph_card("HVAC activity ribbon")
-
-    assert card["hours_to_show"] == 24
-    assert card["height"] == 48
     assert card["lower_bound_secondary"] == 0
     assert card["upper_bound_secondary"] == 1
     assert_binary_state_map(card)
     assert entity_ids(card) == [
+        "sensor.average_indoor_temperature",
         "binary_sensor.climate_heating_active",
         "binary_sensor.climate_cooling_active",
     ]
-    assert card["show"]["labels"] is False
     assert card["show"]["labels_secondary"] is False
-    for entity in card["entities"]:
-        assert entity["y_axis"] == "secondary"
-        assert entity["aggregate_func"] == "max"
-        assert entity["show_line"] is False
-        assert entity["show_fill"] is True
-        assert entity["show_points"] is False
-        assert entity["show_state"] is False
-        assert entity["smoothing"] is False
-        assert entity["color"].startswith("rgba(")
+    assert card["entities"][0]["line_width"] == 4
+    assert_hvac_activity_entities(card)
 
 
-def test_air_quality_trends_keep_voc_and_co2_axes_without_hvac_trace_noise():
+def test_room_temperature_detail_card_keeps_underlying_sensor_readings():
+    card = entities_card("Room temperatures")
+
+    assert card["show_header_toggle"] is False
+    assert entity_ids(card) == [
+        "sensor.average_indoor_temperature",
+        "sensor.dining_room_thermostat_temperature",
+        "sensor.master_bedroom_sensor_temperature",
+        "sensor.weather_outdoor_temperature",
+    ]
+
+
+def test_air_quality_trends_use_aqi_with_hvac_activity_correlation():
     card = graph_card("Air quality trends")
 
     assert card["hours_to_show"] == 24
-    assert "state_map" not in card
+    assert card["lower_bound_secondary"] == 0
+    assert card["upper_bound_secondary"] == 1
+    assert_binary_state_map(card)
     assert entity_ids(card) == [
-        "sensor.thermostat_vocs",
-        "sensor.thermostat_carbon_dioxide",
+        "sensor.thermostat_air_quality_index",
+        "binary_sensor.climate_heating_active",
+        "binary_sensor.climate_cooling_active",
     ]
-    co2 = card["entities"][1]
-    assert co2["y_axis"] == "secondary"
+    assert card["show"]["labels_secondary"] is False
+    assert card["entities"][0]["line_width"] == 4
+    assert_hvac_activity_entities(card)
+
+
+def test_air_quality_detail_card_keeps_composite_and_sensor_readings():
+    card = entities_card("Air quality details")
+
+    assert card["show_header_toggle"] is False
+    assert entity_ids(card) == [
+        "sensor.air_quality_composite_status",
+        "sensor.thermostat_air_quality_index",
+        "sensor.thermostat_carbon_dioxide",
+        "sensor.thermostat_vocs",
+    ]


### PR DESCRIPTION
## Summary
- simplify the temperature mini-graph to average indoor temperature with HVAC heating/cooling activity overlaid for timing correlation
- add a room-temperature detail card for average indoor, dining room, master bedroom, and outdoor readings
- simplify the air-quality mini-graph to AQI with the same HVAC activity overlay, with a separate detail card for composite status, AQI, CO2, and VOC

## Validation
- python3 YAML parse for dashboards/climate_control.yaml, packages/climate_control.yaml, packages/air_quality.yaml
- pytest tests/test_climate_dashboard.py
- pytest

Closes #138