### PR TITLE
fix(ventilation): clarify brief purge dashboard state

### DIFF
--- a/dashboards/window_ventilation.yaml
+++ b/dashboards/window_ventilation.yaml
@@ -17,14 +17,53 @@ views:
         title: "Current advice"
         content: >-
           {% set rec = states('sensor.window_ventilation_recommendation') %}
-          ## {{ 'Open Briefly' if rec == 'open_briefly' else rec | title }}
+          {% set mode = state_attr('sensor.window_ventilation_recommendation', 'mode') | trim %}
+          {% set label = {
+            'open': 'Open for comfort ventilation',
+            'open_briefly': 'Brief stale-air purge',
+            'close': 'Close windows',
+            'neutral': 'Neutral / no window change'
+          }.get(rec, rec | title) %}
+          {% set mode_label = {
+            'comfort': 'Comfort ventilation',
+            'winter_purge': 'Brief cold-weather airing',
+            'brief_purge': 'Bounded stale-air purge'
+          }.get(mode, mode | replace('_', ' ') | title) %}
+          ## {{ label }}
 
-          **Mode:** {{ state_attr('sensor.window_ventilation_recommendation', 'mode') }}
+          **Recommendation class:** {{ mode_label }}
+
+          {% if rec == 'open_briefly' %}
+          **This is not ordinary comfort ventilation.** Open briefly only for
+          the bounded stale-air purge, then close windows after 5-10 minutes.
+          {% elif rec == 'open' %}
+          **Comfort ventilation:** outdoor comfort and moisture conditions are
+          favorable enough for normal window opening.
+          {% elif rec == 'close' %}
+          **Close path:** rain, HVAC, humidity, or comfort checks are against
+          open windows.
+          {% else %}
+          **Neutral path:** no active open, close, or brief-purge recommendation.
+          {% endif %}
 
           {{ states('sensor.window_ventilation_reason') }}
 
           _This is advisory-only. It does not confirm individual window-contact
           state or change HVAC behavior._
+
+      - type: conditional
+        conditions:
+          - entity: sensor.window_ventilation_recommendation
+            state: "open_briefly"
+        card:
+          type: markdown
+          title: "Brief purge guardrails"
+          content: >-
+            This compromise state is a short stale-air purge, not a comfort
+            ventilation recommendation. It only appears when indoor air is poor
+            and worsening, rain/HVAC suppression is clear, and outdoor
+            temperature/dew point are within the brief-purge bounds. Close
+            windows after 5-10 minutes.
 
       - type: entities
         title: "Advisor status"
@@ -33,19 +72,19 @@ views:
           - entity: input_boolean.window_ventilation_advisor_enabled
             name: "Advisor notifications enabled"
           - entity: sensor.window_ventilation_recommendation
-            name: "Recommendation"
+            name: "Recommendation state"
           - entity: sensor.window_ventilation_reason
             name: "Reason"
           - type: attribute
             entity: sensor.window_ventilation_recommendation
             attribute: mode
-            name: "Mode"
+            name: "Recommendation class"
           - entity: binary_sensor.window_ventilation_favorable
-            name: "Favorable for opening"
+            name: "Comfort ventilation favorable"
           - entity: binary_sensor.window_ventilation_unfavorable
             name: "Unfavorable / close windows"
           - entity: binary_sensor.window_ventilation_brief_purge
-            name: "Brief stale-air purge"
+            name: "Bounded stale-air purge active"
 
       - type: entities
         title: "Comfort and dew point context"

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -21,6 +21,8 @@ def entity_refs(cards):
     for card in cards:
         if "entity" in card:
             refs.append(card["entity"])
+        if "card" in card:
+            refs.extend(entity_refs([card["card"]]))
         for row in card.get("entities", []):
             if isinstance(row, str):
                 refs.append(row)
@@ -80,6 +82,9 @@ def test_window_ventilation_dashboard_surfaces_required_context():
     assert required_entities <= refs
     assert "state_attr('sensor.window_ventilation_recommendation', 'mode')" in markdown
     assert "advisory-only" in markdown
+    assert "Brief stale-air purge" in markdown
+    assert "This is not ordinary comfort ventilation" in markdown
+    assert "Open Briefly" not in markdown
 
     attribute_rows = [
         row
@@ -106,3 +111,45 @@ def test_window_ventilation_dashboard_surfaces_required_context():
         for row in card.get("entities", [])
         if isinstance(row, dict)
     )
+
+
+def test_window_ventilation_dashboard_separates_brief_purge_from_comfort_open():
+    dashboard = load_dashboard()
+    cards = dashboard["views"][0]["cards"]
+    markdown = "\n".join(
+        card.get("content", "") for card in cards if card.get("type") == "markdown"
+    )
+
+    status_card = next(card for card in cards if card.get("title") == "Advisor status")
+    status_names = {
+        row["entity"]: row["name"]
+        for row in status_card["entities"]
+        if isinstance(row, dict) and "entity" in row and "name" in row
+    }
+    brief_purge_card = next(
+        card
+        for card in cards
+        if card.get("type") == "conditional"
+        and card.get("card", {}).get("title") == "Brief purge guardrails"
+    )
+
+    assert "'open': 'Open for comfort ventilation'" in markdown
+    assert "'open_briefly': 'Brief stale-air purge'" in markdown
+    assert "'brief_purge': 'Bounded stale-air purge'" in markdown
+    assert "not ordinary comfort ventilation" in markdown
+    assert status_names["binary_sensor.window_ventilation_favorable"] == (
+        "Comfort ventilation favorable"
+    )
+    assert status_names["binary_sensor.window_ventilation_brief_purge"] == (
+        "Bounded stale-air purge active"
+    )
+    assert brief_purge_card["conditions"] == [
+        {
+            "entity": "sensor.window_ventilation_recommendation",
+            "state": "open_briefly",
+        }
+    ]
+    assert "not a comfort ventilation recommendation" in brief_purge_card["card"][
+        "content"
+    ]
+    assert "5-10 minutes" in brief_purge_card["card"]["content"]


### PR DESCRIPTION
## Summary
- Relabel the window ventilation dashboard so open_briefly renders as a brief stale-air purge, not ordinary comfort ventilation
- Add a brief-purge-only guardrails card that explains the bounded stale-air compromise and 5-10 minute close expectation
- Extend dashboard tests to lock the distinct brief-purge labels and conditional card

## Test Plan
- python3 YAML parse for dashboards/window_ventilation.yaml and packages/window_ventilation.yaml
- pytest -q tests/test_window_ventilation_dashboard.py tests/test_window_ventilation_package.py
- pytest -q
- git diff --check