### PR TITLE
Refactor climate dashboard sections

### DIFF
--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -2,8 +2,9 @@
 #
 # Mobile-first operator view for climate control.
 #
-# This dashboard is YAML-managed from configuration.yaml. Trend cards use the
-# already-installed mini-graph-card custom card for compact operator history.
+# This dashboard is YAML-managed from packages/shared_infrastructure.yaml. Trend
+# cards use the already-installed mini-graph-card custom card for compact
+# operator history.
 
 title: "Climate Control"
 views:
@@ -37,7 +38,7 @@ views:
           content: >-
             ## Extreme heat expected, overlay disabled
 
-            Forecast high: {{ state_attr('binary_sensor.climate_extreme_heat_day', 'forecast_high_f') | default('unknown', true) }}°F<br>
+            Forecast high: {{ states('sensor.temperature_forecast_high_today') }}°F<br>
             Threshold: {{ states('input_number.climate_extreme_heat_threshold') }}°F
 
       - type: conditional
@@ -64,7 +65,7 @@ views:
           content: >-
             ## Extreme heat expected
 
-            Forecast high: {{ state_attr('binary_sensor.climate_extreme_heat_day', 'forecast_high_f') | default('unknown', true) }}°F<br>
+            Forecast high: {{ states('sensor.temperature_forecast_high_today') }}°F<br>
             Overlay is armed and may pre-cool during eligible occupied,
             guest, or pre-arrival windows.
 
@@ -78,168 +79,136 @@ views:
           content: >-
             ## Climate pre-arrival is eligible
 
-            Expected arrivals: {{ state_attr('binary_sensor.climate_pre_arrival_expected', 'expected_people') | default('unknown', true) }}<br>
-            Rule: {{ state_attr('binary_sensor.climate_pre_arrival_expected', 'reason') | default('active', true) }}
-
-      - type: thermostat
-        entity: climate.dining_room_thermostat
-        name: "Dining Room Thermostat"
-
-      - type: custom:mini-graph-card
-        name: "Temperature trends"
-        hours_to_show: 24
-        points_per_hour: 4
-        hour24: true
-        animate: false
-        lower_bound_secondary: 0
-        upper_bound_secondary: 1
-        state_map:
-          - value: "off"
-            label: "Inactive"
-          - value: "on"
-            label: "Active"
-        show:
-          legend: true
-          labels: true
-          labels_secondary: false
-          points: false
-          extrema: true
-        entities:
-          - entity: sensor.average_indoor_temperature
-            name: "Indoor avg"
-            color: "#26a69a"
-            line_width: 4
-            show_fill: false
-          - entity: binary_sensor.climate_heating_active
-            name: "Heating"
-            color: "rgba(239, 83, 80, 0.35)"
-            y_axis: secondary
-            aggregate_func: max
-            show_line: false
-            show_fill: true
-            show_points: false
-            show_state: false
-            smoothing: false
-          - entity: binary_sensor.climate_cooling_active
-            name: "Cooling"
-            color: "rgba(41, 182, 246, 0.35)"
-            y_axis: secondary
-            aggregate_func: max
-            show_line: false
-            show_fill: true
-            show_points: false
-            show_state: false
-            smoothing: false
-
-      - type: custom:mini-graph-card
-        name: "Room temperatures"
-        hours_to_show: 24
-        points_per_hour: 4
-        hour24: true
-        animate: false
-        show:
-          legend: true
-          labels: true
-          points: false
-          extrema: true
-        entities:
-          - entity: sensor.average_indoor_temperature
-            name: "Indoor average"
-            color: "#26a69a"
-            line_width: 4
-            show_fill: false
-          - entity: sensor.dining_room_thermostat_temperature
-            name: "Dining room"
-            color: "#42a5f5"
-            line_width: 2
-            show_fill: false
-          - entity: sensor.master_bedroom_sensor_temperature
-            name: "Master bedroom"
-            color: "#ab47bc"
-            line_width: 2
-            show_fill: false
-          - entity: sensor.weather_outdoor_temperature
-            name: "Outdoor"
-            color: "#78909c"
-            line_width: 2
-            show_fill: false
-
-      - type: custom:mini-graph-card
-        name: "Air quality trends"
-        hours_to_show: 24
-        points_per_hour: 4
-        hour24: true
-        animate: false
-        lower_bound_secondary: 0
-        upper_bound_secondary: 1
-        state_map:
-          - value: "off"
-            label: "Inactive"
-          - value: "on"
-            label: "Active"
-        show:
-          legend: true
-          labels: true
-          labels_secondary: false
-          points: false
-          extrema: true
-        entities:
-          - entity: sensor.thermostat_air_quality_index
-            name: "AQI"
-            color: "#ff7043"
-            line_width: 4
-            show_fill: false
-          - entity: binary_sensor.climate_heating_active
-            name: "Heating"
-            color: "rgba(239, 83, 80, 0.35)"
-            y_axis: secondary
-            aggregate_func: max
-            show_line: false
-            show_fill: true
-            show_points: false
-            show_state: false
-            smoothing: false
-          - entity: binary_sensor.climate_cooling_active
-            name: "Cooling"
-            color: "rgba(41, 182, 246, 0.35)"
-            y_axis: secondary
-            aggregate_func: max
-            show_line: false
-            show_fill: true
-            show_points: false
-            show_state: false
-            smoothing: false
-
-      - type: custom:mini-graph-card
-        name: "Air quality details"
-        hours_to_show: 24
-        points_per_hour: 4
-        hour24: true
-        animate: false
-        show:
-          legend: true
-          labels: true
-          points: false
-          extrema: true
-        entities:
-          - entity: sensor.thermostat_air_quality_index
-            name: "AQI"
-            color: "#ff7043"
-            line_width: 4
-            show_fill: false
-          - entity: sensor.thermostat_carbon_dioxide
-            name: "CO2"
-            color: "#7e57c2"
-            line_width: 2
-            show_fill: false
-          - entity: sensor.thermostat_vocs
-            name: "VOC"
-            color: "#66bb6a"
-            line_width: 2
-            show_fill: false
+            An eligible resident appears to be nearing home. Climate recovery may
+            restore the normal daytime targets if the house is empty and guest
+            mode is off.
 
       - type: grid
