### PR TITLE
docs: rewrite Home Assistant repository docs

### DIFF
--- a/.github/CI-README.md
+++ b/.github/CI-README.md
@@ -1,69 +1,40 @@
 # Home Assistant Configuration CI
 
-This directory contains GitHub Actions workflows for continuous integration of the Home Assistant configuration.
+This directory contains GitHub Actions configuration for repository validation.
 
-## Validation Workflow
+## Validation workflow
 
-The `validate.yaml` workflow consists of three separate jobs:
+The active workflow is `.github/workflows/validate.yaml` and is named `Check`. It runs on pushes and pull requests.
 
-1. **YAML Linting**: Checks the syntax and style of all YAML files in the repository
-2. **Home Assistant Config Check**: Validates Home Assistant configuration using a container-based approach
-3. **Notify Results**: Adds comments to pull requests indicating success or failure
+The current job is:
 
-The workflow runs on every push to `main` branch and on pull requests that change YAML files. You can also trigger it manually through the GitHub Actions UI.
+1. **Home Assistant Core Configuration Check**
+   - Checks out the repository.
+   - Creates a dummy `SERVICE_ACCOUNT.json` with the fields required by `configuration.yaml`.
+   - Creates `.storage/` for Home Assistant runtime expectations.
+   - Runs `frenck/action-home-assistant@v1.4.1` with `version: stable`.
 
-## How it Works
+The workflow currently sets `continue-on-error: true` on the Home Assistant check step, so review the logs even when GitHub reports the job as non-blocking.
 
-### YAML Linting
-This job uses `yamllint` with custom rules defined in `.github/yamllint-config.yaml` to check for:
-- Proper indentation (2 spaces)
-- Line length (max 120 characters)
-- Home Assistant specific truthy values
-- Other YAML syntax rules
+## Local validation
 
-### Home Assistant Config Check
-This job:
-1. Creates dummy files for sensitive information (SERVICE_ACCOUNT.json, secrets.yaml)
-2. Uses a dedicated Home Assistant container to validate the configuration
-3. Reports validation errors without requiring actual credentials
-
-## Local Validation
-
-To validate your configuration locally before pushing, you can run:
+For configuration changes, prefer safe static checks first. If Docker and the required local context are available, a Home Assistant-style check can be run with:
 
 ```bash
-# Using the Home Assistant CLI
-hass --script check_config --config .
-
-# Using Docker (more similar to the CI environment)
-docker run --rm -v $(pwd):/config homeassistant/home-assistant:stable hass -c /config --script check_config
+docker run --rm -v "$(pwd):/config" homeassistant/home-assistant:stable hass -c /config --script check_config
 ```
 
-## YAMLLint Configuration
+For documentation-only changes, a package inventory check and Markdown review is usually the relevant validation.
 
-The `.github/yamllint-config.yaml` file contains custom rules optimized for Home Assistant configuration:
+## Secrets and generated files
 
-- Line length limit: 120 characters
-- Indentation: 2 spaces
-- Special handling for Home Assistant's truthy values
-- Ignores directories like `.storage/`, `themes/`, and `blueprints/`
-
-## Handling Secrets
-
-The workflow creates dummy versions of:
-- SERVICE_ACCOUNT.json
-- secrets.yaml (if used)
-
-This allows validation without exposing sensitive information in the repository.
+The workflow uses dummy credential material only. Do not commit real Home Assistant secrets, `.storage/`, database files, generated exports, or service account credentials.
 
 ## Troubleshooting
 
 If validation fails:
 
-1. Check the workflow logs for detailed error messages
-2. Common issues include:
-   - Indentation errors
-   - Missing or incorrect entity references
-   - Invalid service calls
-   - Syntax errors in templates
-   - References to missing files or secrets
+1. Read the workflow logs for the exact Home Assistant error.
+2. Check changed YAML indentation, entity IDs, service names, and template syntax.
+3. Confirm any newly referenced include files exist in the repository.
+4. Confirm no live-only credential or runtime file was accidentally required by the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,72 +1,85 @@
 # Contributing Guide
 
-Thank you for your interest in contributing to this Home Assistant configuration! This document provides guidelines and processes to follow when making changes.
+Thank you for helping improve this Home Assistant configuration. This repository is a live smart-home configuration, so changes should be small, reviewable, and validated before they are proposed for integration.
 
-## Getting Started
+## Before starting
 
