### PR TITLE
fix(security): wait for away lock state to settle

### DIFF
--- a/packages/security_sanity.yaml
+++ b/packages/security_sanity.yaml
@@ -27,6 +27,20 @@ script:
               - "night"
               - "away"
     sequence:
+      # Away mode issues the front-door lock command as the alarm arms, so give
+      # the lock entity a bounded chance to report locked before calculating
+      # findings. A real failure still times out and alerts below.
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ (check_context | default('night')) == 'away' and
+                     not is_state('lock.front_door', 'locked') }}
+            sequence:
+              - wait_template: "{{ is_state('lock.front_door', 'locked') }}"
+                timeout: "00:00:45"
+                continue_on_timeout: true
+
       - variables:
           security_context: "{{ check_context | default('night') }}"
           expected_alarm_state: >

--- a/tests/test_security_sanity.py
+++ b/tests/test_security_sanity.py
@@ -24,6 +24,36 @@ def script_step_services(script):
     return [step.get("service") for step in script["sequence"] if isinstance(step, dict)]
 
 
+def test_secure_house_away_context_waits_for_front_door_to_settle_before_reading_state():
+    package = load_yaml(SECURITY)
+    script = package["script"]["secure_house_sanity_check"]
+    settle_step = script["sequence"][0]
+    variables_step = script["sequence"][1]
+
+    assert "choose" in settle_step
+    settle_choice = settle_step["choose"][0]
+    assert settle_choice["conditions"] == [
+        {
+            "condition": "template",
+            "value_template": (
+                "{{ (check_context | default('night')) == 'away' and\n"
+                "   not is_state('lock.front_door', 'locked') }}\n"
+            ),
+        }
+    ]
+    assert settle_choice["sequence"] == [
+        {
+            "wait_template": "{{ is_state('lock.front_door', 'locked') }}",
+            "timeout": "00:00:45",
+            "continue_on_timeout": True,
+        }
+    ]
+    assert "variables" in variables_step
+    assert variables_step["variables"]["front_door_state"] == (
+        "{{ states('lock.front_door') }}"
+    )
+
+
 def test_secure_house_sanity_script_aggregates_and_stays_notify_first():
     package = load_yaml(SECURITY)
     script = package["script"]["secure_house_sanity_check"]
@@ -37,6 +67,7 @@ def test_secure_house_sanity_script_aggregates_and_stays_notify_first():
     assert "findings.items | join" in text
     assert "mismatch_count | int > 0" in text
     assert "1 if front_door_state != 'locked' else 0" in text
+    assert "continue_on_timeout: true" in text
     assert "Guest Mode is on" in text
 
     services = script_step_services(script)


### PR DESCRIPTION
## Bug Description

Fixes #165.

The away-mode secure-house check could read `lock.front_door` while the lock command issued by the alarm-away flow was still settling, producing a false unlocked notification even though the lock later reported `locked`.

## Root Cause

`script.secure_house_sanity_check` sampled the front-door lock state once. The everyone-left automation waited a fixed 15 seconds before invoking the script, but the script itself had no bounded settle/retry behavior before calculating security findings.

## Fix

- Added an away-context-only bounded wait before the secure-house script snapshots `lock.front_door`.
- The wait exits as soon as the lock reports `locked`, avoiding the false alert path.
- The wait times out after 45 seconds and continues into the existing mismatch calculation, so a genuine failure to lock still produces the secure-house alert.
- Added regression coverage asserting the away-context settle wait happens before `front_door_state` is read.

## How to Verify

1. Review `packages/security_sanity.yaml` and confirm the away-context wait precedes the variables snapshot.
2. Run `python3 -m pytest tests/test_security_sanity.py`.
3. Run `python3 -m pytest`.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Parsed changed YAML with PyYAML
- [x] Attempted yamllint; local tool is not installed

## Risk Assessment

Low — the change is bounded to the consolidated secure-house sanity script and only waits when `check_context` is `away` and the front door is not already locked. Night checks keep their existing behavior, and timeout fallback preserves real failure alerts.
