### PR TITLE
Fix air quality detail graph axes

### DIFF
--- a/dashboards/climate_control.yaml
+++ b/dashboards/climate_control.yaml
@@ -190,21 +190,20 @@ views:
           - type: custom:mini-graph-card
             <<: *climate_detail_graph
             name: "Air quality details"
+            show:
+              <<: *climate_detail_show
+              labels_secondary: true
             entities:
-              - entity: sensor.thermostat_air_quality_index
-                name: "AQI"
-                color: "#ff7043"
-                line_width: 4
-                show_fill: false
               - entity: sensor.thermostat_carbon_dioxide
                 name: "CO2"
                 color: "#7e57c2"
-                line_width: 2
+                line_width: 3
                 show_fill: false
               - entity: sensor.thermostat_vocs
                 name: "VOC"
                 color: "#66bb6a"
-                line_width: 2
+                y_axis: secondary
+                line_width: 3
                 show_fill: false
 
       - type: grid

--- a/tests/test_climate_dashboard.py
+++ b/tests/test_climate_dashboard.py
@@ -180,12 +180,26 @@ def test_air_quality_trends_use_aqi_with_hvac_activity_correlation():
     assert_hvac_activity_entities(card)
 
 
-def test_air_quality_detail_graph_keeps_sensor_readings_without_hvac_overlays():
-    assert_graph_detail_card("Air quality details", [
-        "sensor.thermostat_air_quality_index",
+def test_air_quality_detail_graph_splits_co2_and_voc_without_aqi_or_hvac_overlays():
+    card = graph_card("Air quality details")
+
+    assert card["hours_to_show"] == 24
+    assert card["show"]["legend"] is True
+    assert card["show"]["labels"] is True
+    assert card["show"]["labels_secondary"] is True
+    assert card["show"]["points"] is False
+    assert entity_ids(card) == [
         "sensor.thermostat_carbon_dioxide",
         "sensor.thermostat_vocs",
-    ])
+    ]
+    assert "sensor.thermostat_air_quality_index" not in entity_ids(card)
+    assert "binary_sensor.climate_heating_active" not in entity_ids(card)
+    assert "binary_sensor.climate_cooling_active" not in entity_ids(card)
+    assert "y_axis" not in card["entities"][0]
+    assert card["entities"][1]["y_axis"] == "secondary"
+    for entity in card["entities"]:
+        assert entity["show_fill"] is False
+        assert entity["line_width"] == 3
 
 
 def test_dashboard_separates_operator_tuning_and_diagnostic_sections():


### PR DESCRIPTION
## Summary
- Remove AQI from the Air quality details mini-graph so it remains represented only in the higher-level trend card.
- Plot CO2 on the primary axis and VOC on the secondary axis, with secondary labels enabled for readability.
- Update climate dashboard tests to lock the bounded graph contract.

## Validation
- python - <<'PY'
from pathlib import Path
import yaml
for path in [Path("dashboards/climate_control.yaml")]:
    yaml.safe_load(path.read_text())
    print(f"{path}: ok")
PY
- python -m pytest tests/test_climate_dashboard.py
- python -m pytest

Closes #159