### PR TITLE
feat(notifications): add Brian-only back-door alert

### DIFF
--- a/packages/notifications.yaml
+++ b/packages/notifications.yaml
@@ -31,3 +31,36 @@ automation:
           entity_id: tts.google_en_com
         action: tts.speak
     mode: single
+
+  - id: "back_door_open_notification"
+    alias: "Back Door Open Notification"
+    description: "Notify Brian when the kitchen back door opens"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.kitchen_back_door
+        from: "off"
+        to: "on"
+    action:
+      - service: notify.mobile_app_brian_phone
+        data:
+          title: "Back Door"
+          message: "Back door opened."
+          data:
+            tag: "back-door-open"
+    mode: single
+
+  - id: "back_door_close_clear_notification"
+    alias: "Back Door Close Clear Notification"
+    description: "Clear Brian's back-door notification when the door closes"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.kitchen_back_door
+        from: "on"
+        to: "off"
+    action:
+      - service: notify.mobile_app_brian_phone
+        data:
+          message: "clear_notification"
+          data:
+            tag: "back-door-open"
+    mode: single

--- a/tests/test_back_door_notification.py
+++ b/tests/test_back_door_notification.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOTIFICATIONS = ROOT / "packages" / "notifications.yaml"
+BACK_DOOR_ENTITY = "binary_sensor.kitchen_back_door"
+BACK_DOOR_TAG = "back-door-open"
+BRIAN_NOTIFIER = "notify.mobile_app_brian_phone"
+
+
+def automation_by_id(automation_id):
+    package = yaml.safe_load(NOTIFICATIONS.read_text())
+    for automation in package["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def test_back_door_open_notification_is_brian_only_and_tagged():
+    automation = automation_by_id("back_door_open_notification")
+
+    assert automation["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": BACK_DOOR_ENTITY,
+            "from": "off",
+            "to": "on",
+        }
+    ]
+    assert automation["action"] == [
+        {
+            "service": BRIAN_NOTIFIER,
+            "data": {
+                "title": "Back Door",
+                "message": "Back door opened.",
+                "data": {"tag": BACK_DOOR_TAG},
+            },
+        }
+    ]
+    assert automation["mode"] == "single"
+
+
+def test_back_door_close_clears_the_matching_brian_notification():
+    automation = automation_by_id("back_door_close_clear_notification")
+
+    assert automation["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": BACK_DOOR_ENTITY,
+            "from": "on",
+            "to": "off",
+        }
+    ]
+    assert automation["action"] == [
+        {
+            "service": BRIAN_NOTIFIER,
+            "data": {
+                "message": "clear_notification",
+                "data": {"tag": BACK_DOOR_TAG},
+            },
+        }
+    ]
+    assert automation["mode"] == "single"


### PR DESCRIPTION
## Summary
- Add explicit off-to-on and on-to-off automations for binary_sensor.kitchen_back_door.
- Notify only notify.mobile_app_brian_phone with the stable back-door-open tag.
- Clear that exact tagged notification when the door closes, with focused contract tests.

Closes #173

## Validation
- python3 -m pytest -q tests/test_back_door_notification.py (2 passed)
- python3 -m pytest -q (83 passed)
- PyYAML parse of packages/notifications.yaml
- git diff --check

`yamllint` was not installed. No safe local Home Assistant Core config-check command was available; no live Home Assistant action was performed.

## Documentation impact
None; this extends the existing notifications.yaml package without adding or changing a package boundary or operator documentation.
