### PR TITLE
feat(notifications): alert on open garage interior door

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -27,7 +27,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `climate_schedule.yaml` | Baseline climate control for the dining-room thermostat: setpoint helpers, schedule windows, occupied setpoint application, and startup resync. |
 | `device_batteries.yaml` | Battery monitoring rollups, proactive alert thresholds, critical/low battery notifications, and notification action handling. |
 | `device_connectivity.yaml` | Device health monitoring for stale devices, Z-Wave node health, integration availability, and conservative alerting. |
-| `exterior_door_monitoring.yaml` | Two-minute continuous-open household alerts and matching per-door tagged clears for the front and back exterior contacts. The garage interior contact remains separately scoped as a garage-to-house boundary. |
+| `exterior_door_monitoring.yaml` | Two-minute continuous-open household alerts and matching per-door tagged clears for the front, back, and garage interior contacts. Immediate armed-security and secure-house checks remain in their separate packages. |
 | `garage_door_monitoring.yaml` | Garage-door open-duration monitoring, reminder/escalation helpers, actionable notifications, and related scripts/templates. |
 | `known_batteries.yaml` | Template sensors that normalize known battery-powered devices into consistent names and attributes for the battery-health package. |
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |

--- a/packages/exterior_door_monitoring.yaml
+++ b/packages/exterior_door_monitoring.yaml
@@ -5,9 +5,9 @@
 # Sends one tagged household notification when a monitored exterior door remains
 # open for two minutes, then clears only that door's tag when it closes.
 #
-# The garage interior contact is intentionally excluded: this package monitors
-# exterior entry points. Its garage-to-house security-boundary treatment needs a
-# separately scoped decision rather than silently treating it as exterior.
+# The garage interior contact is included here only for this two-minute
+# household reminder. Its immediate armed-security and secure-house workflows
+# remain separately owned by their respective packages.
 
 homeassistant:
   customize:
@@ -19,6 +19,9 @@ homeassistant:
         binary_sensor.kitchen_back_door:
           name: "Back Door"
           tag: "exterior-door-open-back"
+        binary_sensor.garage_garage_interior_door:
+          name: "Garage Interior Door"
+          tag: "exterior-door-open-garage-interior"
 
 automation:
   - id: "exterior_door_open_two_minute_alert"
@@ -33,6 +36,7 @@ automation:
         entity_id:
           - binary_sensor.entry_front_door
           - binary_sensor.kitchen_back_door
+          - binary_sensor.garage_garage_interior_door
         from: "off"
         to: "on"
         for: "00:02:00"
@@ -46,7 +50,7 @@ automation:
           data:
             tag: "{{ door_contacts[trigger.entity_id]['tag'] }}"
     mode: parallel
-    max: 2
+    max: 3
 
   - id: "exterior_door_close_clear_alert"
     alias: "Exterior Door Close Clear Alert"
@@ -58,6 +62,7 @@ automation:
         entity_id:
           - binary_sensor.entry_front_door
           - binary_sensor.kitchen_back_door
+          - binary_sensor.garage_garage_interior_door
         from: "on"
         to: "off"
     action:
@@ -67,4 +72,4 @@ automation:
           data:
             tag: "{{ door_contacts[trigger.entity_id]['tag'] }}"
     mode: parallel
-    max: 2
+    max: 3

--- a/tests/test_exterior_door_monitoring.py
+++ b/tests/test_exterior_door_monitoring.py
@@ -15,6 +15,10 @@ CONTACTS = {
         "name": "Back Door",
         "tag": "exterior-door-open-back",
     },
+    "binary_sensor.garage_garage_interior_door": {
+        "name": "Garage Interior Door",
+        "tag": "exterior-door-open-garage-interior",
+    },
 }
 
 
@@ -29,18 +33,18 @@ def automation_by_id(package, automation_id):
     raise AssertionError(f"automation {automation_id!r} not found")
 
 
-def test_exterior_door_contacts_are_limited_to_front_and_back_doors():
+def test_exterior_door_contacts_include_the_garage_interior_contact():
     package = load_package()
     contacts = package["homeassistant"]["customize"]["package.node_anchors"][
         "exterior_door_contacts"
     ]
 
     assert contacts == CONTACTS
-    assert "binary_sensor.garage_garage_interior_door" not in contacts
-    assert "garage-to-house security-boundary" in PACKAGE.read_text()
+    assert len({contact["tag"] for contact in contacts.values()}) == len(contacts)
+    assert "immediate armed-security and secure-house workflows" in PACKAGE.read_text()
 
 
-def test_open_alert_holds_for_two_continuous_minutes_and_uses_stable_tags():
+def test_open_alert_holds_for_two_continuous_minutes_and_cancels_on_early_close():
     package = load_package()
     automation = automation_by_id(package, "exterior_door_open_two_minute_alert")
 
@@ -53,6 +57,8 @@ def test_open_alert_holds_for_two_continuous_minutes_and_uses_stable_tags():
             "for": "00:02:00",
         }
     ]
+    # A state trigger with `for` only fires after an uninterrupted off -> on
+    # hold; returning to off before two minutes cancels the pending trigger.
     assert automation["variables"] == {"door_contacts": CONTACTS}
     assert automation["action"] == [
         {
@@ -70,7 +76,7 @@ def test_open_alert_holds_for_two_continuous_minutes_and_uses_stable_tags():
         }
     ]
     assert automation["mode"] == "parallel"
-    assert automation["max"] == 2
+    assert automation["max"] == 3
 
 
 def test_close_clears_only_the_matching_tag_for_each_monitored_door():
@@ -98,7 +104,7 @@ def test_close_clears_only_the_matching_tag_for_each_monitored_door():
         }
     ]
     assert automation["mode"] == "parallel"
-    assert automation["max"] == 2
+    assert automation["max"] == 3
 
 
 def test_historical_brian_only_back_door_automation_is_not_present():


### PR DESCRIPTION
## Summary
- adds Garage Interior Door to the package-owned two-minute continuous-open household alert
- uses the stable `exterior-door-open-garage-interior` tag and matching close-only clear
- increases parallel capacity to cover all three monitored contacts and updates focused contract tests/docs

## Validation
- `pytest -q tests/test_exterior_door_monitoring.py` (4 passed)
- `pytest -q` (93 passed)
- Home Assistant Docker config check: `hass -c /config --script check_config` (passed)
- `git diff --check` (passed)

## Documentation impact
Updated `packages/README.md` to describe Garage Interior Door coverage and its separate security workflows.

Closes #183