### PR TITLE
Issue #146: Make shared infrastructure dependencies explicit

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,7 @@ Follow these standards for all Home Assistant configuration changes:
 
 0. **Repository structure**:
    - `packages: !include_dir_named packages` loads feature packages
+   - `packages/shared_infrastructure.yaml` owns shared package contracts such as `notify.all_mobile_devices` and YAML Lovelace dashboard registration; feature packages may consume these contracts but should not redefine them ad hoc
    - `automation: !include_dir_merge_list automation` loads standalone automation files
    - `input_boolean: !include_dir_merge_named input_boolean` loads helper toggles
    - Prefer extending the existing modular structure instead of placing unrelated logic in `configuration.yaml`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This configuration uses Home Assistant's packages feature to organize functional
 - **presence.yaml**: Presence detection and related automations
 - **remotes.yaml**: Z-Wave remote control configuration
 - **routines.yaml**: Common household routines (Good Night, etc.)
+- **shared_infrastructure.yaml**: Shared contracts for infrastructure consumed by packages, including `notify.all_mobile_devices` and YAML Lovelace dashboard registration
 - **security_lights.yaml**: Security-focused lighting automations
 - **weather.yaml**: Weather data processing and event monitoring
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -8,21 +8,6 @@ default_config:
 frontend:
   themes: !include_dir_merge_named themes
 
-lovelace:
-  dashboards:
-    window-ventilation:
-      mode: yaml
-      title: "Ventilation Advisor"
-      icon: mdi:window-open-variant
-      show_in_sidebar: false
-      filename: dashboards/window_ventilation.yaml
-    climate-control:
-      mode: yaml
-      title: "Climate Control"
-      icon: mdi:thermostat-auto
-      show_in_sidebar: true
-      filename: dashboards/climate_control.yaml
-
 automation: !include_dir_merge_list automation
 input_boolean: !include_dir_merge_named input_boolean
 scene: !include scenes.yaml
@@ -43,10 +28,3 @@ google_assistant:
 recorder: !include recorder.yaml
 
 logbook: !include logbook.yaml
-
-notify:
-  - platform: group
-    name: all_mobile_devices
-    services:
-      - service: mobile_app_brian_phone
-      - service: mobile_app_hester_phone

--- a/packages/shared_infrastructure.yaml
+++ b/packages/shared_infrastructure.yaml
@@ -1,0 +1,46 @@
+# packages/shared_infrastructure.yaml
+#
+# Shared Home Assistant infrastructure contract.
+#
+# This package owns root-level wiring that first-party feature packages consume
+# but should not each define independently. Keeping these contracts together
+# makes package dependencies explicit without changing runtime behavior.
+#
+# Provided contracts:
+# - notify.all_mobile_devices: shared household mobile notification target used
+#   by alerting and routine packages.
+# - Lovelace dashboard registration for YAML dashboards stored under
+#   dashboards/.
+#
+# Known package consumers of notify.all_mobile_devices:
+# - packages/air_quality.yaml
+# - packages/cameras.yaml
+# - packages/device_batteries.yaml
+# - packages/device_connectivity.yaml
+# - packages/garage_door_monitoring.yaml
+# - packages/routines.yaml
+# - packages/security_sanity.yaml
+# - packages/towner_notifications.yaml
+# - packages/window_ventilation.yaml
+
+lovelace:
+  dashboards:
+    window-ventilation:
+      mode: yaml
+      title: "Ventilation Advisor"
+      icon: mdi:window-open-variant
+      show_in_sidebar: false
+      filename: dashboards/window_ventilation.yaml
+    climate-control:
+      mode: yaml
+      title: "Climate Control"
+      icon: mdi:thermostat-auto
+      show_in_sidebar: true
+      filename: dashboards/climate_control.yaml
+
+notify:
+  - platform: group
+    name: all_mobile_devices
+    services:
+      - service: mobile_app_brian_phone
+      - service: mobile_app_hester_phone