-        title: "Schedule tuning"
+        title: "Primary operator view"
+        columns: 1
+        square: false
+        cards:
+          - type: thermostat
+            entity: climate.dining_room_thermostat
+            name: "Dining Room Thermostat"
+
+          - type: custom:mini-graph-card
+            <<: &climate_activity_graph
+              hours_to_show: 24
+              points_per_hour: 4
+              hour24: true
+              animate: false
+              lower_bound_secondary: 0
+              upper_bound_secondary: 1
+              state_map:
+                - value: "off"
+                  label: "Inactive"
+                - value: "on"
+                  label: "Active"
+              show: &climate_activity_show
+                legend: true
+                labels: true
+                labels_secondary: false
+                points: false
+                extrema: true
+            name: "Temperature trends"
+            entities:
+              - entity: sensor.average_indoor_temperature
+                name: "Indoor avg"
+                color: "#26a69a"
+                line_width: 4
+                show_fill: false
+              - &heating_overlay
+                entity: binary_sensor.climate_heating_active
+                name: "Heating"
+                color: "rgba(239, 83, 80, 0.35)"
+                y_axis: secondary
+                aggregate_func: max
+                show_line: false
+                show_fill: true
+                show_points: false
+                show_state: false
+                smoothing: false
+              - &cooling_overlay
+                entity: binary_sensor.climate_cooling_active
+                name: "Cooling"
+                color: "rgba(41, 182, 246, 0.35)"
+                y_axis: secondary
+                aggregate_func: max
+                show_line: false
+                show_fill: true
+                show_points: false
+                show_state: false
+                smoothing: false
+
+          - type: custom:mini-graph-card
+            <<: &climate_detail_graph
+              hours_to_show: 24
+              points_per_hour: 4
+              hour24: true
+              animate: false
+              show: &climate_detail_show
+                legend: true
+                labels: true
+                points: false
+                extrema: true
+            name: "Room temperatures"
+            entities:
+              - entity: sensor.average_indoor_temperature
+                name: "Indoor average"
+                color: "#26a69a"
+                line_width: 4
+                show_fill: false
+              - entity: sensor.dining_room_thermostat_temperature
+                name: "Dining room"
+                color: "#42a5f5"
+                line_width: 2
+                show_fill: false
+              - entity: sensor.master_bedroom_sensor_temperature
+                name: "Master bedroom"
+                color: "#ab47bc"
+                line_width: 2
+                show_fill: false
+              - entity: sensor.weather_outdoor_temperature
+                name: "Outdoor"
+                color: "#78909c"
+                line_width: 2
+                show_fill: false
+
+          - type: custom:mini-graph-card
+            <<: *climate_activity_graph
+            name: "Air quality trends"
+            entities:
+              - entity: sensor.thermostat_air_quality_index
+                name: "AQI"
+                color: "#ff7043"
+                line_width: 4
+                show_fill: false
+              - *heating_overlay
+              - *cooling_overlay
+
+          - type: custom:mini-graph-card
+            <<: *climate_detail_graph
+            name: "Air quality details"
+            entities:
+              - entity: sensor.thermostat_air_quality_index
+                name: "AQI"
+                color: "#ff7043"
+                line_width: 4
+                show_fill: false
+              - entity: sensor.thermostat_carbon_dioxide
+                name: "CO2"
+                color: "#7e57c2"
+                line_width: 2
+                show_fill: false
+              - entity: sensor.thermostat_vocs
+                name: "VOC"
+                color: "#66bb6a"
+                line_width: 2
+                show_fill: false
+
+      - type: grid
+        title: "Admin tuning"
         columns: 1
         square: false
         cards:
