### PR TITLE
Fix climate pre-arrival qualification freshness

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -285,7 +285,7 @@ template:
           - input_number.climate_precool_arrival_distance_ft
           - input_number.climate_precool_arrival_signal_max_age
         id: prearrival_input_changed
-      # Time ticks allow fresh inbound signals to age out even if the proximity
+      # Time ticks allow fresh distance signals to age out even if the proximity
       # integration stops publishing before the abandoned-trip restore window.
       - platform: time_pattern
         minutes: "/1"
@@ -327,15 +327,12 @@ template:
             {% set direction = states(signals.direction) %}
             {% set person_state = states(person) %}
             {% set distance_obj = states[signals.distance] if signals.distance in states else none %}
-            {% set direction_obj = states[signals.direction] if signals.direction in states else none %}
             {% set distance_age = now_ts - as_timestamp(distance_obj.last_updated, 0) if distance_obj is not none else max_age + 1 %}
-            {% set direction_age = now_ts - as_timestamp(direction_obj.last_updated, 0) if direction_obj is not none else max_age + 1 %}
             {% if person_state != 'home'
                   and distance is not none
                   and distance <= max_distance
                   and direction == 'towards'
-                  and distance_age <= max_age
-                  and direction_age <= max_age %}
+                  and distance_age <= max_age %}
               {% set ns.expected = true %}
             {% endif %}
           {% endfor %}
@@ -366,22 +363,22 @@ template:
               {% set distance = states(signals.distance) | float(none) %}
               {% set direction = states(signals.direction) %}
               {% set distance_obj = states[signals.distance] if signals.distance in states else none %}
-              {% set direction_obj = states[signals.direction] if signals.direction in states else none %}
               {% set distance_age = now_ts - as_timestamp(distance_obj.last_updated, 0) if distance_obj is not none else max_age + 1 %}
-              {% set direction_age = now_ts - as_timestamp(direction_obj.last_updated, 0) if direction_obj is not none else max_age + 1 %}
               {% if states(person) != 'home'
                     and distance is not none
                     and distance <= max_distance
                     and direction == 'towards'
-                    and distance_age <= max_age
-                    and direction_age <= max_age %}
+                    and distance_age <= max_age %}
                 {% set ns.names = ns.names + [signals.name] %}
               {% endif %}
             {% endfor %}
             {{ ns.names | join(', ') if ns.names else 'none' }}
           reason: >
-            Requires an eligible person not already home, a fresh proximity
-            direction of 'towards', and distance below the configured threshold.
+            Requires an eligible person not already home, current proximity
+            direction of 'towards', and fresh distance below the configured
+            threshold. Direction state is not age-gated because the proximity
+            integration may keep reporting the same direction while only the
+            distance state changes.
 
 # Automations
 automation:

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -1,10 +1,56 @@
 from pathlib import Path
+from datetime import datetime, timedelta
 
+from jinja2 import Environment
 import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
 CLIMATE = ROOT / "packages" / "climate_control.yaml"
+
+
+class MockState:
+    def __init__(self, state, last_updated):
+        self.state = state
+        self.last_updated = last_updated
+
+
+class MockStates:
+    def __init__(self, states, updated_at, default_updated_at):
+        self._states = states
+        self._updated_at = updated_at
+        self._default_updated_at = default_updated_at
+
+    def __call__(self, entity_id):
+        return self._states.get(entity_id, "unknown")
+
+    def __contains__(self, entity_id):
+        return entity_id in self._states
+
+    def __getitem__(self, entity_id):
+        return MockState(
+            self._states[entity_id],
+            self._updated_at.get(entity_id, self._default_updated_at),
+        )
+
+
+def as_timestamp(value, default=None):
+    if value is None:
+        return default
+    if isinstance(value, datetime):
+        return value.timestamp()
+    return value
+
+
+def render_ha_template(template, states, updated_at=None, now=None):
+    now = now or datetime(2026, 6, 29, 15, 52, 35)
+    env = Environment()
+    env.globals.update(
+        states=MockStates(states, updated_at or {}, now),
+        now=lambda: now,
+        as_timestamp=as_timestamp,
+    )
+    return env.from_string(template).render().strip()
 
 
 def load_climate():
