### PR TITLE
feat(device-health): monitor critical door contacts

### DIFF
--- a/packages/device_connectivity.yaml
+++ b/packages/device_connectivity.yaml
@@ -6,6 +6,11 @@
 # - Z-Wave node health monitoring
 # - Stale last-seen entity detection
 # - Integration update entity availability checks
+# - Critical exterior/security door contact availability checks
+
+# The current door-contact integration does not expose separate battery entities
+# in this repository. If it later does, add normalized battery sensors in
+# known_batteries.yaml; device_batteries.yaml will include them automatically.
 
 input_boolean:
   device_connectivity_monitoring_enabled:
@@ -35,6 +40,39 @@ input_number:
 
 template:
   - sensor:
+      - name: "Device Connectivity Critical Door Contact Problems"
+        unique_id: device_connectivity_critical_door_contact_problems
+        state: >
+          {% set contacts = {
+            'binary_sensor.entry_front_door': 'Front Door Contact',
+            'binary_sensor.kitchen_back_door': 'Back Door Contact',
+            'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact'
+          } %}
+          {% set ns = namespace(problems=[]) %}
+          {% for entity_id, name in contacts.items() %}
+            {% set state = states(entity_id) %}
+            {% if state in ['unavailable', 'unknown'] %}
+              {% set ns.problems = ns.problems + [name] %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.problems | length }}
+        unit_of_measurement: "contacts"
+        attributes:
+          problem_contacts: >
+            {% set contacts = {
+              'binary_sensor.entry_front_door': 'Front Door Contact',
+              'binary_sensor.kitchen_back_door': 'Back Door Contact',
+              'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact'
+            } %}
+            {% set ns = namespace(problems=[]) %}
+            {% for entity_id, name in contacts.items() %}
+              {% set state = states(entity_id) %}
+              {% if state in ['unavailable', 'unknown'] %}
+                {% set ns.problems = ns.problems + [name ~ ' (' ~ state ~ ')'] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.problems | join(', ') if ns.problems else 'None' }}
+
       - name: "Device Connectivity Z-Wave Problems"
         unique_id: device_connectivity_zwave_problems
         state: >
@@ -129,6 +167,7 @@ template:
             states('sensor.device_connectivity_z_wave_problems') | int(0)
             + states('sensor.device_connectivity_stale_last_seen') | int(0)
             + states('sensor.device_connectivity_integration_problems') | int(0)
+            + states('sensor.device_connectivity_critical_door_contact_problems') | int(0)
           }}
         unit_of_measurement: "issues"
         attributes:
