### PR TITLE
Fix air quality trend history basis

### DIFF
--- a/packages/air_quality.yaml
+++ b/packages/air_quality.yaml
@@ -60,6 +60,37 @@ input_number:
     icon: mdi:air-filter
     initial: *aqi_threshold
 
+sensor:
+  # Ecobee air-quality sensors update frequently enough that 1-hour statistics
+  # sensors provide a real recent-history baseline without relying on mirrored
+  # attributes from the current composite status template.
+  - platform: statistics
+    name: "Air Quality AQI 1h Mean"
+    unique_id: air_quality_aqi_1h_mean
+    entity_id: sensor.thermostat_air_quality_index
+    state_characteristic: mean
+    max_age:
+      hours: 1
+    sampling_size: 240
+
+  - platform: statistics
+    name: "Air Quality CO2 1h Mean"
+    unique_id: air_quality_co2_1h_mean
+    entity_id: sensor.thermostat_carbon_dioxide
+    state_characteristic: mean
+    max_age:
+      hours: 1
+    sampling_size: 240
+
+  - platform: statistics
+    name: "Air Quality VOC 1h Mean"
+    unique_id: air_quality_voc_1h_mean
+    entity_id: sensor.thermostat_vocs
+    state_characteristic: mean
+    max_age:
+      hours: 1
+    sampling_size: 240
+
 template:
   - sensor:
       - name: "Air Quality Composite Status"
@@ -159,12 +190,12 @@ template:
         state: >
           {% set current_aqi = states('sensor.thermostat_air_quality_index') | int(0) %}
           {% set current_co2 = states('sensor.thermostat_carbon_dioxide') | int(0) %}
-          {% set current_voc = states('sensero.thermostat_vocs') | int(0) %}
+          {% set current_voc = states('sensor.thermostat_vocs') | int(0) %}
           
