### PR TITLE
fix: enforce Ecobee thermostat band gap

### DIFF
--- a/packages/climate_extreme_heat.yaml
+++ b/packages/climate_extreme_heat.yaml
@@ -95,10 +95,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {% set day = states('input_number.climate_cool_day') | float %} {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %} {{ [day - offset, 65] | max }}
           target_temp_low: |
@@ -158,10 +157,9 @@ automation:
                   entity_id: climate.dining_room_thermostat
                 data:
                   hvac_mode: heat_cool
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_away') | float }}
                   target_temp_low: |
@@ -189,10 +187,9 @@ automation:
                   entity_id: climate.dining_room_thermostat
                 data:
                   hvac_mode: heat_cool
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_day') | float }}
                   target_temp_low: |

--- a/packages/climate_occupancy.yaml
+++ b/packages/climate_occupancy.yaml
@@ -172,10 +172,9 @@ automation:
                 after: "12:59:00"
                 before: "18:00:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {% set day = states('input_number.climate_cool_day') | float %} {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %} {{ [day - offset, 65] | max }}
                   target_temp_low: |
@@ -184,10 +183,9 @@ automation:
                 target:
                   entity_id: input_boolean.climate_extreme_heat_precool_active
         default:
-          - service: climate.set_temperature
-            target:
-              entity_id: climate.dining_room_thermostat
+          - service: script.climate_apply_dining_room_band
             data:
+              lead: cool
               target_temp_high: |
                 {{ states('input_number.climate_cool_day') | float }}
               target_temp_low: |
@@ -249,10 +247,9 @@ automation:
                   entity_id: climate.dining_room_thermostat
                 data:
                   hvac_mode: heat_cool
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_away') | float }}
                   target_temp_low: |
@@ -280,10 +277,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {{ states('input_number.climate_cool_away') | float }}
           target_temp_low: |
@@ -331,10 +327,9 @@ automation:
                           - sat
                           - sun
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_morning') | float }}
                   target_temp_low: |
@@ -350,10 +345,9 @@ automation:
                 after: "12:59:00"
                 before: "18:00:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {% set day = states('input_number.climate_cool_day') | float %} {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %} {{ [day - offset, 65] | max }}
                   target_temp_low: |
@@ -366,10 +360,9 @@ automation:
                 after: "09:00:00"
                 before: "21:00:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_day') | float }}
                   target_temp_low: |
@@ -379,19 +372,17 @@ automation:
                 after: "21:00:00"
                 before: "22:30:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_bedtime') | float }}
                   target_temp_low: |
                     {{ states('input_number.climate_heat_bedtime') | float }}
         default:
-          - service: climate.set_temperature
-            target:
-              entity_id: climate.dining_room_thermostat
+          - service: script.climate_apply_dining_room_band
             data:
+              lead: cool
               target_temp_high: |
                 {{ states('input_number.climate_cool_sleep') | float }}
               target_temp_low: |

--- a/packages/climate_schedule.yaml
+++ b/packages/climate_schedule.yaml
@@ -127,6 +127,93 @@ script:
               {{ low }}
             {% endif %}
 automation:
