### PR TITLE
feat(security): include open contacts in sanity checks

### DIFF
--- a/packages/security_sanity.yaml
+++ b/packages/security_sanity.yaml
@@ -4,7 +4,8 @@
 #
 # Features:
 # - Reusable secure-house sanity check script for routines and presence
-# - Aggregates front door, garage door, and alarm mismatches into one alert
+# - Aggregates lock, garage, alarm, and security-boundary contact mismatches
+#   into one alert
 # - Notification actions remediate only when explicitly selected
 # - Guest mode is documented as an intentional advisory exception
 
@@ -12,8 +13,9 @@ script:
   secure_house_sanity_check:
     alias: "Secure House Sanity Check"
     description: >
-      Check front door, garage door, and alarm state for a securing context and
-      send one actionable notification only when the house is not fully secure.
+      Check lock, garage door, alarm, and security-boundary contact state for a
+      securing context and send one actionable notification only when the house
+      is not fully secure.
     mode: parallel
     fields:
       check_context:
@@ -51,11 +53,23 @@ script:
           front_door_state: "{{ states('lock.front_door') }}"
           garage_door_state: "{{ states('cover.garage_door') }}"
           alarm_state: "{{ states('alarm_control_panel.home_alarm') }}"
+          security_door_contacts:
+            binary_sensor.entry_front_door: "Front Door"
+            binary_sensor.kitchen_back_door: "Back Door"
+            binary_sensor.garage_garage_interior_door: "Garage Interior Door"
           garage_obstructed: >
             {{ is_state('binary_sensor.garage_door_obstruction', 'on') }}
           front_door_needs_lock: "{{ front_door_state != 'locked' }}"
           garage_needs_close: "{{ garage_door_state != 'closed' }}"
           alarm_needs_arm: "{{ alarm_state != expected_alarm_state }}"
+          open_security_contact_count: >
+            {% set count = namespace(value=0) %}
+            {% for entity_id in security_door_contacts %}
+              {% if is_state(entity_id, 'on') %}
+                {% set count.value = count.value + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ count.value }}
           security_findings: >
             {% set findings = namespace(items=[]) %}
             {% if front_door_state != 'locked' %}
@@ -76,11 +90,18 @@ script:
                 ['Alarm is ' ~ alarm_state ~ ' instead of armed ' ~
                  expected_alarm_label ~ '.'] %}
             {% endif %}
+            {% for entity_id, name in security_door_contacts.items() %}
+              {% if is_state(entity_id, 'on') %}
+                {% set findings.items = findings.items +
+                  [name ~ ' contact is open.'] %}
+              {% endif %}
+            {% endfor %}
             {{ findings.items | join('\n') }}
           mismatch_count: >
             {{ (1 if front_door_state != 'locked' else 0) +
                (1 if garage_door_state != 'closed' else 0) +
-               (1 if alarm_state != expected_alarm_state else 0) }}
+               (1 if alarm_state != expected_alarm_state else 0) +
+               (open_security_contact_count | int) }}
           notification_tag: >
             secure-house-{{ security_context }}-{{ (now().timestamp() * 1000) |
             int }}-{{ range(0, 999) | random }}

--- a/tests/test_security_sanity.py
+++ b/tests/test_security_sanity.py
@@ -1,12 +1,18 @@
 from pathlib import Path
 
 import yaml
+from jinja2 import Environment
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SECURITY = ROOT / "packages" / "security_sanity.yaml"
 ROUTINES = ROOT / "packages" / "routines.yaml"
 PRESENCE = ROOT / "packages" / "presence.yaml"
+SECURITY_DOOR_CONTACTS = {
+    "binary_sensor.entry_front_door": "Front Door",
+    "binary_sensor.kitchen_back_door": "Back Door",
+    "binary_sensor.garage_garage_interior_door": "Garage Interior Door",
+}
 
 
 def load_yaml(path):
