### PR TITLE
Issue #148: normalize weather forecast helper ownership

### DIFF
--- a/packages/climate_control.yaml
+++ b/packages/climate_control.yaml
@@ -206,47 +206,24 @@ template:
         unique_id: climate_extreme_heat_day
         icon: mdi:sun-thermometer
         availability: >
-          {% set daily_state = states('sensor.weather_daily_forecast') %}
+          {% set forecast_high = states('sensor.temperature_forecast_high_today') | float(none) %}
           {% set threshold = states('input_number.climate_extreme_heat_threshold') | float(none) %}
-          {{ daily_state not in ['unknown', 'unavailable', '', none] and threshold is not none }}
+          {{ forecast_high is not none and threshold is not none }}
         state: >
           {#
-            NWS twice-daily forecast periods in this deployment expose
-            temperature values in Fahrenheit. Use the normalized forecast
-            attribute directly instead of the older derived high-temp helper
-            so the hot-day decision is not dependent on ambiguous units.
+            Weather owns forecast payload normalization. Climate consumes the
+            weather-owned high-temperature helper so hot-day decisions do not
+            reparse weather.get_forecasts payloads in this package.
           #}
+          {% set forecast_high = states('sensor.temperature_forecast_high_today') | float(none) %}
           {% set threshold = states('input_number.climate_extreme_heat_threshold') | float(95) %}
-          {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
-          {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
-          {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
-          {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
-          {% set ns = namespace(high=none) %}
-          {% for period in forecast[:2] %}
-            {% set temp = period.temperature | float(none) %}
-            {% if temp is not none and (ns.high is none or temp > ns.high) %}
-              {% set ns.high = temp %}
-            {% endif %}
-          {% endfor %}
-          {{ ns.high is not none and ns.high >= threshold }}
+          {{ forecast_high is not none and forecast_high >= threshold }}
         attributes:
-          forecast_high_f: >
-            {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
-            {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
-            {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
-            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
-            {% set ns = namespace(high=none) %}
-            {% for period in forecast[:2] %}
-              {% set temp = period.temperature | float(none) %}
-              {% if temp is not none and (ns.high is none or temp > ns.high) %}
-                {% set ns.high = temp %}
-              {% endif %}
-            {% endfor %}
-            {{ ns.high if ns.high is not none else 'unknown' }}
+          forecast_high_f: "{{ states('sensor.temperature_forecast_high_today') }}"
           threshold_f: "{{ states('input_number.climate_extreme_heat_threshold') | float(95) }}"
-          forecast_source: "sensor.weather_daily_forecast"
-          forecast_unit_assumption: "NWS forecast temperature attribute is Fahrenheit"
-          decision_scope: "maximum temperature from the first two twice-daily periods"
+          forecast_source: "sensor.temperature_forecast_high_today"
+          forecast_unit_assumption: "weather-owned helper publishes °F"
+          decision_scope: "weather-owned maximum temperature from the first two twice-daily periods"
 
   - sensor:
       - name: "Average Indoor Temperature"

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -289,28 +289,39 @@ template:
 
       - name: "Temperature forecast high today"
         unique_id: weather_forecast_temperature_high_today
-        state: >
+        availability: >
           {% set sensor_state = states('sensor.weather_daily_forecast') %}
           {% set invalid_states = ['unknown', 'unavailable', '', none] %}
           {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
+          {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+          {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
+          {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
+          {% set ns = namespace(high=none) %}
           {% if sensor_state not in invalid_states %}
-            {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
-            {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
-            {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
-            {% set ns = namespace(high=none) %}
             {% for period in forecast[:2] %}
               {% set temp = period.temperature | float(none) %}
               {% if temp is not none and (ns.high is none or temp > ns.high) %}
                 {% set ns.high = temp %}
               {% endif %}
             {% endfor %}
-            {% if ns.high is not none %}
-              {{ ns.high | round(1) }}
-            {% else %}
-              {{ states('sensor.weather_outdoor_temperature') | default('unknown') }}
-            {% endif %}
-          {% else %}
-            {{ states('sensor.weather_outdoor_temperature') | default('unknown') }}
           {% endif %}
+          {{ ns.high is not none }}
+        state: >
+          {% set source_entity = state_attr('sensor.weather_daily_forecast', 'source_entity') | default('weather.nws_home_kmle', true) %}
+          {% set direct_forecast = state_attr('sensor.weather_daily_forecast', 'forecast') %}
+          {% set source_payload = state_attr('sensor.weather_daily_forecast', source_entity) %}
+          {% set forecast = direct_forecast if direct_forecast is not none else source_payload.forecast if source_payload is mapping and source_payload.forecast is defined else [] %}
+          {% set ns = namespace(high=none) %}
+          {% for period in forecast[:2] %}
+            {% set temp = period.temperature | float(none) %}
+            {% if temp is not none and (ns.high is none or temp > ns.high) %}
+              {% set ns.high = temp %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.high | round(1) if ns.high is not none else 'unknown' }}
+        attributes:
+          forecast_source: "sensor.weather_daily_forecast"
+          forecast_unit_assumption: "NWS forecast temperature attribute is Fahrenheit"
+          decision_scope: "maximum temperature from the first two twice-daily periods"
         unit_of_measurement: "°F"
         device_class: temperature

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -119,19 +119,20 @@ def test_extreme_heat_helpers_are_configurable_in_fahrenheit():
     assert "initial" not in config["input_boolean"]["climate_pre_arrival_recovery_active"]
 
 
-def test_extreme_heat_day_uses_validated_daily_forecast_attributes_not_derived_sensor():
+def test_extreme_heat_day_uses_weather_owned_high_temperature_helper():
     sensor = binary_sensor("Climate Extreme Heat Day")
     state = sensor["state"]
+    availability = sensor["availability"]
     attrs = sensor["attributes"]
 
-    assert "state_attr('sensor.weather_daily_forecast', 'forecast')" in state
-    assert "state_attr('sensor.weather_daily_forecast', source_entity)" in state
-    assert "forecast[:2]" in state
-    assert "period.temperature" in state
+    assert "states('sensor.temperature_forecast_high_today')" in availability
+    assert "states('sensor.temperature_forecast_high_today')" in state
     assert "input_number.climate_extreme_heat_threshold" in state
-    assert "sensor.temperature_forecast_high_today" not in state
-    assert attrs["forecast_source"] == "sensor.weather_daily_forecast"
-    assert "Fahrenheit" in attrs["forecast_unit_assumption"]
+    assert "state_attr('sensor.weather_daily_forecast'" not in state
+    assert "forecast[:2]" not in state
+    assert "period.temperature" not in state
+    assert attrs["forecast_source"] == "sensor.temperature_forecast_high_today"
+    assert "weather-owned helper" in attrs["forecast_unit_assumption"]
 
 
 def test_precool_apply_is_bounded_occupied_and_one_shot():

--- a/tests/test_weather_forecast_cache.py
+++ b/tests/test_weather_forecast_cache.py
@@ -114,8 +114,13 @@ def test_temperature_forecast_high_today_uses_deployment_fahrenheit_units():
     sensor = template_sensor("Temperature forecast high today")
 
     assert sensor["unit_of_measurement"] == "°F"
+    assert "availability" in sensor
     assert "forecast[:2]" in sensor["state"]
     assert "ns.high" in sensor["state"]
+    assert "weather_outdoor_temperature" not in sensor["state"]
+    assert sensor["attributes"]["forecast_source"] == "sensor.weather_daily_forecast"
+    assert "Fahrenheit" in sensor["attributes"]["forecast_unit_assumption"]
+    assert "first two twice-daily periods" in sensor["attributes"]["decision_scope"]
 
 
 def test_precipitation_next_hour_uses_nws_probability_semantics():


### PR DESCRIPTION
## Summary
- Moves the extreme-heat forecast high decision seam into `packages/weather.yaml` by making `sensor.temperature_forecast_high_today` the weather-owned stable helper for the first two twice-daily periods.
- Updates climate extreme-heat day logic to consume that helper instead of reparsing `sensor.weather_daily_forecast` payloads.
- Adds/updates tests to lock the helper ownership boundary and climate consumer behavior.

## Validation
- `python -m pytest tests/test_weather_forecast_cache.py tests/test_climate_extreme_heat_overlay.py` -> 22 passed
- `python -m pytest` -> 57 passed
- PyYAML parse of all `packages/*.yaml` -> passed
- `git diff --check` -> clean
- `docker run --rm -v "$PWD":/config ghcr.io/home-assistant/home-assistant:stable python -m homeassistant --script check_config -c /config` -> passed

## Documentation impact
No external/operator documentation update needed; this is an internal ownership refactor preserving the existing climate extreme-heat behavior.

Closes #148
