### PR TITLE
feat(routines): prompt for open windows before arming

### DIFF
--- a/packages/routines.yaml
+++ b/packages/routines.yaml
@@ -64,6 +64,32 @@ script:
           garage_notification_tag: >
             good-night-garage-door-{{ (now().timestamp() * 1000) | int }}-{{ range(0,
             999) | random }}
+          security_window_contacts:
+            binary_sensor.kitchen_kitchen_porch_window: "Kitchen Porch Window"
+            binary_sensor.kitchen_kitchen_sink_window: "Kitchen Sink Window"
+            binary_sensor.living_room_living_room_window: "Living Room Window"
+            binary_sensor.master_bedroom_brian_s_window: "Brian's Window"
+            binary_sensor.master_bedroom_hester_s_window: "Hester's Window"
+            binary_sensor.porter_s_room_porter_s_window: "Porter's Window"
+            binary_sensor.towner_s_room_towner_s_window: "Towner's Window"
+            binary_sensor.office_window: "Office Window"
+          has_open_windows: >
+            {% for entity_id in security_window_contacts %}
+              {% if is_state(entity_id, 'on') %}
+                true
+              {% endif %}
+            {% endfor %}
+          open_window_names: >
+            {% set windows = namespace(names=[]) %}
+            {% for entity_id, name in security_window_contacts.items() %}
+              {% if is_state(entity_id, 'on') %}
+                {% set windows.names = windows.names + [name] %}
+              {% endif %}
+            {% endfor %}
+            {{ windows.names | join(', ') }}
+          window_notification_tag: >
+            good-night-open-windows-{{ (now().timestamp() * 1000) | int }}-{{ range(0,
+            999) | random }}
 
       # Always: Turn off outside lights
       - service: light.turn_off
@@ -194,9 +220,6 @@ script:
                     target:
                       entity_id: light.downstairs_lights
               # Always: Arm the alarm system for night mode
-              - service: alarm_control_panel.alarm_arm_night
-                target:
-                  entity_id: alarm_control_panel.home_alarm
 
           # If dishwasher state is unavailable
           - conditions:
@@ -246,9 +269,6 @@ script:
                     target:
                       entity_id: light.downstairs_lights
               # Always: Arm the alarm system
-              - service: alarm_control_panel.alarm_arm_night
-                target:
-                  entity_id: alarm_control_panel.home_alarm
 
         # Default: Dishwasher is available but not running
         default:
@@ -305,10 +325,44 @@ script:
                 target:
                   entity_id: light.downstairs_lights
 
-          # Always: Arm the alarm system for night mode
-          - service: alarm_control_panel.alarm_arm_night
-            target:
-              entity_id: alarm_control_panel.home_alarm
+      # Before final arming, name any open windows and require an explicit
+      # Continue action or a bounded timeout. Window contacts are read-only;
+      # Good Night never attempts to close a window.
+      - if:
+          - condition: template
+            value_template: "{{ has_open_windows }}"
+        then:
+          - service: notify.all_mobile_devices
+            data:
+              title: "Good Night Routine"
+              message: >
+                Windows still open: {{ open_window_names }}. Close them if appropriate, then
+                choose Continue to arm Night anyway.
+              data:
+                tag: "{{ window_notification_tag }}"
+                when: "{{ now().timestamp() | int }}"
+                priority: "high"
+                ttl: 0
+                actions:
+                  - action: "good_night_continue_with_open_windows"
+                    title: "Acknowledge & Continue"
+          - wait_for_trigger:
+              - platform: event
+                event_type: mobile_app_notification_action
+                event_data:
+                  action: good_night_continue_with_open_windows
+            continue_on_timeout: true
+            timeout: "00:02:00"
+          - service: notify.all_mobile_devices
+            data:
+              message: "clear_notification"
+              data:
+                tag: "{{ window_notification_tag }}"
+
+      # Always arm Night after the dishwasher and open-window decisions.
+      - service: alarm_control_panel.alarm_arm_night
+        target:
+          entity_id: alarm_control_panel.home_alarm
 
       # Final security sanity check: alert only if the house is still not
       # secure after Good Night has had a moment to run its arm/lock handlers.

--- a/tests/test_security_sanity.py
+++ b/tests/test_security_sanity.py
@@ -174,6 +174,100 @@ def test_good_night_invokes_secure_house_check_after_routine_sequence():
     }
 
 