@@ -22,6 +28,14 @@ def automation_by_id(package, automation_id):
 
 def script_step_services(script):
     return [step.get("service") for step in script["sequence"] if isinstance(step, dict)]
+
+
+def render_template(template, state_map, **variables):
+    environment = Environment()
+    environment.globals["is_state"] = lambda entity_id, state: (
+        state_map.get(entity_id) == state
+    )
+    return environment.from_string(template).render(**variables).strip()
 
 
 def test_secure_house_away_context_waits_for_front_door_to_settle_before_reading_state():
@@ -64,6 +78,8 @@ def test_secure_house_sanity_script_aggregates_and_stays_notify_first():
     assert "lock.front_door" in text
     assert "cover.garage_door" in text
     assert "alarm_control_panel.home_alarm" in text
+    assert "security_door_contacts" in text
+    assert "open_security_contact_count" in text
     assert "findings.items | join" in text
     assert "mismatch_count | int > 0" in text
     assert "1 if front_door_state != 'locked' else 0" in text
@@ -76,6 +92,56 @@ def test_secure_house_sanity_script_aggregates_and_stays_notify_first():
     assert "cover.close_cover" not in services
     assert "alarm_control_panel.alarm_arm_night" not in services
     assert "alarm_control_panel.alarm_arm_away" not in services
+
+
+def test_secure_house_sanity_lists_open_security_contacts_in_one_findings_summary():
+    package = load_yaml(SECURITY)
+    variables = package["script"]["secure_house_sanity_check"]["sequence"][1][
+        "variables"
+    ]
+    secure_states = {
+        "binary_sensor.entry_front_door": "off",
+        "binary_sensor.kitchen_back_door": "off",
+        "binary_sensor.garage_garage_interior_door": "off",
+    }
+    open_contact_states = {
+        **secure_states,
+        "binary_sensor.kitchen_back_door": "on",
+        "binary_sensor.garage_garage_interior_door": "on",
+    }
+    finding_variables = {
+        "front_door_state": "locked",
+        "garage_door_state": "closed",
+        "alarm_state": "armed_night",
+        "expected_alarm_state": "armed_night",
+        "expected_alarm_label": "night",
+        "security_door_contacts": SECURITY_DOOR_CONTACTS,
+    }
+
+    assert variables["security_door_contacts"] == SECURITY_DOOR_CONTACTS
+    assert render_template(
+        variables["open_security_contact_count"], secure_states, **finding_variables
+    ) == "0"
+    assert render_template(
+        variables["security_findings"], secure_states, **finding_variables
+    ) == ""
+    assert render_template(
+        variables["open_security_contact_count"],
+        open_contact_states,
+        **finding_variables,
+    ) == "2"
+    findings = render_template(
+        variables["security_findings"], open_contact_states, **finding_variables
+    )
+    assert "Back Door contact is open." in findings
+    assert "Garage Interior Door contact is open." in findings
+    assert "Front Door contact is open." not in findings
+    assert render_template(
+        variables["mismatch_count"],
+        open_contact_states,
+        open_security_contact_count=2,
+        **finding_variables,
+    ) == "2"
 
 
 def test_secure_house_actions_require_explicit_notification_events():


### PR DESCRIPTION
## Summary
- add Front Door, Back Door, and Garage Interior Door contacts to the existing secure-house findings
- count open contacts in the single consolidated alert without changing remediation actions
- add rendered template coverage for quiet and open-contact paths; retain Good Night and everyone-left caller assertions

## Validation
- `python -m pytest -q` (93 passed)
- `python -m pytest -q tests/test_security_sanity.py tests/test_security_door_alerts.py` (10 passed)
- Parsed 24 package YAML files with PyYAML
- `git diff --check` and diff hygiene checks passed

## Documentation impact
None: this is a focused behavior extension within the existing `security_sanity.yaml` package; no package inventory or operator workflow changed.

Closes #177