-1. Read the [DEVELOPMENT.md](DEVELOPMENT.md) file for detailed workflow information
-2. Check existing [GitHub issues](https://github.com/yourusername/home-assistant-config/issues) for current work
-3. Fork the repository if you're not already a collaborator
+1. Read `DEVELOPMENT.md` for the detailed workflow and implementation standards.
+2. Check existing GitHub issues at https://github.com/bcl1713/homeassistant_config/issues.
+3. Comment on the issue you plan to work on, or create one if the change is not already tracked.
+4. Work only in the repository checkout unless a task explicitly authorizes live Home Assistant changes.
 
-## Contribution Process
+## Branch and pull-request flow
 
-### 1. Pick an Issue or Create One
+The normal integration branch is `dev`. Do not branch from `main` for ordinary feature, fix, automation, or documentation work.
 
-- Browse existing issues or create a new one
-- Comment on the issue you'd like to work on to avoid duplication of effort
-
-### 2. Branch Management
-
-Follow these branching conventions:
-- Feature branches: `feature/descriptive-name`
-- Bug fixes: `fix/descriptive-name`
-- Documentation: `docs/descriptive-name`
-
-Always start from the latest main branch:
 ```bash
-git checkout main
-git pull origin main
-git checkout -b feature/your-feature-name
+git fetch origin
+git checkout dev
+git pull origin dev
+git checkout -b docs/short-description
 ```
 
-### 3. Development Standards
+Use focused branch names:
 
-Please follow these standards:
-- Use 2-space indentation in YAML files
-- Follow existing naming conventions
-- Group related configurations logically
-- Add sufficient comments to explain complex automations
-- Test all changes before submitting
+- `feature/descriptive-name` for new user-facing behavior.
+- `fix/descriptive-name` for bug fixes.
+- `docs/descriptive-name` for documentation-only changes.
+- `chore/descriptive-name` for maintenance.
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed standards.
+Open pull requests against `dev`:
 
-### 4. Commit Messages
-
-Use conventional commit format:
+```bash
+gh pr create --base dev --title "docs: update package documentation" --body "Summary..."
 ```
+
+`main` is reserved for the established release gate. Do not self-merge to `main`.
+
+## Development standards
+
+- Use the existing package structure instead of adding unrelated logic to `configuration.yaml`.
+- Use 2-space YAML indentation.
+- Follow existing entity, helper, script, and automation naming conventions.
+- Add comments for complex templates or non-obvious automation logic.
+- Keep package boundaries clear; cross-cutting notifier/dashboard contracts belong in `packages/shared_infrastructure.yaml`.
+- Do not commit secrets, `.storage/`, generated exports, runtime databases, or credential files.
+
+## Testing and validation
+
+Before opening a pull request:
+
+1. Review the diff for accidental entity renames, indentation mistakes, unrelated refactors, and secret leakage.
+2. Run the most relevant local validation available for the change.
+3. For documentation-only changes, verify package inventories and links by inspection or script.
+4. For Home Assistant configuration changes, prefer safe static validation first. Run a full Home Assistant config check only when a known-safe local command/environment is available.
+5. Do not reload or restart the live Home Assistant host unless the task explicitly authorizes it and includes the intended rollback/safety path.
+
+## Commit messages
+
+Use conventional commits:
+
+```text
 <type>(<scope>): <description>
 
 [optional body]
-
-[optional footer(s)]
 ```
 
 Examples:
-- `feat(security): add camera motion detection notifications`
-- `fix(automation): correct good night routine condition check`
-- `docs(README): update with new security camera instructions`
 
-### 5. Pull Request Process
+- `feat(security): add camera motion notifications`
+- `fix(climate): preserve thermostat band gap`
+- `docs(packages): refresh active package inventory`
 
-1. Push your branch to GitHub
-2. Create a pull request to merge into main
-3. Reference the issue number in the PR description
-4. Wait for review and address any feedback
+Common types are `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, and `ci`.
 
-## Code of Conduct
+## Pull request checklist
 
-- Be respectful and inclusive in all communications
-- Provide constructive feedback
-- Help maintain a welcoming environment for contributors of all skill levels
+A good PR should include:
 
-Thank you for helping to improve this Home Assistant configuration!
+- A concise summary of what changed.
+- The issue number, when applicable.
+- Validation performed.
+- Any live Home Assistant actions intentionally not performed.
+- Documentation impact, especially when packages, dashboards, helpers, or operator workflows change.
+
+Wait for the reviewer gate and the established integration flow before merge.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,283 +1,151 @@
 # Home Assistant Development Guide
 
-This document outlines consistent workflows and processes to follow when making changes to this Home Assistant configuration. Following these guidelines will ensure consistent, high-quality contributions that align with the project's standards and make the system more maintainable.
+This guide documents the safe development workflow for this Home Assistant configuration repository. The repository is treated as source-controlled infrastructure: make changes in Git, validate locally where possible, open a pull request to `dev`, and let the reviewer/integration gate decide when changes advance.
 
-## Development Workflow
+## Development workflow
 
-### 1. Feature Selection and Planning
+### 1. Plan the change
 
-When selecting a new feature or automation to implement:
+- Check existing GitHub issues before starting new work.
+- Create or update an issue for non-trivial changes.
+- Identify the owning package, dashboard, script, blueprint, or root include before editing.
+- Keep live Home Assistant side effects out of normal development unless a task explicitly authorizes them.
 
-1. **Check GitHub issues** to see if it's already being worked on
-2. **Understand dependencies** - identify if the feature depends on other incomplete components
-3. **Create a GitHub issue** if one doesn't exist:
-   ```
-   gh issue create --title "Feature Name" --body "Description..." --label "enhancement,category"
-   ```
+### 2. Branch from `dev`
 
-### 2. Branch Management
+Always start ordinary work from the latest `dev` branch:
 
-1. **Always start from the latest `dev` branch**:
+```bash
+git fetch origin
+git checkout dev
+git pull origin dev
+```
+
+Create a focused branch:
+
+```bash
+git checkout -b feature/descriptive-name
+git checkout -b fix/descriptive-name
+git checkout -b docs/descriptive-name
+git checkout -b chore/descriptive-name
+```
+
+Target pull requests at `dev`. Do not merge automation or configuration changes directly to `main`; `main` is reserved for the established release gate.
+
+### 3. Understand repository structure
+
+`configuration.yaml` intentionally stays small and delegates most behavior to includes:
+
+- `homeassistant.packages: !include_dir_named packages` loads feature packages.
+- `automation: !include_dir_merge_list automation` loads standalone automations.
+- `input_boolean: !include_dir_merge_named input_boolean` loads helper modes.
+- `scene: !include scenes.yaml` loads scenes.
+- `recorder: !include recorder.yaml` and `logbook: !include logbook.yaml` keep history/logging configuration separate.
+
+Feature packages live in `packages/`. Shared package-level contracts live in `packages/shared_infrastructure.yaml`, currently including `notify.all_mobile_devices` and YAML Lovelace dashboard registration.
+
+Dedicated operator dashboards live in `dashboards/` and are registered by shared infrastructure. ESPHome device YAML lives in `esphome/`. Utility scripts live in `scripts/`.
+
+### 4. Package design standards
+
+- Keep related helpers, templates, scripts, and automations in the owning feature package.
+- Do not add unrelated feature logic directly to `configuration.yaml`.
+- Put shared notifier/dashboard/root-level contracts in `shared_infrastructure.yaml` rather than redefining them in feature packages.
+- Split complex domains by responsibility. The climate subsystem is the current example:
+  - `climate_schedule.yaml` owns baseline setpoints and schedule application.
+  - `climate_occupancy.yaml` owns away, return-home, and pre-arrival behavior.
+  - `climate_extreme_heat.yaml` owns hot-day/pre-cool overlay behavior.
+  - `climate_diagnostics.yaml` owns read-only dashboard diagnostics.
+- Update `packages/README.md` whenever an active `packages/*.yaml` file is added, renamed, removed, enabled, or disabled.
+
+### 5. YAML and automation standards
+
+- Use 2-space YAML indentation.
+- Keep lines reasonably short and readable.
+- Prefer descriptive entity, helper, script, and automation names.
+- Add comments for complex templates or safety-sensitive behavior.
+- Use helper entities for user-tunable thresholds and enable flags.
+- Choose Home Assistant automation modes deliberately (`single`, `restart`, `queued`, `parallel`).
+- Add timeouts to waits where an automation could otherwise hang.
+- Avoid broad refactors while making a focused behavior or documentation change.
+
+### 6. Dashboards and operator views
+
+- Put dedicated YAML dashboards under `dashboards/`.
+- Register YAML dashboards from `packages/shared_infrastructure.yaml`.
+- Keep dashboard-facing diagnostic sensors in the package that owns the data.
+- Document new operator views in `README.md` and any feature-specific package documentation.
+
+Current YAML dashboards:
+
+- `dashboards/climate_control.yaml` for climate operations and diagnostics.
+- `dashboards/window_ventilation.yaml` for advisory ventilation recommendations.
+
+### 7. Notifications
+
+Use `notify.all_mobile_devices` for household-wide mobile fan-out unless the package has a deliberate narrower target. The shared notify group is defined in `packages/shared_infrastructure.yaml` so feature packages can consume a stable contract.
+
+Notification-heavy packages should clearly document enable flags, thresholds, action identifiers, and reset behavior inside the package or package README entry.
+
+### 8. Testing and validation
+
+Before considering a change complete:
+
+1. Review the diff for accidental entity renames, formatting-only churn, unrelated edits, and secrets.
+2. Parse or lint changed YAML where practical.
+3. Run repository tests when they cover the changed area.
+4. For documentation-only changes, verify package/documentation inventories by script or manual checklist.
+5. Run a Home Assistant config check only when the task or environment provides a known-safe local command. Do not assume access to the live instance is safe.
+6. Do not reload or restart the live Home Assistant host as part of routine development unless explicitly authorized.
+
+The GitHub workflow in `.github/workflows/validate.yaml` prepares dummy credential material and runs a Home Assistant Core configuration check using `frenck/action-home-assistant`.
+
+### 9. Commit guidelines
+
+Use conventional commits:
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+```
+
+Common types:
+
+- `feat`: new automation or user-facing behavior
+- `fix`: bug fix
+- `docs`: documentation changes
+- `test`: tests or validation fixtures
+- `refactor`: restructuring without intended behavior change
+- `chore`: maintenance
+- `ci`: workflow or validation changes
+
+Examples:
+
+```text
+feat(security): add camera motion notifications
+fix(climate): preserve thermostat band gap
+docs(packages): refresh active package inventory
+```
+
+### 10. Pull requests and integration
+
+1. Stage only the files needed for the change.
+2. Commit with a conventional commit message.
+3. Push the branch.
+4. Open a pull request against `dev`:
+
    ```bash
-   git checkout dev
-   git pull origin dev
+   gh pr create --base dev --title "docs: refresh repository documentation" --body "Summary..."
    ```
 
-2. **Create focused branches** with consistent naming:
-   ```bash
-   git checkout -b feature/descriptive-name
-   ```
-   For bug fixes:
-   ```bash
-   git checkout -b fix/descriptive-name
-   ```
-   For documentation or maintenance work:
-   ```bash
-   git checkout -b docs/descriptive-name
-   git checkout -b chore/descriptive-name
-   ```
-
-3. **Keep branches focused** on a single feature or bug fix
-4. **Target pull requests at `dev`**. Do not merge automation changes directly to `main`.
-
-### 3. Implementation Standards
-
-Follow these standards for all Home Assistant configuration changes:
-
-0. **Repository structure**:
-   - `packages: !include_dir_named packages` loads feature packages
-   - `packages/shared_infrastructure.yaml` owns shared package contracts such as `notify.all_mobile_devices` and YAML Lovelace dashboard registration; feature packages may consume these contracts but should not redefine them ad hoc
-   - `automation: !include_dir_merge_list automation` loads standalone automation files
-   - `input_boolean: !include_dir_merge_named input_boolean` loads helper toggles
-   - Prefer extending the existing modular structure instead of placing unrelated logic in `configuration.yaml`
-   - Keep complex packages split by responsibility when a domain has distinct helper, automation, and dashboard-facing layers; for example climate is split into schedule, occupancy, extreme-heat overlay, and diagnostics packages
-
-1. **Package structure**:
-   - Place new integrations in appropriate `packages/` directories
-   - Follow existing patterns in similar packages
-   - Create subpackages when appropriate for complex features
-
-2. **Configuration design**:
-   - Group related automations, scripts, and entities logically
-   - Use descriptive entity names with consistent naming conventions
-   - Leverage input booleans for user-toggleable features
-   - Use variables and templates to reduce duplication
-
-3. **Automation structure**:
-   - Each automation should have a clear purpose defined in its alias and description
-   - Group conditions logically
-   - Use appropriate action sequences with proper error handling
-   - Consider using blueprints for reusable automation patterns
-
-4. **YAML formatting**:
-   - Use 2-space indentation
-   - Keep lines to a reasonable length (around 80-100 characters)
-   - Use YAML lists and dictionaries appropriately
-   - Be consistent with quoting strings
-
-5. **Comment standards**:
-   - Add a header comment to each file explaining its purpose
-   - Document complex templates or non-obvious automation logic
-   - Use consistent comment formatting
-
-### 4. Testing
-
-Before considering a feature complete:
-
-1. **Prefer safe static validation first**:
-   - Parse changed YAML files
-   - Run repository-provided documentation or lint checks when available
-   - Review diffs for accidental entity renames, indentation problems, or package loading mistakes
-
-2. **Run a Home Assistant config check only when the task or repo provides a known-safe local command/environment**:
-   - Do not assume ad hoc access to a live instance is safe
-   - Do not rely on live reloads or restarts as part of normal development verification
-
-3. **Test in isolation** when possible:
-   - Validate scripts independently
-   - Verify template syntax in a safe development context
-
-4. **Verify Lovelace integration** if adding UI elements
-
-5. **Monitor logs** for any errors or warnings related to your changes when a task explicitly includes a safe log-review path
-
-### 5. Commit Guidelines
-
-Follow the established commit message format:
-
-1. **Use conventional commits**:
-   ```
-   <type>(<scope>): <description>
-   
-   [optional body]
-   
-   [optional footer(s)]
-   ```
-
-2. **Types**:
-   - `feat`: New feature or automation
-   - `fix`: Bug fix
-   - `docs`: Documentation changes
-   - `style`: Formatting, no code change
-   - `refactor`: Code change that neither fixes a bug nor adds a feature
-   - `perf`: Code change that improves performance
-   - `test`: Adding test configurations
-   - `chore`: Changes to auxiliary tools/configurations
-
-3. **Scope** should be the package or component being modified
-
-4. **Description** should be concise and descriptive in imperative mood
-
-5. **Example commits**:
-   ```
-   feat(security): add camera motion detection notifications
-   
-   docs(README): update with new security camera instructions
-   
-   fix(automation): correct good night routine condition check
-   ```
-
-### 6. Pull Request and Merging
-
-For completing a feature:
-
-1. **Verify all files are included** in the commit
-
-2. **Push branch** to GitHub:
-   ```bash
-   git push origin feature/feature-name
-   ```
-
-3. **Create a pull request** to merge into `dev`:
-   ```bash
-   gh pr create --title "Feature: Add descriptive name" --body "Description and closes #ISSUE_NUMBER" --base dev
-   ```
-
-4. **Wait for review** if working with others, or verify quality if self-reviewing
-
-5. **Merge to `dev`** once approved:
-   ```bash
-   gh pr merge --squash
-   ```
-
-6. **Do not self-merge automation changes**; wait for reviewer approval and the established integration flow.
-
-7. **Close related GitHub issue** if not auto-closed:
-   ```bash
-   gh issue close ISSUE_NUMBER
-   ```
-
-## Feature Implementation Patterns
-
-### Adding a New Package
-
-When adding a new package:
-
-1. **Create package file** in appropriate location (e.g., `packages/new-feature.yaml`)
-
-2. **Follow package template**:
-   ```yaml
-   # packages/new-feature.yaml
-   #
-   # Description of what this package does
-   #
-   # Features:
-   # - Feature 1
-   # - Feature 2
-   
-   # Configuration
-   [configuration sections]
-   
-   # Automations
-   automation:
-     - alias: "Feature Automation"
-       description: "Detailed description"
-       trigger:
-         [triggers]
-       condition:
-         [conditions]
-       action:
-         [actions]
-   
-   # Scripts
-   script:
-     feature_script:
-       alias: "Feature Script"
-       sequence:
-         [sequence]
-   
-   # Other components as needed
-   ```
-
-3. **Reference in `configuration.yaml`** if needed for global imports
-
-### Creating Automations
-
-For complex automation implementation:
-
-1. **Consider using blueprints** for reusable patterns
-
-2. **Break complex sequences** into separate scripts for better maintainability
-
-3. **Use helper entities** to track states and reduce complexity:
-   - Input booleans for modes and flags
-   - Input selects for multi-state options
-   - Input numbers for thresholds
-
-4. **Implement proper error handling**:
-   - Choose appropriate action modes (single, restart, parallel, etc.)
-   - Add timeouts to wait_for actions
-   - Include notification for critical failures
-
-### Implementing Device Integration
-
-When adding new device integrations:
-
-1. **Verify entity naming** follows project conventions
-
-2. **Group related devices** with appropriate groups
-
-3. **Create consistent UI cards** for the device
-
-4. **Test compatibility** with existing automations
-
-5. **Document any special setup requirements** for the device
-
-### Common Troubleshooting
-
-When troubleshooting issues:
-
-1. **Check Home Assistant logs** for errors when the task explicitly includes a safe way to do so:
-   ```bash
-   tail -f home-assistant.log
-   ```
-
-2. **Verify YAML syntax** is correct
-
-3. **Test templates** in a safe development environment before relying on live behavior
-
-4. **Check entity availability** before referencing in automations
-
-5. **Do not restart or reload Home Assistant as part of routine development work unless the task explicitly authorizes the live action and rollback plan**
-
-6. **Review entity history** to understand state changes
-
-## Best Practices
-
-1. **Use packages** to organize complex configurations
-
-2. **Leverage templates** for dynamic content
-
-3. **Keep automations focused** on single tasks
-
-4. **Document complex logic** with comments
-
-5. **Use meaningful names** for all entities and scripts
-
-6. **Test all edge cases** before considering implementation complete
-
-7. **Keep UI clean and intuitive** for all users
-
-8. **Maintain consistency** with existing configuration patterns
-
-By following this guide, all contributions will maintain a consistent, high-quality standard that ensures the Home Assistant configuration remains maintainable and reliable over time.
+5. Include a summary, validation performed, linked issue, and documentation impact.
+6. Wait for review and address feedback.
+7. Do not self-merge to `main`.
+
+## Troubleshooting notes
+
+- If validation fails, read the failing workflow/test output before editing.
+- Check sibling packages for the same pattern before fixing a repeated issue in only one place.
+- If a change depends on live runtime state, record the assumption and avoid making live changes without explicit authorization.
+- If a package rename/addition changes operator expectations, update README/package/dashboard documentation in the same PR.

--- a/README.md
+++ b/README.md
@@ -3,72 +3,111 @@
 ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2025.3.4-blue?style=flat-square&logo=home-assistant)
 ![License](https://img.shields.io/github/license/bcl1713/homeassistant_config?style=flat-square)
 ![GitHub last commit](https://img.shields.io/github/last-commit/bcl1713/homeassistant_config?style=flat-square)
-![GitHub stars](https://img.shields.io/github/stars/bcl1713/homeassistant_config?style=flat-square)
 ![GitHub issues](https://img.shields.io/github/issues/bcl1713/homeassistant_config?style=flat-square)
 
-This repository contains my personal Home Assistant configuration, providing automated control and monitoring of my smart home.
+This repository contains Brian's Home Assistant configuration. It is organized for safe, reviewable development: feature packages live under `packages/`, generated or secret runtime files stay out of Git, and contributor changes flow through pull requests to `dev` before any `main` release gate.
 
-## Overview
+## Current system overview
 
-This Home Assistant configuration provides a comprehensive smart home automation system with the following features:
+The active configuration is package-first. `configuration.yaml` keeps global includes small and loads most feature logic through Home Assistant packages:
 
-- **Security and Monitoring**: Camera integrations, motion detection alerts, and alarm system management
-- **Lighting Control**: Automated lighting based on presence, time of day, and security events
-- **Routine Automation**: Good night routines, morning wake-up sequences, and presence-based automations
-- **Notification System**: Multi-device alerts for critical events
-- **Device Monitoring**: Battery health plus Z-Wave connectivity and stale-device visibility
-- **Weather Integration**: Automated responses to weather conditions
-- **Chore Management**: Tracking and rotation of household responsibilities
+- `homeassistant.packages: !include_dir_named packages` loads feature packages.
+- `automation: !include_dir_merge_list automation` loads standalone automations.
+- `input_boolean: !include_dir_merge_named input_boolean` loads helper modes such as guest mode.
+- `scene`, `recorder`, and `logbook` are split into their own root-level files.
+- `packages/shared_infrastructure.yaml` owns shared contracts consumed by other packages, including `notify.all_mobile_devices` and YAML-managed Lovelace dashboard registration.
 
-## Directory Structure
+The system currently emphasizes:
 
-```
+- Climate control for `climate.dining_room_thermostat`, split across schedule, occupancy, extreme-heat overlay, and diagnostics packages.
+- Mobile-first operational dashboards for climate control and window ventilation advice.
+- Device health monitoring for batteries, stale devices, Z-Wave health, and integration availability.
+- Household safety and security flows for cameras, garage doors, secure-house sanity checks, security lighting, routines, and notifications.
+- Weather, air-quality, seasonal, school, and window-ventilation advice driven by templates and helper entities.
+- ESPHome/device-specific configuration, currently including a RATGDO garage-door controller YAML file.
+
+## Repository layout
+
+```text
 /
-├── automation/               # Individual automation files
-├── blueprints/              # Reusable automation blueprints
-├── input_boolean/           # Boolean switch definitions
-├── packages/                # Feature-specific configuration packages
-│   ├── cameras.yaml        # Camera configuration
-│   ├── chores.yaml         # Chore management
-│   └── ...                 # Other feature packages
-├── scenes.yaml              # Defined scenes
-├── configuration.yaml       # Main configuration file
-└── recorder.yaml            # Database recording settings
+├── .github/                 # GitHub Actions validation workflow and CI notes
+├── automation/              # Standalone automation includes
+├── blueprints/              # Imported and local automation/script/template blueprints
+├── dashboards/              # YAML-managed Lovelace dashboards
+├── esphome/                 # ESPHome device configuration tracked with the repo
+├── input_boolean/           # Mode/helper booleans loaded by configuration.yaml
+├── packages/                # Feature packages loaded with !include_dir_named
+├── scripts/                 # Repo utility scripts, including HA context export helpers
+├── automations.yaml         # UI-managed or legacy automation file
+├── configuration.yaml       # Main Home Assistant entry point and includes
+├── logbook.yaml             # Logbook filters/configuration
+├── recorder.yaml            # Recorder filters/configuration
+└── scenes.yaml              # Scene definitions
 ```
 
-## Packages
+## Active package inventory
 
-This configuration uses Home Assistant's packages feature to organize functionality into discrete modules:
+All active package files under `packages/*.yaml` are documented in `packages/README.md`. The current active set is:
 
-- **cameras.yaml**: Camera integration with motion detection and notifications
-- **device_batteries.yaml**: Battery inventory, summary sensors, and battery alerts
-- **device_connectivity.yaml**: Conservative Z-Wave, stale-device, and integration-health alerts
-- **chores.yaml**: Household chore rotation and tracking system
-- **climate_schedule.yaml**: Baseline HVAC setpoint helpers, schedule application, and occupied restart resync
-- **climate_occupancy.yaml**: Away, return-home, and pre-arrival climate recovery behavior
-- **climate_extreme_heat.yaml**: Extreme-heat day detection plus bounded pre-cool overlay behavior
-- **climate_diagnostics.yaml**: Dashboard-facing climate activity and temperature diagnostic sensors
-- **light_groups.yaml**: Logical grouping of lights for easier control
-- **presence.yaml**: Presence detection and related automations
-- **remotes.yaml**: Z-Wave remote control configuration
-- **routines.yaml**: Common household routines (Good Night, etc.)
-- **shared_infrastructure.yaml**: Shared contracts for infrastructure consumed by packages, including `notify.all_mobile_devices` and YAML Lovelace dashboard registration
-- **security_lights.yaml**: Security-focused lighting automations
-- **weather.yaml**: Weather data processing and event monitoring
+- `air_quality.yaml` - composite air-quality status, thresholds, alerts, and recheck notifications.
+- `cameras.yaml` - camera notification automation payloads and guards.
+- `climate_diagnostics.yaml` - dashboard-facing thermostat/temperature diagnostics.
+- `climate_extreme_heat.yaml` - hot-day detection and bounded pre-cool overlay behavior.
+- `climate_occupancy.yaml` - away, return-home, and pre-arrival climate recovery behavior.
+- `climate_schedule.yaml` - baseline thermostat setpoint helpers and schedule application.
+- `device_batteries.yaml` - battery health summaries and alerting.
+- `device_connectivity.yaml` - stale-device, Z-Wave, and integration-health monitoring.
+- `garage_door_monitoring.yaml` - garage-door duration monitoring, reminders, and controls.
+- `known_batteries.yaml` - normalized template sensors for known battery-powered devices.
+- `light_groups.yaml` - logical light groups.
+- `notifications.yaml` - shared notification automations that do not belong to a larger package.
+- `presence.yaml` - presence, alarm-panel, and presence-related lighting behavior.
+- `remotes.yaml` - Z-Wave remote helper scripts and blueprint-backed automations.
+- `routines.yaml` - household routines, including Good Night.
+- `seasonal.yaml` - active seasonal lighting automation.
+- `security_lights.yaml` - security-focused lighting automations.
+- `security_sanity.yaml` - reusable secure-house sanity check workflow.
+- `shared_infrastructure.yaml` - shared notifier/dashboard contracts for packages.
+- `towner_notifications.yaml` - school arrival/departure notification state handling.
+- `weather.yaml` - weather caching, MQTT data, forecasts, and weather-driven automation.
+- `window_ventilation.yaml` - advisory window ventilation recommendations and notifications.
 
-## Getting Started
+Disabled package files, such as `*.yaml.disabled`, are retained as inactive reference material and are not part of the active package inventory.
 
-To use this configuration as a template:
+## Dashboards
 
-1. Install Home Assistant using your preferred method
-2. Clone this repository to your configuration directory
-3. Update the configuration to match your devices and preferences
-4. Restart Home Assistant to apply changes
+YAML-managed dashboards live in `dashboards/` and are registered by `packages/shared_infrastructure.yaml`:
 
-## Development
+- `dashboards/climate_control.yaml` provides the mobile-first climate operator view, thermostat controls, temperature and air-quality trend graphs, extreme-heat overlay controls, and diagnostics.
+- `dashboards/window_ventilation.yaml` provides the advisory ventilation view, current recommendation, comfort/dew-point context, rain/HVAC context, air-quality baseline comparisons, and tuning helpers.
 
-Please see [DEVELOPMENT.md](DEVELOPMENT.md) for contribution guidelines, development workflows, and coding standards.
+## Notifications and shared contracts
+
+Feature packages should consume shared infrastructure instead of redefining it. The important current contracts are:
+
+- `notify.all_mobile_devices` for fan-out mobile notifications.
+- YAML Lovelace dashboard registration under `lovelace.dashboards`.
+- Package-local helpers for thresholds and enable flags when a feature needs operator tuning.
+
+## Development and contribution flow
+
+Use `dev` as the normal integration branch:
+
+1. Start from the latest `dev`.
+2. Create a focused feature, fix, docs, or chore branch.
+3. Make repository-local changes only; do not reload, restart, or modify the live Home Assistant host unless a task explicitly authorizes it.
+4. Run relevant local checks or static validation.
+5. Open a pull request targeting `dev`.
+6. Wait for reviewer approval and the established integration flow. Do not self-merge changes to `main`.
+
+See `DEVELOPMENT.md` for implementation standards and `CONTRIBUTING.md` for the contributor-facing process.
+
+## Local validation
+
+For documentation-only changes, verify the package inventory and run a Markdown/link sanity check when available. For configuration changes, prefer static validation first and only run Home Assistant config checks when the task or environment provides a known-safe local command.
+
+The GitHub Actions workflow in `.github/workflows/validate.yaml` prepares dummy credential files and runs a Home Assistant Core configuration check with `frenck/action-home-assistant`.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) file for details.
+This project is licensed under the MIT License. See `LICENSE.md` for details.

--- a/packages/README.md
+++ b/packages/README.md
@@ -74,7 +74,7 @@ Notification-heavy packages include:
 `shared_infrastructure.yaml` registers YAML dashboards from `dashboards/`:
 
 - `climate-control` from `dashboards/climate_control.yaml`
-- `ventilation-advisor` from `dashboards/window_ventilation.yaml`
+- `window-ventilation` from `dashboards/window_ventilation.yaml` (title: "Ventilation Advisor")
 
 Packages should add dashboard-facing sensors/templates inside the feature package that owns the data, then wire the presentation in `dashboards/` when a dedicated operator view is needed.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,81 +1,98 @@
 # Home Assistant Packages
 
-This directory contains modular packages that group related functionality. Each package is a self-contained YAML file that defines a specific feature set.
-
-## Available Packages
-
-### Core Functionality
-
-| Package                     | Description                                                        |
-|-----------------------------|--------------------------------------------------------------------|
-| `cameras.yaml`              | Camera integration with motion detection and notifications         |
-| `device_batteries.yaml`      | Battery inventory, summary sensors, and battery alerts              |
-| `device_connectivity.yaml`   | Z-Wave, stale-device, and integration-health alerting               |
-| `presence.yaml`              | Presence detection and related automations                         |
-| `security_lights.yaml`      | Security-focused lighting automations                              |
-| `weather.yaml`              | Weather data processing and event monitoring                       |
-| `window_ventilation.yaml`   | Advisory window ventilation recommendations and notification logic |
-
-### Daily Living
-
-| Package             | Description                                   |
-|---------------------|-----------------------------------------------|
-| `chores.yaml`       | Household chore rotation and tracking system  |
-| `light_groups.yaml` | Logical grouping of lights for easier control |
-| `remotes.yaml`      | Z-Wave remote control configuration           |
-| `routines.yaml`     | Common household routines (Good Night, etc.)  |
-
-### Special Features
-
-| Package                  | Description                                          |
-|--------------------------|------------------------------------------------------|
-| `aircraft.yaml.disabled` | Aircraft tracking (currently disabled)               |
-| `seasonal.yaml.disabled` | Seasonal automation features (currently disabled)    |
-
-## Package Structure
-
-Each package should follow this general structure:
+This directory contains Home Assistant packages loaded by `configuration.yaml` via:
 
 ```yaml
-# packages/example.yaml
-#
-# Description of what this package does
-#
-# Features:
-# - Feature 1
-# - Feature 2
-
-# Configuration
-[configuration sections]
-
-# Automations
-automation:
-  - alias: "Feature Automation"
-    description: "Detailed description"
-    trigger:
-      [triggers]
-    condition:
-      [conditions]
-    action:
-      [actions]
-
-# Scripts
-script:
-  feature_script:
-    alias: "Feature Script"
-    sequence:
-      [sequence]
-
-# Other components as needed
+homeassistant:
+  packages: !include_dir_named packages
 ```
 
-## Creating New Packages
+Each active `*.yaml` file is part of the live configuration. Files ending in `.yaml.disabled` are inactive reference material and are documented separately below.
 
-When adding a new package:
+## Package boundaries
 
-1. Follow the naming convention: lowercase with underscores
-2. Include a header comment with description and features
-3. Group related entities and automations logically
-4. Test thoroughly before committing
+Use packages for feature-owned entities, helpers, scripts, templates, and automations. Keep cross-cutting contracts in `shared_infrastructure.yaml` so feature packages can consume the same notifier and dashboard wiring without redefining root-level Home Assistant configuration.
 
-See [DEVELOPMENT.md](../DEVELOPMENT.md) for detailed development guidelines.
+Complex domains should stay split by responsibility. Climate is the current model: schedule helpers, occupancy behavior, extreme-heat overlay, and dashboard diagnostics live in separate packages so operator controls and automation behavior remain easier to review.
+
+## Active packages
+
+| Package | Responsibility |
+|---|---|
+| `air_quality.yaml` | Composite air-quality status and alerts. Defines AQI/CO2/VOC thresholds, enable flags, derived status sensors, and recheck notifications through the shared mobile notifier. |
+| `cameras.yaml` | Camera notification automation for motion/event payloads, with guard logic for actionable mobile alerts. |
+| `climate_diagnostics.yaml` | Dashboard-facing climate diagnostics derived from thermostat state and room temperature sensors. This package does not change thermostat behavior. |
+| `climate_extreme_heat.yaml` | Extreme-heat overlay for the climate system: forecast hot-day detection, configurable threshold/offset helpers, pre-cool eligibility, and bounded restore behavior. |
+| `climate_occupancy.yaml` | Presence-aware climate behavior: away targets, return-home schedule resume, and pre-arrival recovery based on person/proximity abstractions. |
+| `climate_schedule.yaml` | Baseline climate control for the dining-room thermostat: setpoint helpers, schedule windows, occupied setpoint application, and startup resync. |
+| `device_batteries.yaml` | Battery monitoring rollups, proactive alert thresholds, critical/low battery notifications, and notification action handling. |
+| `device_connectivity.yaml` | Device health monitoring for stale devices, Z-Wave node health, integration availability, and conservative alerting. |
+| `garage_door_monitoring.yaml` | Garage-door open-duration monitoring, reminder/escalation helpers, actionable notifications, and related scripts/templates. |
+| `known_batteries.yaml` | Template sensors that normalize known battery-powered devices into consistent names and attributes for the battery-health package. |
+| `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
+| `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |
+| `presence.yaml` | Presence-related behavior, including alarm-panel helpers and lighting automations tied to occupancy/time conditions. |
+| `remotes.yaml` | Z-Wave remote support: helper toggles, scripts, and blueprint-backed automations for Brian and Hester remotes. |
+| `routines.yaml` | Household scripts such as the Good Night routine, intended for direct calls from automations, dashboards, or voice assistants. |
+| `seasonal.yaml` | Active seasonal lighting automation, currently for seasonal/holiday decoration behavior. |
+| `security_lights.yaml` | Security-focused lighting helpers and automations, including after-dark/security-event lighting behavior. |
+| `security_sanity.yaml` | Reusable secure-house sanity check workflow used by routines and presence flows to verify/notify about doors, locks, garage state, and other security context. |
+| `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control and ventilation advice. |
+| `towner_notifications.yaml` | School arrival/departure notification workflow that handles infrequent location updates, race conditions, verification windows, and timeout/reset states. |
+| `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and event-based automation triggers. |
+| `window_ventilation.yaml` | Advisory window-ventilation recommendations using indoor/outdoor comfort, dew point, rain forecast, HVAC state, and relative air-quality context. |
+
+## Climate subsystem
+
+Climate control is intentionally split across packages:
+
+- `climate_schedule.yaml` owns the normal setpoint schedule and thermostat application script.
+- `climate_occupancy.yaml` adjusts behavior for away, return-home, guest, and pre-arrival contexts.
+- `climate_extreme_heat.yaml` layers a bounded pre-cool overlay on top of the baseline schedule when forecast heat warrants it.
+- `climate_diagnostics.yaml` exposes read-only diagnostic sensors for the dashboard.
+- `dashboards/climate_control.yaml` is registered by `shared_infrastructure.yaml` and is the operator-facing view for the subsystem.
+
+Do not collapse these packages into one file just because they share a thermostat. The split keeps tuning helpers, behavioral automation, overlays, and diagnostics reviewable.
+
+## Notifications
+
+Packages that send household alerts should use `notify.all_mobile_devices` from `shared_infrastructure.yaml` unless they have a clear reason to target a narrower notify service. This keeps mobile fan-out in one place and prevents feature packages from duplicating root-level notifier definitions.
+
+Notification-heavy packages include:
+
+- `air_quality.yaml`
+- `device_batteries.yaml`
+- `device_connectivity.yaml`
+- `garage_door_monitoring.yaml`
+- `notifications.yaml`
+- `security_sanity.yaml`
+- `towner_notifications.yaml`
+- `window_ventilation.yaml`
+
+## Dashboards and operator views
+
+`shared_infrastructure.yaml` registers YAML dashboards from `dashboards/`:
+
+- `climate-control` from `dashboards/climate_control.yaml`
+- `ventilation-advisor` from `dashboards/window_ventilation.yaml`
+
+Packages should add dashboard-facing sensors/templates inside the feature package that owns the data, then wire the presentation in `dashboards/` when a dedicated operator view is needed.
+
+## Disabled package files
+
+| File | Status |
+|---|---|
+| `aircraft.yaml.disabled` | Inactive aircraft-tracking reference package. Not loaded by Home Assistant. |
+| `chores.yaml.disabled` | Inactive chore-rotation reference package. Not loaded by Home Assistant. |
+| `seasonal.yaml.disabled` | Inactive previous seasonal automation reference. The active seasonal package is `seasonal.yaml`. |
+
+## Adding or changing a package
+
+1. Start from the latest `dev` branch and make changes in a focused branch.
+2. Keep related entities, helpers, scripts, templates, and automations together in the owning package.
+3. Put shared root-level infrastructure in `shared_infrastructure.yaml`, not in individual feature packages.
+4. Add or update dashboard files under `dashboards/` when an operator view is required.
+5. Update this README whenever `packages/*.yaml` is added, renamed, removed, enabled, or disabled.
+6. Prefer static YAML/package validation first. Do not restart or reload the live Home Assistant host unless a task explicitly authorizes that side effect.
+
+See `../DEVELOPMENT.md` for the broader development workflow.


### PR DESCRIPTION
## Summary
- Rewrites the root README around the current package-first Home Assistant architecture, active package inventory, dashboards, notifications, and repo-local development flow.
- Rewrites `packages/README.md` so every active `packages/*.yaml` file is documented, including climate split packages, shared infrastructure, notifications, garage/security/window ventilation, and school notification packages.
- Reconciles `CONTRIBUTING.md` and `DEVELOPMENT.md` around the `dev` integration branch policy and removes stale copied/template references; also refreshes `.github/CI-README.md` to match the actual validation workflow.

## Verification
- Confirmed `README.md` and `packages/README.md` reference all 22 active `packages/*.yaml` files with no missing active package entries.
- Confirmed stale `main` contribution instructions and placeholder GitHub URL references were removed from Markdown docs.
- Ran `git diff --check` for changed docs.
- Ran `python3 -m pytest -q` (72 passed).

## Documentation impact
- Documentation-only PR; no Home Assistant runtime files, live host state, automations, dashboards, or package YAML behavior changed.
- The package inventory is now driven by the current repository files under `packages/`.

## Intentional gaps
- Disabled `*.yaml.disabled` packages are listed as inactive reference material but not documented as live behavior.
- Existing blueprint and script README files were not expanded beyond this docs overhaul because issue #167 focused on repository/operator/developer documentation and active package boundaries.

Addresses #167.
