### PR TITLE
feat(security): alert on armed door openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `remotes.yaml` - Z-Wave remote helper scripts and blueprint-backed automations.
 - `routines.yaml` - household routines, including Good Night.
 - `seasonal.yaml` - active seasonal lighting automation.
+- `security_door_alerts.yaml` - immediate armed away/night security-boundary door alerts, dedicated tagged clears, and concise bedroom-display announcements.
 - `security_lights.yaml` - security-focused lighting automations.
 - `security_sanity.yaml` - reusable secure-house sanity check workflow.
 - `shared_infrastructure.yaml` - shared notifier/dashboard contracts for packages.

--- a/packages/README.md
+++ b/packages/README.md
@@ -36,6 +36,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `remotes.yaml` | Z-Wave remote support: helper toggles, scripts, and blueprint-backed automations for Brian and Hester remotes. |
 | `routines.yaml` | Household scripts such as the Good Night routine, intended for direct calls from automations, dashboards, or voice assistants. |
 | `seasonal.yaml` | Active seasonal lighting automation, currently for seasonal/holiday decoration behavior. |
+| `security_door_alerts.yaml` | Immediate high-priority alerts when front, back, or garage-interior security-boundary contacts open while the alarm is armed away/night. Uses a separate security tag namespace, clears only those tags on close, and announces once through the master bedroom display. |
 | `security_lights.yaml` | Security-focused lighting helpers and automations, including after-dark/security-event lighting behavior. |
 | `security_sanity.yaml` | Reusable secure-house sanity check workflow used by routines and presence flows to verify/notify about doors, locks, garage state, and other security context. |
 | `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control and ventilation advice. |

--- a/packages/security_door_alerts.yaml
+++ b/packages/security_door_alerts.yaml
@@ -1,0 +1,110 @@
+# packages/security_door_alerts.yaml
+#
+# Armed Security Door Alerts
+#
+# Sends an immediate high-priority mobile alert (and one concise bedroom-display
+# announcement) only when a security-boundary contact opens while the alarm is
+# armed away or armed night. This is independent of the two-minute exterior-door
+# reminder package, including its notification tags and close behavior.
+#
+# The trigger is intentionally contact-state-only: arming the alarm while a door
+# is already open must not generate a duplicate alert.
+
+homeassistant:
+  customize:
+    package.node_anchors:
+      security_door_contacts: &security_door_contacts
+        binary_sensor.entry_front_door:
+          name: "Front Door"
+          tag_suffix: "front"
+        binary_sensor.kitchen_back_door:
+          name: "Back Door"
+          tag_suffix: "back"
+        binary_sensor.garage_garage_interior_door:
+          name: "Garage Interior Door"
+          tag_suffix: "garage-interior"
+
+automation:
+  - id: "armed_security_door_open_alert"
+    alias: "Armed Security Door Open Alert"
+    description: >
+      Immediately alert only when a configured security-boundary door opens
+      while the alarm is armed away or armed night and guest mode is off.
+    variables:
+      door_contacts: *security_door_contacts
+      security_mode: "{{ states('alarm_control_panel.home_alarm') }}"
+      security_mode_label: "{{ 'away' if security_mode == 'armed_away' else 'night' }}"
+      notification_tag: "{{ 'security-door-open-' ~ door_contacts[trigger.entity_id]['tag_suffix'] ~ '-' ~ security_mode_label }}"
+      announcement: >
+        Security alert. {{ door_contacts[trigger.entity_id]['name'] }} opened
+        while the house is armed {{ security_mode_label }}.
+    trigger:
+      - platform: state
+        entity_id:
+          - binary_sensor.entry_front_door
+          - binary_sensor.kitchen_back_door
+          - binary_sensor.garage_garage_interior_door
+        from: "off"
+        to: "on"
+    condition:
+      - condition: state
+        entity_id: input_boolean.mode_guest
+        state: "off"
+      - condition: template
+        value_template: >
+          {{ states('alarm_control_panel.home_alarm') in
+             ['armed_away', 'armed_night'] }}
+    action:
+      - service: notify.all_mobile_devices
+        data:
+          title: "Security Door Alert"
+          message: >
+            {{ door_contacts[trigger.entity_id]['name'] }} opened while the
+            house is armed {{ security_mode_label }}.
+          data:
+            tag: "{{ notification_tag }}"
+            priority: "high"
+            ttl: 0
+            critical: true
+      # This uses the existing tts.google_en_com service contract. The state
+      # transition trigger means each open transition produces at most one
+      # announcement; repeated state updates while open do not re-announce.
+      - action: tts.speak
+        target:
+          entity_id: tts.google_en_com
+        data:
+          cache: true
+          media_player_entity_id: media_player.master_bedroom_display
+          message: "{{ announcement }}"
+    mode: parallel
+    max: 3
+
+  - id: "armed_security_door_close_clear_alert"
+    alias: "Armed Security Door Close Clear Alert"
+    description: >
+      Clear only armed-security notifications for the door after it closes.
+      Both armed-mode tags are cleared because the alarm state may change before
+      the close event; exterior two-minute reminder tags are never targeted.
+    variables:
+      door_contacts: *security_door_contacts
+    trigger:
+      - platform: state
+        entity_id:
+          - binary_sensor.entry_front_door
+          - binary_sensor.kitchen_back_door
+          - binary_sensor.garage_garage_interior_door
+        from: "on"
+        to: "off"
+    action:
+      - repeat:
+          for_each:
+            - "away"
+            - "night"
+          sequence:
+            - service: notify.all_mobile_devices
+              data:
+                message: "clear_notification"
+                data:
+                  tag: "{{ 'security-door-open-' ~ door_contacts[trigger.entity_id]['tag_suffix'] ~ '-' ~ repeat.item }}"
+    mode: parallel
+    max: 3

--- a/packages/shared_infrastructure.yaml
+++ b/packages/shared_infrastructure.yaml
@@ -20,6 +20,7 @@
 # - packages/exterior_door_monitoring.yaml
 # - packages/garage_door_monitoring.yaml
 # - packages/routines.yaml
+# - packages/security_door_alerts.yaml
 # - packages/security_sanity.yaml
 # - packages/towner_notifications.yaml
 # - packages/window_ventilation.yaml

--- a/tests/test_security_door_alerts.py
+++ b/tests/test_security_door_alerts.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "security_door_alerts.yaml"
+
+CONTACTS = {
+    "binary_sensor.entry_front_door": {"name": "Front Door", "tag_suffix": "front"},
+    "binary_sensor.kitchen_back_door": {"name": "Back Door", "tag_suffix": "back"},
+    "binary_sensor.garage_garage_interior_door": {
+        "name": "Garage Interior Door",
+        "tag_suffix": "garage-interior",
+    },
+}
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def automation_by_id(package, automation_id):
+    for automation in package["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def test_armed_security_contacts_include_exterior_and_garage_boundary_doors():
+    package = load_package()
+    contacts = package["homeassistant"]["customize"]["package.node_anchors"][
+        "security_door_contacts"
+    ]
+
+    assert contacts == CONTACTS
+
+
+def test_open_alert_is_immediate_armed_only_and_guest_mode_exempt():
+    package = load_package()
+    automation = automation_by_id(package, "armed_security_door_open_alert")
+
+    assert automation["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": list(CONTACTS),
+            "from": "off",
+            "to": "on",
+        }
+    ]
+    assert automation["condition"] == [
+        {
+            "condition": "state",
+            "entity_id": "input_boolean.mode_guest",
+            "state": "off",
+        },
+        {
+            "condition": "template",
+            "value_template": (
+                "{{ states('alarm_control_panel.home_alarm') in\n"
+                "   ['armed_away', 'armed_night'] }}\n"
+            ),
+        },
+    ]
+    assert "for" not in automation["trigger"][0]
+    assert automation["variables"]["security_mode_label"] == (
+        "{{ 'away' if security_mode == 'armed_away' else 'night' }}"
+    )
+    assert "armed_night" in automation["condition"][1]["value_template"]
+
+
+def test_open_alert_uses_distinct_critical_tags_and_one_bedroom_announcement():
+    package = load_package()
+    automation = automation_by_id(package, "armed_security_door_open_alert")
+    notification = automation["action"][0]
+    tts = automation["action"][1]
+
+    assert notification["service"] == "notify.all_mobile_devices"
+    assert notification["data"]["title"] == "Security Door Alert"
+    assert notification["data"]["data"] == {
+        "tag": "{{ notification_tag }}",
+        "priority": "high",
+        "ttl": 0,
+        "critical": True,
+    }
+    assert "security-door-open-" in automation["variables"]["notification_tag"]
+    assert "exterior-door-open-" not in automation["variables"]["notification_tag"]
+    tag_template = Environment().from_string(automation["variables"]["notification_tag"])
+    assert tag_template.render(
+        door_contacts=CONTACTS,
+        trigger={"entity_id": "binary_sensor.entry_front_door"},
+        security_mode_label="away",
+    ) == "security-door-open-front-away"
+    assert "from: \"off\"" in PACKAGE.read_text()
+    assert "while open do not re-announce" in PACKAGE.read_text()
+
+    assert tts == {
+        "action": "tts.speak",
+        "target": {"entity_id": "tts.google_en_com"},
+        "data": {
+            "cache": True,
+            "media_player_entity_id": "media_player.master_bedroom_display",
+            "message": "{{ announcement }}",
+        },
+    }
+    assert automation["mode"] == "parallel"
+    assert automation["max"] == 3
+
+
+def test_close_clears_only_matching_armed_security_tag_namespace():
+    package = load_package()
+    automation = automation_by_id(package, "armed_security_door_close_clear_alert")
+
+    assert automation["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": list(CONTACTS),
+            "from": "on",
+            "to": "off",
+        }
+    ]
+    repeat = automation["action"][0]["repeat"]
+    assert repeat["for_each"] == ["away", "night"]
+    assert repeat["sequence"] == [
+        {
+            "service": "notify.all_mobile_devices",
+            "data": {
+                "message": "clear_notification",
+                "data": {
+                    "tag": "{{ 'security-door-open-' ~ door_contacts[trigger.entity_id]['tag_suffix'] ~ '-' ~ repeat.item }}"
+                },
+            },
+        }
+    ]
+    assert "exterior-door-open-" not in str(repeat)
+    assert automation["mode"] == "parallel"
+    assert automation["max"] == 3


### PR DESCRIPTION
## Summary
- Add immediate critical mobile alerts for front, back, and garage-interior security-boundary contacts when the alarm is armed away or night.
- Keep guest mode exempt; use contact-only transitions and mode-specific `security-door-open-*` tags to avoid alarm-transition duplicates and preserve two-minute reminder tags.
- Add one concise `tts.speak` announcement to `media_player.master_bedroom_display` per open transition, then clear only security-tagged alerts on close.

## Validation
- `python -m pytest -q` (89 passed)
- Parsed all 24 package YAML files with PyYAML
- `git diff --check`

## Documentation impact
- Documented the new active package and its shared notifier consumer contract.

No live Home Assistant config, service, reload, or restart actions were performed. GitHub Actions remains the repository-provided Home Assistant Core configuration-check environment.

Closes #176