+def good_night_window_decision(script):
+    for step in script["sequence"]:
+        if "if" not in step:
+            continue
+        condition = step["if"][0]
+        if "has_open_windows" in condition.get("value_template", ""):
+            return step
+    raise AssertionError("Good Night open-window decision not found")
+
+
+def test_good_night_open_window_trace_names_only_open_windows_before_arming():
+    script = load_yaml(ROUTINES)["script"]["good_night"]
+    variables = next(step["variables"] for step in script["sequence"] if "variables" in step)
+    window_contacts = {
+        "binary_sensor.kitchen_kitchen_porch_window": "Kitchen Porch Window",
+        "binary_sensor.kitchen_kitchen_sink_window": "Kitchen Sink Window",
+        "binary_sensor.living_room_living_room_window": "Living Room Window",
+        "binary_sensor.master_bedroom_brian_s_window": "Brian's Window",
+        "binary_sensor.master_bedroom_hester_s_window": "Hester's Window",
+        "binary_sensor.porter_s_room_porter_s_window": "Porter's Window",
+        "binary_sensor.towner_s_room_towner_s_window": "Towner's Window",
+        "binary_sensor.office_window": "Office Window",
+    }
+    closed_states = {entity_id: "off" for entity_id in window_contacts}
+    open_states = {
+        **closed_states,
+        "binary_sensor.kitchen_kitchen_sink_window": "on",
+        "binary_sensor.office_window": "on",
+    }
+
+    assert variables["security_window_contacts"] == window_contacts
+    assert (
+        render_template(
+            variables["open_window_names"],
+            closed_states,
+            security_window_contacts=window_contacts,
+        )
+        == ""
+    )
+    assert render_template(
+        variables["open_window_names"],
+        open_states,
+        security_window_contacts=window_contacts,
+    ) == "Kitchen Sink Window, Office Window"
+
+    sequence = script["sequence"]
+    decision_index = sequence.index(good_night_window_decision(script))
+    first_arm_index = next(
+        index
+        for index, step in enumerate(sequence)
+        if "alarm_control_panel.alarm_arm_night" in str(step)
+    )
+    assert decision_index < first_arm_index
+
+
+def test_good_night_all_closed_window_trace_skips_the_notification():
+    script = load_yaml(ROUTINES)["script"]["good_night"]
+    decision = good_night_window_decision(script)
+
+    assert decision["if"] == [
+        {"condition": "template", "value_template": "{{ has_open_windows }}"}
+    ]
+    assert "else" not in decision
+
+
+def test_good_night_open_window_timeout_trace_is_bounded_and_continues():
+    decision = good_night_window_decision(load_yaml(ROUTINES)["script"]["good_night"])
+    wait_step = next(step for step in decision["then"] if "wait_for_trigger" in step)
+
+    assert wait_step["continue_on_timeout"] is True
+    assert wait_step["timeout"] == "00:02:00"
+
+
+def test_good_night_open_window_continue_trace_has_an_explicit_action():
+    decision = good_night_window_decision(load_yaml(ROUTINES)["script"]["good_night"])
+    notification = decision["then"][0]
+    wait_step = decision["then"][1]
+
+    assert notification["service"] == "notify.all_mobile_devices"
+    assert notification["data"]["data"]["actions"] == [
+        {
+            "action": "good_night_continue_with_open_windows",
+            "title": "Acknowledge & Continue",
+        }
+    ]
+    assert wait_step["wait_for_trigger"] == [
+        {
+            "platform": "event",
+            "event_type": "mobile_app_notification_action",
+            "event_data": {"action": "good_night_continue_with_open_windows"},
+        }
+    ]
+
+
 def test_everyone_left_invokes_same_secure_house_check():
     package = load_yaml(PRESENCE)
     automation = automation_by_id(package, "presence_everyone_left")


### PR DESCRIPTION
## Summary
- Add a read-only Good Night open-window decision before the single final Night-arm call.
- Name open windows, offer Acknowledge & Continue, and bound the wait at two minutes.
- Preserve Guest Mode, garage, dishwasher, and final secure-house sanity behavior with trace coverage.

## Validation
- ........................................................................ [ 74%]
.........................                                                [100%]
97 passed in 4.54s (97 passed)
- Changed YAML parsed with PyYAML
- 

Closes #193