@@ -257,6 +226,7 @@ views:
                 name: "Sleep"
               - entity: input_number.climate_cool_away
                 name: "Away"
+
           - type: entities
             title: "Heating setpoints"
             show_header_toggle: false
@@ -272,28 +242,25 @@ views:
               - entity: input_number.climate_heat_away
                 name: "Away"
 
-      - type: entities
-        title: "Extreme heat tuning"
-        show_header_toggle: false
-        entities:
-          - entity: binary_sensor.climate_extreme_heat_day
-            name: "Extreme heat day"
-          - type: attribute
-            entity: binary_sensor.climate_extreme_heat_day
-            attribute: forecast_high_f
-            name: "Forecast high"
-            suffix: "°F"
-          - entity: input_number.climate_extreme_heat_threshold
-            name: "Extreme heat threshold"
-          - entity: input_number.climate_extreme_heat_precool_offset
-            name: "Pre-cool offset"
-          - entity: input_boolean.climate_extreme_heat_precool_active
-            name: "Pre-cool active"
-          - entity: binary_sensor.climate_pre_arrival_expected
-            name: "Pre-arrival expected"
+          - type: entities
+            title: "Extreme heat overlay"
+            show_header_toggle: false
+            entities:
+              - entity: binary_sensor.climate_extreme_heat_day
+                name: "Extreme heat day"
+              - entity: sensor.temperature_forecast_high_today
+                name: "Forecast high"
+              - entity: input_number.climate_extreme_heat_threshold
+                name: "Extreme heat threshold"
+              - entity: input_number.climate_extreme_heat_precool_offset
+                name: "Pre-cool offset"
+              - entity: input_boolean.climate_extreme_heat_overlay_enabled
+                name: "Overlay enabled"
+              - entity: input_boolean.climate_extreme_heat_precool_active
+                name: "Pre-cool active"
 
       - type: entities
-        title: "Diagnostics / why"
+        title: "Operational diagnostics"
         show_header_toggle: false
         entities:
           - type: attribute
@@ -318,15 +285,5 @@ views:
             name: "People home"
           - entity: input_boolean.mode_guest
             name: "Guest mode"
-          - type: attribute
-            entity: binary_sensor.climate_extreme_heat_day
-            attribute: decision_scope
-            name: "Hot-day decision scope"
-          - type: attribute
-            entity: binary_sensor.climate_pre_arrival_expected
-            attribute: expected_people
-            name: "Expected arrivals"
-          - type: attribute
-            entity: binary_sensor.climate_pre_arrival_expected
-            attribute: reason
-            name: "Pre-arrival rule"
+          - entity: binary_sensor.climate_pre_arrival_expected
+            name: "Pre-arrival eligible"

--- a/tests/test_climate_dashboard.py
+++ b/tests/test_climate_dashboard.py
@@ -7,6 +7,7 @@ from climate_package_helpers import load_climate_packages
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "dashboards" / "climate_control.yaml"
+WEATHER = ROOT / "packages" / "weather.yaml"
 
 
 def load_climate():
@@ -15,6 +16,10 @@ def load_climate():
 
 def load_dashboard():
     return yaml.safe_load(DASHBOARD.read_text())
+
+
+def load_weather():
+    return yaml.safe_load(WEATHER.read_text())
 
 
 def template_entities(kind):
@@ -30,12 +35,41 @@ def named_template(kind, name):
     raise AssertionError(f"{kind} template {name!r} not found")
 
 