@@ -138,6 +177,8 @@ template:
             {{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}
           integration_problems: >
             {{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}
+          critical_door_contact_problems: >
+            {{ state_attr('sensor.device_connectivity_critical_door_contact_problems', 'problem_contacts') }}
 
   - binary_sensor:
       - name: "Device Connectivity Has Issues"
@@ -149,7 +190,9 @@ template:
 automation:
   - alias: "device_connectivity_issue_alert"
     id: "device_connectivity_issue_alert"
-    description: "Alert when Z-Wave nodes, last_seen sensors, or integration update entities look unhealthy"
+    description: >
+      Alert when Z-Wave nodes, last_seen sensors, integration update entities,
+      or critical door contacts look unhealthy for 15 continuous minutes.
     trigger:
       - platform: state
         entity_id: binary_sensor.device_connectivity_has_issues
@@ -175,9 +218,11 @@ automation:
           zwave_count: "{{ states('sensor.device_connectivity_z_wave_problems') | int(0) }}"
           stale_count: "{{ states('sensor.device_connectivity_stale_last_seen') | int(0) }}"
           integration_count: "{{ states('sensor.device_connectivity_integration_problems') | int(0) }}"
+          door_contact_count: "{{ states('sensor.device_connectivity_critical_door_contact_problems') | int(0) }}"
           zwave_summary: "{{ state_attr('sensor.device_connectivity_z_wave_problems', 'problem_nodes') }}"
           stale_summary: "{{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}"
           integration_summary: "{{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}"
+          door_contact_summary: "{{ state_attr('sensor.device_connectivity_critical_door_contact_problems', 'problem_contacts') }}"
       - service: notify.all_mobile_devices
         data:
           title: "Device Connectivity Alert"
@@ -186,6 +231,7 @@ automation:
             Z-Wave: {{ zwave_count }} ({{ zwave_summary }}).
             Last seen: {{ stale_count }} ({{ stale_summary }}).
             Integrations: {{ integration_count }} ({{ integration_summary }}).
+            Critical door contacts: {{ door_contact_count }} ({{ door_contact_summary }}).
           data:
             tag: "device-connectivity-alert"
             priority: "high"
@@ -200,6 +246,8 @@ automation:
             Stale last_seen devices: {{ stale_summary }}
 
             Unavailable update entities: {{ integration_summary }}
+
+            Critical door contacts: {{ door_contact_summary }}
 
             Threshold: {{ states('input_number.device_connectivity_last_seen_threshold_hours') | int(24) }} hours
 
@@ -219,3 +267,8 @@ automation:
       - service: persistent_notification.dismiss
         data:
           notification_id: device_connectivity_alert
+      - service: notify.all_mobile_devices
+        data:
+          message: "clear_notification"
+          data:
+            tag: "device-connectivity-alert"

--- a/tests/test_door_contact_health.py
+++ b/tests/test_door_contact_health.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "device_connectivity.yaml"
+CRITICAL_DOOR_CONTACTS = {
+    "binary_sensor.entry_front_door": "Front Door Contact",
+    "binary_sensor.kitchen_back_door": "Back Door Contact",
+    "binary_sensor.garage_garage_interior_door": "Garage Interior Door Contact",
+}
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def sensor_by_name(package, sensor_name):
+    for template_block in package["template"]:
+        for sensor in template_block.get("sensor", []):
+            if sensor["name"] == sensor_name:
+                return sensor
+    raise AssertionError(f"sensor {sensor_name!r} not found")
+
+
+def render(template, state_map):
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals["states"] = lambda entity_id: state_map.get(entity_id, "unknown")
+    return environment.from_string(template).render()
+
+
+def test_critical_door_contact_sensor_flags_only_unavailable_or_unknown_contacts():
+    package = load_package()
+    sensor = sensor_by_name(package, "Device Connectivity Critical Door Contact Problems")
+    state_map = {
+        "binary_sensor.entry_front_door": "off",
+        "binary_sensor.kitchen_back_door": "unavailable",
+        "binary_sensor.garage_garage_interior_door": "unknown",
+    }
+
+    assert all(entity_id in sensor["state"] for entity_id in CRITICAL_DOOR_CONTACTS)
+    assert render(sensor["state"], state_map).strip() == "2"
+    assert render(sensor["attributes"]["problem_contacts"], state_map).strip() == (
+        "Back Door Contact (unavailable), Garage Interior Door Contact (unknown)"
+    )
+
+
+def test_door_contact_recovery_clears_the_problem_sensor_and_notification():
+    package = load_package()
+    sensor = sensor_by_name(package, "Device Connectivity Critical Door Contact Problems")
+    alert = next(item for item in package["automation"] if item["id"] == "device_connectivity_issue_alert")
+    reset = next(
+        item for item in package["automation"] if item["id"] == "device_connectivity_issue_alert_reset"
+    )
+    recovered_states = {entity_id: "off" for entity_id in CRITICAL_DOOR_CONTACTS}
+
+    assert render(sensor["state"], recovered_states).strip() == "0"
+    assert render(sensor["attributes"]["problem_contacts"], recovered_states).strip() == "None"
+    assert alert["trigger"][0]["for"] == {"minutes": 15}
+    assert "door_contact_count" in alert["action"][1]["variables"]
+    assert "door_contact_summary" in alert["action"][1]["variables"]
+    assert alert["action"][2]["data"]["data"]["tag"] == "device-connectivity-alert"
+    assert reset["action"][-1] == {
+        "service": "notify.all_mobile_devices",
+        "data": {"message": "clear_notification", "data": {"tag": "device-connectivity-alert"}},
+    }
+
+
+def test_connectivity_summary_consumes_critical_door_contact_problem_count():
+    package = load_package()
+    summary = sensor_by_name(package, "Device Connectivity Summary")
+
+    assert "sensor.device_connectivity_critical_door_contact_problems" in summary["state"]
+    assert (
+        "sensor.device_connectivity_critical_door_contact_problems"
+        in summary["attributes"]["critical_door_contact_problems"]
+    )


### PR DESCRIPTION
## Summary
- Add a connectivity health sensor for the front, back, and garage interior critical door contacts.
- Include door-contact failures in the existing grouped device-health alert and clear its stable mobile notification on recovery.
- Document that no dedicated contact-battery entities are currently exposed, while preserving the canonical battery-inventory path for future sources.

## Validation
- `python3 -m pytest -q tests` (88 passed)
- Parsed `packages/device_connectivity.yaml` with PyYAML
- `git diff --check`

## Safety
- No live `/config` edit, Home Assistant reload, or restart was performed.

## Documentation impact
- No documentation files changed: this adds behavior to the existing documented `device_connectivity.yaml` package.

Closes #178