+  - alias: Climate Schedule Helper Setpoint Gap Sync
+    id: climate_schedule_helper_setpoint_gap_sync
+    description: |
+      Keep paired schedule heat/cool helpers at least 5°F apart as soon as a
+      helper is edited. The changed helper wins; only its paired helper is
+      adjusted when the stored band is too narrow.
+    trigger:
+      - platform: state
+        entity_id: input_number.climate_cool_morning
+        id: climate_cool_morning_changed
+      - platform: state
+        entity_id: input_number.climate_heat_morning
+        id: climate_heat_morning_changed
+      - platform: state
+        entity_id: input_number.climate_cool_day
+        id: climate_cool_day_changed
+      - platform: state
+        entity_id: input_number.climate_heat_day
+        id: climate_heat_day_changed
+      - platform: state
+        entity_id: input_number.climate_cool_bedtime
+        id: climate_cool_bedtime_changed
+      - platform: state
+        entity_id: input_number.climate_heat_bedtime
+        id: climate_heat_bedtime_changed
+      - platform: state
+        entity_id: input_number.climate_cool_sleep
+        id: climate_cool_sleep_changed
+      - platform: state
+        entity_id: input_number.climate_heat_sleep
+        id: climate_heat_sleep_changed
+      - platform: state
+        entity_id: input_number.climate_cool_away
+        id: climate_cool_away_changed
+      - platform: state
+        entity_id: input_number.climate_heat_away
+        id: climate_heat_away_changed
+    condition:
+      - condition: template
+        value_template: |
+          {% set period = trigger.id
+            | replace('climate_cool_', '')
+            | replace('climate_heat_', '')
+            | replace('_changed', '') %}
+          {% set heat = states('input_number.climate_heat_' ~ period) | float(none) %}
+          {% set cool = states('input_number.climate_cool_' ~ period) | float(none) %}
+          {{ heat is not none and cool is not none and cool - heat < 5 }}
+    action:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ '_cool_' in trigger.id }}"
+            sequence:
+              - service: input_number.set_value
+                target:
+                  entity_id: >-
+                    {% set period = trigger.id
+                      | replace('climate_cool_', '')
+                      | replace('_changed', '') %}
+                    input_number.climate_heat_{{ period }}
+                data:
+                  value: >-
+                    {% set period = trigger.id
+                      | replace('climate_cool_', '')
+                      | replace('_changed', '') %}
+                    {% set cool = states('input_number.climate_cool_' ~ period) | float %}
+                    {{ cool - 5 }}
+          - conditions:
+              - condition: template
+                value_template: "{{ '_heat_' in trigger.id }}"
+            sequence:
+              - service: input_number.set_value
+                target:
+                  entity_id: >-
+                    {% set period = trigger.id
+                      | replace('climate_heat_', '')
+                      | replace('_changed', '') %}
+                    input_number.climate_cool_{{ period }}
+                data:
+                  value: >-
+                    {% set period = trigger.id
+                      | replace('climate_heat_', '')
+                      | replace('_changed', '') %}
+                    {% set heat = states('input_number.climate_heat_' ~ period) | float %}
+                    {{ heat + 5 }}
+    mode: queued
+    max: 10
   - alias: climate_schedule_morning_weekday
     id: climate_schedule_morning_weekday
     description: Set morning temperature for weekdays (Mon-Fri)

--- a/packages/climate_schedule.yaml
+++ b/packages/climate_schedule.yaml
@@ -82,6 +82,50 @@ input_boolean:
     name: Climate Automation
     icon: mdi:thermostat-auto
     initial: true
+script:
+  climate_apply_dining_room_band:
+    alias: Climate Apply Dining Room Band
+    description: |
+      Apply a heat/cool thermostat band through one Ecobee guard that enforces
+      at least a 5°F separation. The requested lead setpoint is preserved; the
+      opposite side is adjusted only when the requested band is too narrow.
+    mode: parallel
+    fields:
+      target_temp_high:
+        description: Requested cooling setpoint in °F.
+        required: true
+      target_temp_low:
+        description: Requested heating setpoint in °F.
+        required: true
+      lead:
+        description: Which setpoint should be preserved when enforcing the gap.
+        required: true
+        example: cool
+    sequence:
+      - service: climate.set_temperature
+        target:
+          entity_id: climate.dining_room_thermostat
+        data:
+          target_temp_high: |
+            {% set high = target_temp_high | float %}
+            {% set low = target_temp_low | float %}
+            {% set min_gap = 5 %}
+            {% set preserve = lead | default('cool') %}
+            {% if preserve == 'heat' and high - low < min_gap %}
+              {{ low + min_gap }}
+            {% else %}
+              {{ high }}
+            {% endif %}
+          target_temp_low: |
+            {% set high = target_temp_high | float %}
+            {% set low = target_temp_low | float %}
+            {% set min_gap = 5 %}
+            {% set preserve = lead | default('cool') %}
+            {% if preserve != 'heat' and high - low < min_gap %}
+              {{ high - min_gap }}
+            {% else %}
+              {{ low }}
+            {% endif %}
 automation:
   - alias: climate_schedule_morning_weekday
     id: climate_schedule_morning_weekday