-def graph_card(name):
-    cards = load_dashboard()["views"][0]["cards"]
+def weather_template_sensor(name):
+    for block in load_weather()["template"]:
+        for sensor in block.get("sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"weather template sensor {name!r} not found")
+
+
+def iter_cards(cards):
     for card in cards:
+        yield card
+        nested_cards = card.get("cards", [])
+        if nested_cards:
+            yield from iter_cards(nested_cards)
+        nested_card = card.get("card")
+        if nested_card:
+            yield nested_card
+
+
+def all_cards():
+    return list(iter_cards(load_dashboard()["views"][0]["cards"]))
+
+
+def graph_card(name):
+    for card in all_cards():
         if card.get("type") == "custom:mini-graph-card" and card.get("name") == name:
             return card
     raise AssertionError(f"mini graph card {name!r} not found")
+
+
+def card_by_title(title):
+    for card in all_cards():
+        if card.get("title") == title:
+            return card
+    raise AssertionError(f"card titled {title!r} not found")
 
 
 def assert_graph_detail_card(name, expected_entities):
@@ -152,3 +186,51 @@ def test_air_quality_detail_graph_keeps_sensor_readings_without_hvac_overlays():
         "sensor.thermostat_carbon_dioxide",
         "sensor.thermostat_vocs",
     ])
+
+
+def test_dashboard_separates_operator_tuning_and_diagnostic_sections():
+    dashboard = load_dashboard()
+    top_titles = [card.get("title") for card in dashboard["views"][0]["cards"]]
+
+    assert "Primary operator view" in top_titles
+    assert "Admin tuning" in top_titles
+    assert "Operational diagnostics" in top_titles
+
+    primary = card_by_title("Primary operator view")
+    admin = card_by_title("Admin tuning")
+    diagnostics = card_by_title("Operational diagnostics")
+
+    assert any(card.get("type") == "thermostat" for card in primary["cards"])
+    assert {card.get("title") for card in admin["cards"]} == {
+        "Cooling setpoints",
+        "Heating setpoints",
+        "Extreme heat overlay",
+    }
+    assert diagnostics["type"] == "entities"
+
+
+def test_dashboard_avoids_backend_internal_explanation_attributes():
+    dashboard_text = DASHBOARD.read_text()
+
+    assert "decision_scope" not in dashboard_text
+    assert "expected_people" not in dashboard_text
+    assert "attribute: reason" not in dashboard_text
+    assert "state_attr('binary_sensor.climate_pre_arrival_expected'" not in dashboard_text
+    assert "sensor.temperature_forecast_high_today" in dashboard_text
+
+
+def test_dashboard_uses_weather_owned_forecast_high_sensor():
+    sensor = weather_template_sensor("Temperature forecast high today")
+
+    assert sensor["unique_id"] == "weather_forecast_temperature_high_today"
+    assert "sensor.temperature_forecast_high_today" in DASHBOARD.read_text()
+
+
+def test_dashboard_reuses_graph_configuration_with_yaml_anchors():
+    dashboard_text = DASHBOARD.read_text()
+
+    assert "&climate_activity_graph" in dashboard_text
+    assert "*climate_activity_graph" in dashboard_text
+    assert "&climate_detail_graph" in dashboard_text
+    assert "*climate_detail_graph" in dashboard_text
+    assert dashboard_text.count("hours_to_show: 24") == 2


### PR DESCRIPTION
## Summary
- Separates the climate dashboard into a primary operator view, admin tuning section, and operational diagnostics.
- Reuses common mini-graph-card configuration with YAML anchors to reduce repeated dashboard bulk while preserving existing thermostat, temperature, AQI, CO2, VOC, and HVAC activity visibility.
- Removes dashboard references to backend implementation-detail attributes such as `decision_scope`, `expected_people`, and pre-arrival `reason`; forecast high now reads the weather-owned helper sensor directly.

## Tests / validation
- `python3 -m pytest -q` — 65 passed
- `python3 -m pytest tests/test_climate_dashboard.py tests/test_climate_extreme_heat_overlay.py -q` — 26 passed
- Custom PyYAML parse with Home Assistant tag fallback over 39 YAML files — passed
- `git diff --check` — clean
- `docker run --rm -v "$(pwd):/config" homeassistant/home-assistant:stable hass -c /config --script check_config` — passed
- Independent review subagent — passed; no security concerns or logic errors

Closes #151