@@ -193,9 +239,58 @@ def test_precool_prearrival_helpers_use_person_level_proximity_abstractions():
     assert "device_tracker" not in state
     assert "direction == 'towards'" in state
     assert "last_updated" in state
+    assert "direction_age" not in state
     assert "climate_precool_arrival_distance_ft" in state
     assert sensor["attributes"]["eligible_people"] == "Brian, Hester"
     assert "To add another climate pre-arrival person" in text
+
+
+def test_precool_prearrival_qualifies_fresh_distance_with_stable_towards_direction():
+    sensor = binary_sensor("Climate Pre-arrival Expected")
+    current_time = datetime(2026, 6, 29, 15, 52, 35)
+    states = {
+        "person.brian": "not_home",
+        "person.hester": "home",
+        "sensor.home_brian_distance": "285",
+        "sensor.home_brian_direction_of_travel": "towards",
+        "sensor.home_hester_distance": "12000",
+        "sensor.home_hester_direction_of_travel": "away_from",
+        "input_number.climate_precool_arrival_distance_ft": "30000",
+        "input_number.climate_precool_arrival_signal_max_age": "20",
+    }
+    updated_at = {
+        "sensor.home_brian_distance": current_time - timedelta(minutes=1),
+        # Proximity direction may remain the same for a whole trip, so Home
+        # Assistant may not advance last_updated for this entity while fresh
+        # distance updates continue proving the inbound signal is current.
+        "sensor.home_brian_direction_of_travel": current_time - timedelta(hours=1),
+    }
+
+    assert render_ha_template(sensor["state"], states, updated_at, current_time) == "True"
+    assert render_ha_template(
+        sensor["attributes"]["expected_people"], states, updated_at, current_time
+    ) == "Brian"
+
+
+def test_precool_prearrival_rejects_stale_distance_even_if_direction_is_towards():
+    sensor = binary_sensor("Climate Pre-arrival Expected")
+    current_time = datetime(2026, 6, 29, 15, 52, 35)
+    states = {
+        "person.brian": "not_home",
+        "person.hester": "home",
+        "sensor.home_brian_distance": "285",
+        "sensor.home_brian_direction_of_travel": "towards",
+        "sensor.home_hester_distance": "12000",
+        "sensor.home_hester_direction_of_travel": "away_from",
+        "input_number.climate_precool_arrival_distance_ft": "30000",
+        "input_number.climate_precool_arrival_signal_max_age": "20",
+    }
+    updated_at = {
+        "sensor.home_brian_distance": current_time - timedelta(minutes=21),
+        "sensor.home_brian_direction_of_travel": current_time,
+    }
+
+    assert render_ha_template(sensor["state"], states, updated_at, current_time) == "False"
 
 
 def test_precool_prearrival_template_has_explicit_update_triggers():


### PR DESCRIPTION
## Summary
- Fixes the pre-arrival qualification path so a fresh inbound distance update can qualify even when the proximity direction remains stably `towards` without a new `last_updated` timestamp.
- Keeps the less-fragile person/proximity design: explicit `person.*`, Home distance, and Home direction entities feed the trigger-based template sensor directly.
- Preserves the helper-driven distance/max-age behavior by age-gating the changing distance signal, while treating direction as current state rather than a freshness signal.

## Root cause
The template required both distance and direction entities to have fresh `last_updated` values. In practice, the proximity integration can keep direction at `towards` for an entire return trip while only the distance sensor changes. That made otherwise-valid inbound evidence fail the derived `binary_sensor.climate_pre_arrival_expected` path. Charming, in the way only timestamp semantics can be.

## Verification
- `pytest tests/test_climate_extreme_heat_overlay.py -q` — 15 passed
- `pytest -q` — 50 passed
- `python3 - <<'PY' ... yaml.safe_load('packages/climate_control.yaml') ... PY` — `packages/climate_control.yaml: ok`
- `docker run --rm -v "$PWD:/config:ro" ghcr.io/home-assistant/home-assistant:stable python -m homeassistant --script check_config -c /config` — exit 0, `Testing configuration at /config`

Fixes #142
