### PR TITLE
feat(contacts): add protected contact summary

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -33,6 +33,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
 | `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |
 | `presence.yaml` | Presence-related behavior, including alarm-panel helpers and lighting automations tied to occupancy/time conditions. |
+| `protected_contacts.yaml` | Canonical, read-only inventory and open-state summary for eight window contacts plus Front Door, Back Door, and Garage Interior Door. Future packages should consume this seam rather than duplicate the protected-contact roster. |
 | `remotes.yaml` | Z-Wave remote support: helper toggles, scripts, and blueprint-backed automations for Brian and Hester remotes. |
 | `routines.yaml` | Household scripts such as the Good Night routine, intended for direct calls from automations, dashboards, or voice assistants. |
 | `seasonal.yaml` | Active seasonal lighting automation, currently for seasonal/holiday decoration behavior. |
@@ -70,6 +71,16 @@ Notification-heavy packages include:
 - `security_sanity.yaml`
 - `towner_notifications.yaml`
 - `window_ventilation.yaml`
+
+## Protected-contact state seam
+
+`protected_contacts.yaml` owns the complete protected-contact inventory. Its
+`sensor.protected_contact_summary` state is the number of currently open
+contacts; its attributes expose friendly-name lists for open windows and
+security-boundary doors, plus separate unavailable and unknown contact counts
+and lists. The summary is read-only and creates no notifications. Other
+packages should read `sensor.protected_contact_inventory` and
+`sensor.protected_contact_summary` instead of embedding another contact list.
 
 ## Dashboards and operator views
 

--- a/packages/protected_contacts.yaml
+++ b/packages/protected_contacts.yaml
@@ -1,0 +1,137 @@
+# packages/protected_contacts.yaml
+#
+# Canonical, read-only inventory and state summary for protected window and
+# security-boundary door contacts. Other packages should consume the inventory
+# and summary attributes rather than copy the contact roster.
+#
+# This package deliberately contains no automations, scripts, or notifications.
+
+template:
+  - sensor:
+      - name: "Protected Contact Inventory"
+        unique_id: protected_contact_inventory
+        icon: mdi:shield-home-outline
+        state: "11"
+        attributes:
+          contacts: >
+            {{ [
+              {'entity_id': 'binary_sensor.kitchen_kitchen_porch_window', 'name': 'Kitchen Porch Window', 'category': 'window'},
+              {'entity_id': 'binary_sensor.kitchen_kitchen_sink_window', 'name': 'Kitchen Sink Window', 'category': 'window'},
+              {'entity_id': 'binary_sensor.living_room_living_room_window', 'name': 'Living Room Window', 'category': 'window'},
+              {'entity_id': 'binary_sensor.master_bedroom_brian_s_window', 'name': "Brian's Window", 'category': 'window'},
+              {'entity_id': 'binary_sensor.master_bedroom_hester_s_window', 'name': "Hester's Window", 'category': 'window'},
+              {'entity_id': 'binary_sensor.porter_s_room_porter_s_window', 'name': "Porter's Window", 'category': 'window'},
+              {'entity_id': 'binary_sensor.towner_s_room_towner_s_window', 'name': "Towner's Window", 'category': 'window'},
+              {'entity_id': 'binary_sensor.office_window', 'name': 'Office Window', 'category': 'window'},
+              {'entity_id': 'binary_sensor.entry_front_door', 'name': 'Front Door', 'category': 'security_boundary_door'},
+              {'entity_id': 'binary_sensor.kitchen_back_door', 'name': 'Back Door', 'category': 'security_boundary_door'},
+              {'entity_id': 'binary_sensor.garage_garage_interior_door', 'name': 'Garage Interior Door', 'category': 'security_boundary_door'}
+            ] }}
+          categories: "{{ ['window', 'security_boundary_door'] }}"
+          window_count: 8
+          security_boundary_door_count: 3
+
+      - name: "Protected Contact Summary"
+        unique_id: protected_contact_summary
+        icon: mdi:shield-alert-outline
+        state: >
+          {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+          {% set ns = namespace(open_count=0) %}
+          {% for contact in contacts %}
+            {% if states(contact.entity_id) == 'on' %}
+              {% set ns.open_count = ns.open_count + 1 %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.open_count }}
+        unit_of_measurement: "open contacts"
+        attributes:
+          inventory_entity: sensor.protected_contact_inventory
+          total_count: "{{ state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) | length }}"
+          status: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(open_count=0, unavailable_count=0, unknown_count=0) %}
+            {% for contact in contacts %}
+              {% set contact_state = states(contact.entity_id) %}
+              {% if contact_state == 'on' %}
+                {% set ns.open_count = ns.open_count + 1 %}
+              {% elif contact_state == 'unavailable' %}
+                {% set ns.unavailable_count = ns.unavailable_count + 1 %}
+              {% elif contact_state == 'unknown' %}
+                {% set ns.unknown_count = ns.unknown_count + 1 %}
+              {% endif %}
+            {% endfor %}
+            {% if ns.open_count > 0 %}
+              open
+            {% elif ns.unavailable_count > 0 and ns.unknown_count > 0 %}
+              degraded
+            {% elif ns.unavailable_count > 0 %}
+              unavailable
+            {% elif ns.unknown_count > 0 %}
+              unknown
+            {% else %}
+              closed
+            {% endif %}
+          open_count: "{{ this.state | int(0) }}"
+          open_contacts: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(names=[]) %}
+            {% for contact in contacts %}
+              {% if states(contact.entity_id) == 'on' %}
+                {% set ns.names = ns.names + [contact.name] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.names | join(', ') if ns.names else 'None' }}
+          open_windows: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(names=[]) %}
+            {% for contact in contacts %}
+              {% if contact.category == 'window' and states(contact.entity_id) == 'on' %}
+                {% set ns.names = ns.names + [contact.name] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.names | join(', ') if ns.names else 'None' }}
+          open_security_boundary_doors: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(names=[]) %}
+            {% for contact in contacts %}
+              {% if contact.category == 'security_boundary_door' and states(contact.entity_id) == 'on' %}
+                {% set ns.names = ns.names + [contact.name] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.names | join(', ') if ns.names else 'None' }}
+          unavailable_count: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(count=0) %}
+            {% for contact in contacts %}
+              {% if states(contact.entity_id) == 'unavailable' %}
+                {% set ns.count = ns.count + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.count }}
+          unavailable_contacts: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(names=[]) %}
+            {% for contact in contacts %}
+              {% if states(contact.entity_id) == 'unavailable' %}
+                {% set ns.names = ns.names + [contact.name] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.names | join(', ') if ns.names else 'None' }}
+          unknown_count: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(count=0) %}
+            {% for contact in contacts %}
+              {% if states(contact.entity_id) == 'unknown' %}
+                {% set ns.count = ns.count + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.count }}
+          unknown_contacts: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set ns = namespace(names=[]) %}
+            {% for contact in contacts %}
+              {% if states(contact.entity_id) == 'unknown' %}
+                {% set ns.names = ns.names + [contact.name] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.names | join(', ') if ns.names else 'None' }}

--- a/tests/test_protected_contacts.py
+++ b/tests/test_protected_contacts.py
@@ -1,0 +1,142 @@
+import ast
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "protected_contacts.yaml"
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def sensor_by_name(package, name):
+    for block in package["template"]:
+        for sensor in block.get("sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"sensor {name!r} not found")
+
+
+def inventory_contacts(package):
+    inventory = sensor_by_name(package, "Protected Contact Inventory")
+    rendered = Environment().from_string(inventory["attributes"]["contacts"]).render()
+    return ast.literal_eval(rendered)
+
+
+def render(template, contacts, state_map):
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals.update(
+        states=lambda entity_id: state_map.get(entity_id, "unknown"),
+        state_attr=lambda entity_id, attribute: (
+            contacts
+            if (entity_id, attribute)
+            == ("sensor.protected_contact_inventory", "contacts")
+            else None
+        ),
+    )
+    return environment.from_string(template).render().strip()
+
+
+def all_closed(contacts):
+    return {contact["entity_id"]: "off" for contact in contacts}
+
+
+def test_protected_contact_inventory_is_the_single_canonical_roster():
+    package = load_package()
+    inventory = sensor_by_name(package, "Protected Contact Inventory")
+    contacts = inventory_contacts(package)
+
+    assert inventory["unique_id"] == "protected_contact_inventory"
+    assert len(contacts) == 11
+    assert inventory["attributes"]["window_count"] == 8
+    assert inventory["attributes"]["security_boundary_door_count"] == 3
+    assert {contact["category"] for contact in contacts} == {
+        "window",
+        "security_boundary_door",
+    }
+    assert {contact["entity_id"] for contact in contacts} == {
+        "binary_sensor.kitchen_kitchen_porch_window",
+        "binary_sensor.kitchen_kitchen_sink_window",
+        "binary_sensor.living_room_living_room_window",
+        "binary_sensor.master_bedroom_brian_s_window",
+        "binary_sensor.master_bedroom_hester_s_window",
+        "binary_sensor.porter_s_room_porter_s_window",
+        "binary_sensor.towner_s_room_towner_s_window",
+        "binary_sensor.office_window",
+        "binary_sensor.entry_front_door",
+        "binary_sensor.kitchen_back_door",
+        "binary_sensor.garage_garage_interior_door",
+    }
+
+
+def test_protected_contact_summary_reports_all_closed_without_false_open_or_health_status():
+    package = load_package()
+    summary = sensor_by_name(package, "Protected Contact Summary")
+    contacts = inventory_contacts(package)
+    states = all_closed(contacts)
+
+    assert render(summary["state"], contacts, states) == "0"
+    assert render(summary["attributes"]["status"], contacts, states) == "closed"
+    assert render(summary["attributes"]["open_contacts"], contacts, states) == "None"
+    assert render(summary["attributes"]["open_windows"], contacts, states) == "None"
+    assert (
+        render(summary["attributes"]["open_security_boundary_doors"], contacts, states)
+        == "None"
+    )
+    assert render(summary["attributes"]["unavailable_count"], contacts, states) == "0"
+    assert render(summary["attributes"]["unknown_count"], contacts, states) == "0"
+
+
+def test_protected_contact_summary_reports_one_open_contact_with_name_and_category():
+    package = load_package()
+    summary = sensor_by_name(package, "Protected Contact Summary")
+    contacts = inventory_contacts(package)
+    states = all_closed(contacts)
+    states["binary_sensor.office_window"] = "on"
+
+    assert render(summary["state"], contacts, states) == "1"
+    assert render(summary["attributes"]["status"], contacts, states) == "open"
+    assert render(summary["attributes"]["open_contacts"], contacts, states) == "Office Window"
+    assert render(summary["attributes"]["open_windows"], contacts, states) == "Office Window"
+    assert (
+        render(summary["attributes"]["open_security_boundary_doors"], contacts, states)
+        == "None"
+    )
+
+
+def test_protected_contact_summary_distinguishes_unavailable_and_unknown_from_closed():
+    package = load_package()
+    summary = sensor_by_name(package, "Protected Contact Summary")
+    contacts = inventory_contacts(package)
+    states = all_closed(contacts)
+    states["binary_sensor.kitchen_kitchen_sink_window"] = "unavailable"
+    states["binary_sensor.kitchen_back_door"] = "unknown"
+
+    assert render(summary["state"], contacts, states) == "0"
+    assert render(summary["attributes"]["status"], contacts, states) == "degraded"
+    assert render(summary["attributes"]["unavailable_count"], contacts, states) == "1"
+    assert (
+        render(summary["attributes"]["unavailable_contacts"], contacts, states)
+        == "Kitchen Sink Window"
+    )
+    assert render(summary["attributes"]["unknown_count"], contacts, states) == "1"
+    assert (
+        render(summary["attributes"]["unknown_contacts"], contacts, states)
+        == "Back Door"
+    )
+
+
+def test_protected_contact_summary_is_read_only_and_references_the_inventory_seam():
+    package = load_package()
+    summary = sensor_by_name(package, "Protected Contact Summary")
+
+    assert "automation" not in package
+    assert "script" not in package
+    assert summary["attributes"]["inventory_entity"] == "sensor.protected_contact_inventory"
+    assert "sensor.protected_contact_inventory" in summary["state"]
+    assert "sensor.protected_contact_inventory" in str(summary["attributes"])
+    assert "binary_sensor.office_window" not in str(summary)


### PR DESCRIPTION
## Summary
- Adds a canonical read-only inventory for eight window contacts and three security-boundary door contacts.
- Exposes open counts, friendly-name category lists, and distinct unavailable/unknown status details.
- Documents the state seam and adds focused rendered-template coverage.

## Validation
- `python -m pytest -q tests/test_protected_contacts.py` — 5 passed
- `python -m pytest -q` — 98 passed
- PyYAML parse and `git diff --check` — passed
- Local Home Assistant config check was not available because the `homeassistant` Python module is not installed; the repository CI supplies the Home Assistant configuration check.

Closes #190