-          {# Get previous hour's average (simplified for template) #}
-          {% set prev_aqi = state_attr('sensor.air_quality_composite_status', 'aqi_value') | int(0) %}
-          {% set prev_co2 = state_attr('sensor.air_quality_composite_status', 'co2_value') | int(0) %}
-          {% set prev_voc = state_attr('sensor.air_quality_composite_status', 'voc_value') | int(0) %}
+          {# Compare current readings to real 1-hour statistics means. #}
+          {% set prev_aqi = states('sensor.air_quality_aqi_1h_mean') | int(current_aqi) %}
+          {% set prev_co2 = states('sensor.air_quality_co2_1h_mean') | int(current_co2) %}
+          {% set prev_voc = states('sensor.air_quality_voc_1h_mean') | int(current_voc) %}
           
           {% set aqi_diff = current_aqi - prev_aqi %}
           {% set co2_diff = current_co2 - prev_co2 %}
@@ -180,16 +211,17 @@ template:
         attributes:
           aqi_change: >
             {% set current = states('sensor.thermostat_air_quality_index') | int(0) %}
-            {% set previous = state_attr('sensor.air_quality_composite_status', 'aqi_value') | int(0) %}
+            {% set previous = states('sensor.air_quality_aqi_1h_mean') | int(current) %}
             {{ current - previous }}
           co2_change: >
             {% set current = states('sensor.thermostat_carbon_dioxide') | int(0) %}
-            {% set previous = state_attr('sensor.air_quality_composite_status', 'co2_value') | int(0) %}
+            {% set previous = states('sensor.air_quality_co2_1h_mean') | int(current) %}
             {{ current - previous }}
           voc_change: >
             {% set current = states('sensor.thermostat_vocs') | int(0) %}
-            {% set previous = state_attr('sensor.air_quality_composite_status', 'voc_value') | int(0) %}
+            {% set previous = states('sensor.air_quality_voc_1h_mean') | int(current) %}
             {{ current - previous }}
+          comparison_basis: "Current readings minus 1-hour statistics mean"
 
   - binary_sensor:
       - name: "Air Quality Poor"

--- a/tests/test_air_quality_package.py
+++ b/tests/test_air_quality_package.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+from jinja2 import Environment
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "air_quality.yaml"
+
+
+class MockStates:
+    def __init__(self, states):
+        self._states = states
+
+    def __call__(self, entity_id):
+        return self._states.get(entity_id, "unknown")
+
+
+def render_ha_template(template, states):
+    env = Environment()
+    env.globals.update(states=MockStates(states))
+    return env.from_string(template).render().strip()
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def template_sensor(name):
+    for block in load_package()["template"]:
+        for sensor in block.get("sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"sensor {name!r} not found")
+
+
+def test_air_quality_trend_uses_real_statistics_baselines():
+    package = load_package()
+    statistic_sensors = package["sensor"]
+
+    assert {
+        sensor["entity_id"] for sensor in statistic_sensors
+    } == {
+        "sensor.thermostat_air_quality_index",
+        "sensor.thermostat_carbon_dioxide",
+        "sensor.thermostat_vocs",
+    }
+    assert all(sensor["platform"] == "statistics" for sensor in statistic_sensors)
+    assert all(sensor["state_characteristic"] == "mean" for sensor in statistic_sensors)
+    assert all(sensor["max_age"] == {"hours": 1} for sensor in statistic_sensors)
+    assert all(sensor["sampling_size"] == 240 for sensor in statistic_sensors)
+
+    trend = template_sensor("Air Quality Trend")
+    trend_text = trend["state"] + str(trend["attributes"])
+    assert "sensor.air_quality_aqi_1h_mean" in trend_text
+    assert "sensor.air_quality_co2_1h_mean" in trend_text
+    assert "sensor.air_quality_voc_1h_mean" in trend_text
+    assert "sensero.thermostat_vocs" not in trend_text
+    assert "state_attr('sensor.air_quality_composite_status'" not in trend_text
+    assert trend["attributes"]["comparison_basis"] == (
+        "Current readings minus 1-hour statistics mean"
+    )
+
+
+def test_air_quality_trend_reports_worsening_from_statistics_mean():
+    trend = template_sensor("Air Quality Trend")
+
+    assert render_ha_template(
+        trend["state"],
+        {
+            "sensor.thermostat_air_quality_index": "71",
+            "sensor.thermostat_carbon_dioxide": "920",
+            "sensor.thermostat_vocs": "330",
+            "sensor.air_quality_aqi_1h_mean": "60",
+            "sensor.air_quality_co2_1h_mean": "820",
+            "sensor.air_quality_voc_1h_mean": "225",
+        },
+    ) == "worsening"
+
+
+def test_air_quality_trend_reports_improving_from_statistics_mean():
+    trend = template_sensor("Air Quality Trend")
+
+    assert render_ha_template(
+        trend["state"],
+        {
+            "sensor.thermostat_air_quality_index": "49",
+            "sensor.thermostat_carbon_dioxide": "690",
+            "sensor.thermostat_vocs": "175",
+            "sensor.air_quality_aqi_1h_mean": "60",
+            "sensor.air_quality_co2_1h_mean": "790",
+            "sensor.air_quality_voc_1h_mean": "280",
+        },
+    ) == "improving"
+
+
+def test_air_quality_trend_reports_stable_within_thresholds():
+    trend = template_sensor("Air Quality Trend")
+
+    assert render_ha_template(
+        trend["state"],
+        {
+            "sensor.thermostat_air_quality_index": "59",
+            "sensor.thermostat_carbon_dioxide": "889",
+            "sensor.thermostat_vocs": "349",
+            "sensor.air_quality_aqi_1h_mean": "60",
+            "sensor.air_quality_co2_1h_mean": "790",
+            "sensor.air_quality_voc_1h_mean": "250",
+        },
+    ) == "stable"


### PR DESCRIPTION
## Summary
- add 1-hour Home Assistant statistics sensors for AQI, CO2, and VOC trend baselines
- fix the typoed VOC entity reference in the trend template
- make trend/change attributes compare current readings against the statistics means instead of mirrored composite attributes
- add pytest coverage for worsening, improving, and stable trend outcomes

## Validation
- python -m pytest tests/test_air_quality_package.py
- python -m pytest
- python - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('packages/air_quality.yaml').read_text())
print('parsed packages/air_quality.yaml')
PY

Home Assistant config check was not run; the repo/task did not provide a known-safe local HA config-check command or environment.

Closes #150