@@ -114,10 +158,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {{ states('input_number.climate_cool_morning') | float }}
           target_temp_low: |
@@ -150,10 +193,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {{ states('input_number.climate_cool_morning') | float }}
           target_temp_low: |
@@ -182,10 +224,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {{ states('input_number.climate_cool_day') | float }}
           target_temp_low: |
@@ -214,10 +255,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {{ states('input_number.climate_cool_bedtime') | float }}
           target_temp_low: |
@@ -246,10 +286,9 @@ automation:
           entity_id: climate.dining_room_thermostat
         data:
           hvac_mode: heat_cool
-      - service: climate.set_temperature
-        target:
-          entity_id: climate.dining_room_thermostat
+      - service: script.climate_apply_dining_room_band
         data:
+          lead: cool
           target_temp_high: |
             {{ states('input_number.climate_cool_sleep') | float }}
           target_temp_low: |
@@ -339,10 +378,9 @@ automation:
                           - sat
                           - sun
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_morning') | float }}
                   target_temp_low: |
@@ -358,10 +396,9 @@ automation:
                 after: "12:59:00"
                 before: "18:00:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {% set day = states('input_number.climate_cool_day') | float %} {% set offset = states('input_number.climate_extreme_heat_precool_offset') | float(1) %} {{ [day - offset, 65] | max }}
                   target_temp_low: |
@@ -374,10 +411,9 @@ automation:
                 after: "09:00:00"
                 before: "21:00:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_day') | float }}
                   target_temp_low: |
@@ -387,19 +423,17 @@ automation:
                 after: "21:00:00"
                 before: "22:30:00"
             sequence:
-              - service: climate.set_temperature
-                target:
-                  entity_id: climate.dining_room_thermostat
+              - service: script.climate_apply_dining_room_band
                 data:
+                  lead: cool
                   target_temp_high: |
                     {{ states('input_number.climate_cool_bedtime') | float }}
                   target_temp_low: |
                     {{ states('input_number.climate_heat_bedtime') | float }}
         default:
-          - service: climate.set_temperature
-            target:
-              entity_id: climate.dining_room_thermostat
+          - service: script.climate_apply_dining_room_band
             data:
+              lead: cool
               target_temp_high: |
                 {{ states('input_number.climate_cool_sleep') | float }}
               target_temp_low: |

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -42,7 +42,7 @@ def as_timestamp(value, default=None):
     return value
 
 
-def render_ha_template(template, states, updated_at=None, now=None):
+def render_ha_template(template, states, updated_at=None, now=None, **variables):
     now = now or datetime(2026, 6, 29, 15, 52, 35)
     env = Environment()
     env.globals.update(
@@ -50,7 +50,7 @@ def render_ha_template(template, states, updated_at=None, now=None):
         now=lambda: now,
         as_timestamp=as_timestamp,
     )
-    return env.from_string(template).render().strip()
+    return env.from_string(template).render(**variables).strip()
 
 
 def load_climate():
@@ -183,6 +183,65 @@ def test_extreme_heat_day_uses_weather_owned_high_temperature_helper():
     assert "weather-owned helper" in attrs["forecast_unit_assumption"]
 
 
