### PR TITLE
fix(climate): normalize setpoint helper presentation

### DIFF
--- a/packages/climate_schedule.yaml
+++ b/packages/climate_schedule.yaml
@@ -9,39 +9,39 @@
 input_number:
   climate_heat_morning:
     name: Climate Heat - Morning
-    min: 60
+    min: 55
     max: 80
     step: 1
     unit_of_measurement: °F
-    icon: mdi:thermometer-chevron-up
+    icon: mdi:thermometer
   climate_heat_day:
     name: Climate Heat - Daytime
-    min: 60
+    min: 55
     max: 80
     step: 1
     unit_of_measurement: °F
     icon: mdi:thermometer
   climate_heat_bedtime:
     name: Climate Heat - Bedtime
-    min: 60
+    min: 55
     max: 80
     step: 1
     unit_of_measurement: °F
-    icon: mdi:thermometer-chevron-up
+    icon: mdi:thermometer
   climate_heat_sleep:
     name: Climate Heat - Sleep
-    min: 60
+    min: 55
     max: 80
     step: 1
     unit_of_measurement: °F
-    icon: mdi:thermometer-chevron-down
+    icon: mdi:thermometer
   climate_heat_away:
     name: Climate Heat - Away
     min: 55
-    max: 75
+    max: 80
     step: 1
     unit_of_measurement: °F
-    icon: mdi:thermometer-low
+    icon: mdi:thermometer
   climate_cool_morning:
     name: Climate Cool - Morning
     min: 65
@@ -72,11 +72,11 @@ input_number:
     icon: mdi:snowflake
   climate_cool_away:
     name: Climate Cool - Away
-    min: 70
+    min: 65
     max: 85
     step: 1
     unit_of_measurement: °F
-    icon: mdi:snowflake-thermometer
+    icon: mdi:snowflake
 input_boolean:
   climate_automation_enabled:
     name: Climate Automation

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -121,6 +121,35 @@ def test_climate_schedule_setpoint_helpers_restore_last_ui_value():
         assert "initial" not in config["input_number"][helper]
 
 
+def test_climate_schedule_setpoint_helpers_use_comparable_ui_ranges_and_icons():
+    config = load_climate()
+
+    heat_helpers = [
+        "climate_heat_morning",
+        "climate_heat_day",
+        "climate_heat_bedtime",
+        "climate_heat_sleep",
+        "climate_heat_away",
+    ]
+    cool_helpers = [
+        "climate_cool_morning",
+        "climate_cool_day",
+        "climate_cool_bedtime",
+        "climate_cool_sleep",
+        "climate_cool_away",
+    ]
+
+    for helper in heat_helpers:
+        assert config["input_number"][helper]["min"] == 55
+        assert config["input_number"][helper]["max"] == 80
+        assert config["input_number"][helper]["icon"] == "mdi:thermometer"
+
+    for helper in cool_helpers:
+        assert config["input_number"][helper]["min"] == 65
+        assert config["input_number"][helper]["max"] == 85
+        assert config["input_number"][helper]["icon"] == "mdi:snowflake"
+
+
 def test_extreme_heat_helpers_are_configurable_in_fahrenheit():
     config = load_climate()
 


### PR DESCRIPTION
## Summary
- Normalizes heating schedule helper ranges to 55–80°F and a single thermometer icon.
- Normalizes cooling schedule helper ranges to 65–85°F and a single snowflake icon.
- Adds regression coverage that the schedule setpoint helpers remain visually comparable in the raw dashboard entity rows.

## Test Plan
- `python - <<'PY' ... PY` YAML/static parse for `packages/climate_schedule.yaml`, `dashboards/climate_control.yaml`, and `tests/test_climate_extreme_heat_overlay.py`
- `pytest tests/test_climate_extreme_heat_overlay.py tests/test_climate_dashboard.py`
- `pytest`

Closes #161