--- a/tests/test_shared_infrastructure.py
+++ b/tests/test_shared_infrastructure.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION_YAML = ROOT / "configuration.yaml"
+SHARED_INFRASTRUCTURE_YAML = ROOT / "packages" / "shared_infrastructure.yaml"
+PACKAGES_DIR = ROOT / "packages"
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text())
+
+
+def test_shared_infrastructure_owns_root_level_package_contracts():
+    config_text = CONFIGURATION_YAML.read_text()
+    shared = load_yaml(SHARED_INFRASTRUCTURE_YAML)
+
+    assert "packages: !include_dir_named packages" in config_text
+    assert "\nlovelace:" not in config_text
+    assert "\nnotify:" not in config_text
+
+    dashboards = shared["lovelace"]["dashboards"]
+    assert dashboards["window-ventilation"]["filename"] == "dashboards/window_ventilation.yaml"
+    assert dashboards["climate-control"]["filename"] == "dashboards/climate_control.yaml"
+
+    notify_groups = shared["notify"]
+    assert notify_groups == [
+        {
+            "platform": "group",
+            "name": "all_mobile_devices",
+            "services": [
+                {"service": "mobile_app_brian_phone"},
+                {"service": "mobile_app_hester_phone"},
+            ],
+        }
+    ]
+
+
+def test_shared_mobile_notify_consumers_have_documented_contract():
+    shared_text = SHARED_INFRASTRUCTURE_YAML.read_text()
+    consumers = sorted(
+        package.relative_to(ROOT).as_posix()
+        for package in PACKAGES_DIR.glob("*.yaml")
+        if package != SHARED_INFRASTRUCTURE_YAML
+        and "notify.all_mobile_devices" in package.read_text()
+    )
+
+    assert consumers
+    for consumer in consumers:
+        assert f"# - {consumer}" in shared_text

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -4,12 +4,16 @@ import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CONFIGURATION = ROOT / "configuration.yaml"
+SHARED_INFRASTRUCTURE = ROOT / "packages" / "shared_infrastructure.yaml"
 DASHBOARD = ROOT / "dashboards" / "window_ventilation.yaml"
 
 
 def load_dashboard():
     return yaml.safe_load(DASHBOARD.read_text())
+
+
+def load_shared_infrastructure():
+    return yaml.safe_load(SHARED_INFRASTRUCTURE.read_text())
 
 
 def entity_refs(cards):
@@ -26,13 +30,13 @@ def entity_refs(cards):
 
 
 def test_window_ventilation_dashboard_is_yaml_managed_and_hidden():
-    config_text = CONFIGURATION.read_text()
+    dashboard_config = load_shared_infrastructure()["lovelace"]["dashboards"][
+        "window-ventilation"
+    ]
 
-    assert "lovelace:" in config_text
-    assert "window-ventilation:" in config_text
-    assert "mode: yaml" in config_text
-    assert "filename: dashboards/window_ventilation.yaml" in config_text
-    assert "show_in_sidebar: false" in config_text
+    assert dashboard_config["mode"] == "yaml"
+    assert dashboard_config["filename"] == "dashboards/window_ventilation.yaml"
+    assert dashboard_config["show_in_sidebar"] is False
 
 
 def test_window_ventilation_dashboard_surfaces_required_context():


### PR DESCRIPTION
## Summary
- Move shared `notify.all_mobile_devices` and YAML Lovelace dashboard registration into `packages/shared_infrastructure.yaml`
- Document the shared infrastructure contract and known first-party notify consumers
- Update tests so dashboard and shared-notify expectations are anchored to the explicit package boundary

## Validation
- `python3 -m pytest` -> 59 passed
- PyYAML parse for `packages/*.yaml` and `dashboards/*.yaml` -> passed
- `git diff --check` -> passed
- `docker run --rm -v "$PWD":/config ghcr.io/home-assistant/home-assistant:stable python -m homeassistant --config /config --script check_config` -> passed

Closes #146