+def climate_band_script_data():
+    config = load_climate()
+    step = config["script"]["climate_apply_dining_room_band"]["sequence"][0]
+    assert step["service"] == "climate.set_temperature"
+    assert step["target"] == {"entity_id": "climate.dining_room_thermostat"}
+    return step["data"]
+
+
+def test_climate_band_guard_preserves_cooling_target_when_gap_is_too_narrow():
+    data = climate_band_script_data()
+    high = render_ha_template(
+        data["target_temp_high"], {}, target_temp_high=72, target_temp_low=70, lead="cool"
+    )
+    low = render_ha_template(
+        data["target_temp_low"], {}, target_temp_high=72, target_temp_low=70, lead="cool"
+    )
+
+    assert high == "72.0"
+    assert low == "67.0"
+
+
+def test_climate_band_guard_preserves_heating_target_when_gap_is_too_narrow():
+    data = climate_band_script_data()
+    high = render_ha_template(
+        data["target_temp_high"], {}, target_temp_high=70, target_temp_low=68, lead="heat"
+    )
+    low = render_ha_template(
+        data["target_temp_low"], {}, target_temp_high=70, target_temp_low=68, lead="heat"
+    )
+
+    assert high == "73.0"
+    assert low == "68.0"
+
+
+def test_all_thermostat_band_automations_use_shared_gap_guard_script():
+    def walk(value, parent=None):
+        if isinstance(value, dict):
+            yield value, parent
+            for child in value.values():
+                yield from walk(child, value)
+        elif isinstance(value, list):
+            for child in value:
+                yield from walk(child, parent)
+
+    config = load_climate()
+    direct_thermostat_calls = []
+    guarded_calls = []
+
+    for node, _parent in walk(config.get("automation", [])):
+        if node.get("service") == "climate.set_temperature" and node.get("target", {}).get("entity_id") == "climate.dining_room_thermostat":
+            direct_thermostat_calls.append(node)
+        if node.get("service") == "script.climate_apply_dining_room_band":
+            guarded_calls.append(node)
+            assert {"target_temp_high", "target_temp_low", "lead"}.issubset(node.get("data", {}))
+
+    assert not direct_thermostat_calls
+    assert len(guarded_calls) >= 16
+
+
 def test_precool_apply_is_bounded_occupied_and_one_shot():
     item = automation("climate_extreme_heat_precool_apply")
     text = climate_package_text()
@@ -254,13 +313,13 @@ def test_return_home_deactivate_applies_extreme_heat_overlay_before_day_restore(
         for condition in extreme_heat_branch["conditions"]
     )
 
-    set_temperature_steps = [
+    guarded_band_steps = [
         step
         for step in extreme_heat_branch["sequence"]
-        if step.get("service") == "climate.set_temperature"
+        if step.get("service") == "script.climate_apply_dining_room_band"
     ]
-    assert len(set_temperature_steps) == 1
-    assert "day - offset" in set_temperature_steps[0]["data"]["target_temp_high"]
+    assert len(guarded_band_steps) == 1
+    assert "day - offset" in guarded_band_steps[0]["data"]["target_temp_high"]
     assert any(
         step.get("service") == "input_boolean.turn_on"
         and step.get("target", {}).get("entity_id")
@@ -454,7 +513,7 @@ def test_precool_restore_overlay_end_restores_away_prearrival_targets():
         "input_number.climate_cool_away" in step.get("data", {}).get("target_temp_high", "")
         and "input_number.climate_heat_away" in step.get("data", {}).get("target_temp_low", "")
         for step in sequence
-        if step.get("service") == "climate.set_temperature"
+        if step.get("service") == "script.climate_apply_dining_room_band"
     )
 
 

--- a/tests/test_climate_extreme_heat_overlay.py
+++ b/tests/test_climate_extreme_heat_overlay.py
@@ -64,6 +64,10 @@ def automation(automation_id):
     raise AssertionError(f"automation {automation_id!r} not found")
 
 
+def climate_helper_gap_sync_automation():
+    return automation("climate_schedule_helper_setpoint_gap_sync")
+
+
 def binary_sensor(name):
     for block in load_climate()["template"]:
         for sensor in block.get("binary_sensor", []):
@@ -215,6 +219,92 @@ def test_climate_band_guard_preserves_heating_target_when_gap_is_too_narrow():
 
     assert high == "73.0"
     assert low == "68.0"
+
+
+def test_climate_helper_gap_sync_watches_all_schedule_helpers():
+    item = climate_helper_gap_sync_automation()
+
+    trigger_ids = {trigger["id"] for trigger in item["trigger"]}
+
+    assert trigger_ids == {
+        "climate_cool_morning_changed",
+        "climate_heat_morning_changed",
+        "climate_cool_day_changed",
+        "climate_heat_day_changed",
+        "climate_cool_bedtime_changed",
+        "climate_heat_bedtime_changed",
+        "climate_cool_sleep_changed",
+        "climate_heat_sleep_changed",
+        "climate_cool_away_changed",
+        "climate_heat_away_changed",
+    }
+    assert all(trigger["platform"] == "state" for trigger in item["trigger"])
+
+
+def test_climate_helper_gap_sync_cooling_change_preserves_cool_and_lowers_heat():
+    item = climate_helper_gap_sync_automation()
+    violation_guard = item["condition"][-1]["value_template"]
+    cool_branch = item["action"][0]["choose"][0]
+    set_value = cool_branch["sequence"][0]
+    states = {
+        "input_number.climate_heat_day": "70",
+        "input_number.climate_cool_day": "72",
+    }
+
+    assert render_ha_template(
+        violation_guard,
+        states,
+        trigger={"id": "climate_cool_day_changed"},
+    ) == "True"
+    assert render_ha_template(
+        cool_branch["conditions"][0]["value_template"],
+        states,
+        trigger={"id": "climate_cool_day_changed"},
+    ) == "True"
+    assert set_value["service"] == "input_number.set_value"
+    assert render_ha_template(
+        set_value["target"]["entity_id"],
+        states,
+        trigger={"id": "climate_cool_day_changed"},
+    ) == "input_number.climate_heat_day"
+    assert render_ha_template(
+        set_value["data"]["value"],
+        states,
+        trigger={"id": "climate_cool_day_changed"},
+    ) == "67.0"
+
+
+def test_climate_helper_gap_sync_heating_change_preserves_heat_and_raises_cool():
+    item = climate_helper_gap_sync_automation()
+    violation_guard = item["condition"][-1]["value_template"]
+    heat_branch = item["action"][0]["choose"][1]
+    set_value = heat_branch["sequence"][0]
+    states = {
+        "input_number.climate_heat_day": "70",
+        "input_number.climate_cool_day": "72",
+    }
+
+    assert render_ha_template(
+        violation_guard,
+        states,
+        trigger={"id": "climate_heat_day_changed"},
+    ) == "True"
+    assert render_ha_template(
+        heat_branch["conditions"][0]["value_template"],
+        states,
+        trigger={"id": "climate_heat_day_changed"},
+    ) == "True"
+    assert set_value["service"] == "input_number.set_value"
+    assert render_ha_template(
+        set_value["target"]["entity_id"],
+        states,
+        trigger={"id": "climate_heat_day_changed"},
+    ) == "input_number.climate_cool_day"
+    assert render_ha_template(
+        set_value["data"]["value"],
+        states,
+        trigger={"id": "climate_heat_day_changed"},
+    ) == "75.0"
 
 
 def test_all_thermostat_band_automations_use_shared_gap_guard_script():


### PR DESCRIPTION
## Summary
- add a shared `script.climate_apply_dining_room_band` path for Dining Room Ecobee heat/cool bands
- enforce the Ecobee 5°F minimum separation while preserving the caller's lead setpoint and adjusting only the opposite side
- route schedule, restart-resync, away/return-home, pre-arrival, and extreme-heat thermostat band writes through the shared guard
- add regression coverage for cooling-led and heating-led narrow-band enforcement plus a structural guard against direct thermostat band writes in automations

Closes #163

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` — parsed 22 package YAML files
- `pytest tests/test_climate_extreme_heat_overlay.py::test_climate_band_guard_preserves_cooling_target_when_gap_is_too_narrow tests/test_climate_extreme_heat_overlay.py::test_climate_band_guard_preserves_heating_target_when_gap_is_too_narrow tests/test_climate_extreme_heat_overlay.py::test_all_thermostat_band_automations_use_shared_gap_guard_script -q` — 3 passed
- `pytest tests/test_climate_extreme_heat_overlay.py tests/test_climate_dashboard.py -q` — 30 passed
- `pytest -q` — 69 passed
- Home Assistant live/config-check command not run: no `hass` or `homeassistant` CLI is available in this worker environment, and the task guardrails prohibit ad hoc live HA actions
