### PR TITLE
feat(device-health): monitor critical window contacts

### DIFF
--- a/packages/device_connectivity.yaml
+++ b/packages/device_connectivity.yaml
@@ -6,9 +6,9 @@
 # - Z-Wave node health monitoring
 # - Stale last-seen entity detection
 # - Integration update entity availability checks
-# - Critical exterior/security door contact availability checks
+# - Critical exterior/security contact availability checks
 
-# The current door-contact integration does not expose separate battery entities
+# The current critical-contact integration does not expose separate battery entities
 # in this repository. If it later does, add normalized battery sensors in
 # known_batteries.yaml; device_batteries.yaml will include them automatically.
 
@@ -40,13 +40,23 @@ input_number:
 
 template:
   - sensor:
-      - name: "Device Connectivity Critical Door Contact Problems"
+      # Keep the existing unique_id so Home Assistant retains the established
+      # entity while the protected-contact set expands beyond the three doors.
+      - name: "Device Connectivity Critical Contact Problems"
         unique_id: device_connectivity_critical_door_contact_problems
         state: >
           {% set contacts = {
             'binary_sensor.entry_front_door': 'Front Door Contact',
             'binary_sensor.kitchen_back_door': 'Back Door Contact',
-            'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact'
+            'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact',
+            'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
+            'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
+            'binary_sensor.living_room_living_room_window': 'Living Room Window',
+            'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
+            'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
+            'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
+            'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
+            'binary_sensor.office_window': 'Office Window'
           } %}
           {% set ns = namespace(problems=[]) %}
           {% for entity_id, name in contacts.items() %}
@@ -62,7 +72,15 @@ template:
             {% set contacts = {
               'binary_sensor.entry_front_door': 'Front Door Contact',
               'binary_sensor.kitchen_back_door': 'Back Door Contact',
-              'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact'
+              'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact',
+              'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
+              'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
+              'binary_sensor.living_room_living_room_window': 'Living Room Window',
+              'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
+              'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
+              'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
+              'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
+              'binary_sensor.office_window': 'Office Window'
             } %}
             {% set ns = namespace(problems=[]) %}
             {% for entity_id, name in contacts.items() %}
@@ -179,6 +197,8 @@ template:
             {{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}
           critical_door_contact_problems: >
             {{ state_attr('sensor.device_connectivity_critical_door_contact_problems', 'problem_contacts') }}
+          critical_contact_problems: >
+            {{ state_attr('sensor.device_connectivity_critical_door_contact_problems', 'problem_contacts') }}
 
   - binary_sensor:
       - name: "Device Connectivity Has Issues"
@@ -192,7 +212,7 @@ automation:
     id: "device_connectivity_issue_alert"
     description: >
       Alert when Z-Wave nodes, last_seen sensors, integration update entities,
-      or critical door contacts look unhealthy for 15 continuous minutes.
+      or critical contacts look unhealthy for 15 continuous minutes.
     trigger:
       - platform: state
         entity_id: binary_sensor.device_connectivity_has_issues
@@ -218,11 +238,11 @@ automation:
           zwave_count: "{{ states('sensor.device_connectivity_z_wave_problems') | int(0) }}"
           stale_count: "{{ states('sensor.device_connectivity_stale_last_seen') | int(0) }}"
           integration_count: "{{ states('sensor.device_connectivity_integration_problems') | int(0) }}"
-          door_contact_count: "{{ states('sensor.device_connectivity_critical_door_contact_problems') | int(0) }}"
+          critical_contact_count: "{{ states('sensor.device_connectivity_critical_door_contact_problems') | int(0) }}"
           zwave_summary: "{{ state_attr('sensor.device_connectivity_z_wave_problems', 'problem_nodes') }}"
           stale_summary: "{{ state_attr('sensor.device_connectivity_stale_last_seen', 'stale_devices') }}"
           integration_summary: "{{ state_attr('sensor.device_connectivity_integration_problems', 'problem_updates') }}"
-          door_contact_summary: "{{ state_attr('sensor.device_connectivity_critical_door_contact_problems', 'problem_contacts') }}"
+          critical_contact_summary: "{{ state_attr('sensor.device_connectivity_critical_door_contact_problems', 'problem_contacts') }}"
       - service: notify.all_mobile_devices
         data:
           title: "Device Connectivity Alert"
@@ -231,7 +251,7 @@ automation:
             Z-Wave: {{ zwave_count }} ({{ zwave_summary }}).
             Last seen: {{ stale_count }} ({{ stale_summary }}).
             Integrations: {{ integration_count }} ({{ integration_summary }}).
-            Critical door contacts: {{ door_contact_count }} ({{ door_contact_summary }}).
+            Critical contacts: {{ critical_contact_count }} ({{ critical_contact_summary }}).
           data:
             tag: "device-connectivity-alert"
             priority: "high"
@@ -247,7 +267,7 @@ automation:
 
             Unavailable update entities: {{ integration_summary }}
 
-            Critical door contacts: {{ door_contact_summary }}
+            Critical contacts: {{ critical_contact_summary }}
 
             Threshold: {{ states('input_number.device_connectivity_last_seen_threshold_hours') | int(24) }} hours
 

--- a/packages/device_connectivity.yaml
+++ b/packages/device_connectivity.yaml
@@ -41,52 +41,29 @@ input_number:
 template:
   - sensor:
       # Keep the existing unique_id so Home Assistant retains the established
-      # entity while the protected-contact set expands beyond the three doors.
+      # entity while the canonical protected-contact inventory includes doors
+      # and windows.
       - name: "Device Connectivity Critical Contact Problems"
         unique_id: device_connectivity_critical_door_contact_problems
         state: >
-          {% set contacts = {
-            'binary_sensor.entry_front_door': 'Front Door Contact',
-            'binary_sensor.kitchen_back_door': 'Back Door Contact',
-            'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact',
-            'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
-            'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
-            'binary_sensor.living_room_living_room_window': 'Living Room Window',
-            'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
-            'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
-            'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
-            'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
-            'binary_sensor.office_window': 'Office Window'
-          } %}
+          {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
           {% set ns = namespace(problems=[]) %}
-          {% for entity_id, name in contacts.items() %}
-            {% set state = states(entity_id) %}
+          {% for contact in contacts %}
+            {% set state = states(contact.entity_id) %}
             {% if state in ['unavailable', 'unknown'] %}
-              {% set ns.problems = ns.problems + [name] %}
+              {% set ns.problems = ns.problems + [contact.name] %}
             {% endif %}
           {% endfor %}
           {{ ns.problems | length }}
         unit_of_measurement: "contacts"
         attributes:
           problem_contacts: >
-            {% set contacts = {
-              'binary_sensor.entry_front_door': 'Front Door Contact',
-              'binary_sensor.kitchen_back_door': 'Back Door Contact',
-              'binary_sensor.garage_garage_interior_door': 'Garage Interior Door Contact',
-              'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
-              'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
-              'binary_sensor.living_room_living_room_window': 'Living Room Window',
-              'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
-              'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
-              'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
-              'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
-              'binary_sensor.office_window': 'Office Window'
-            } %}
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
             {% set ns = namespace(problems=[]) %}
-            {% for entity_id, name in contacts.items() %}
-              {% set state = states(entity_id) %}
+            {% for contact in contacts %}
+              {% set state = states(contact.entity_id) %}
               {% if state in ['unavailable', 'unknown'] %}
-                {% set ns.problems = ns.problems + [name ~ ' (' ~ state ~ ')'] %}
+                {% set ns.problems = ns.problems + [contact.name ~ ' (' ~ state ~ ')'] %}
               {% endif %}
             {% endfor %}
             {{ ns.problems | join(', ') if ns.problems else 'None' }}

--- a/tests/test_device_connectivity_templates.py
+++ b/tests/test_device_connectivity_templates.py
@@ -85,6 +85,7 @@ def test_device_connectivity_zwave_problem_sensor_counts_non_healthy_nodes():
         sensor["state"],
         entities=[
             Entity("sensor.kitchen_node_status", "alive", "Kitchen Node Status"),
+            Entity("sensor.window_node_status", "asleep", "Window Node Status"),
             Entity("sensor.office_node_status", "dead", "Office Node Status"),
             Entity("sensor.bedroom_node_status", "unknown", "Bedroom Node Status"),
             Entity("sensor.hallway_last_seen", FIXED_NOW.isoformat(), "Hallway Last Seen"),
@@ -100,9 +101,9 @@ def test_device_connectivity_stale_last_seen_sensor_ignores_invalid_values_and_f
         sensor["state"],
         entities=[
             Entity(
-                "sensor.front_door_last_seen",
+                "sensor.kitchen_porch_window_last_seen",
                 (FIXED_NOW - timedelta(hours=30)).isoformat(),
-                "Front Door Last Seen",
+                "Kitchen Porch Window Last Seen",
             ),
             Entity(
                 "sensor.office_last_seen",
@@ -116,6 +117,20 @@ def test_device_connectivity_stale_last_seen_sensor_ignores_invalid_values_and_f
     )
 
     assert rendered.strip() == "1"
+    assert (
+        render_template(
+            sensor["attributes"]["stale_devices"],
+            entities=[
+                Entity(
+                    "sensor.kitchen_porch_window_last_seen",
+                    (FIXED_NOW - timedelta(hours=30)).isoformat(),
+                    "Kitchen Porch Window Last Seen",
+                )
+            ],
+            state_map={"input_number.device_connectivity_last_seen_threshold_hours": "24"},
+        ).strip()
+        == "Kitchen Porch Window Last Seen (30.0h)"
+    )
 
 
 def test_device_connectivity_integration_problem_sensor_counts_unavailable_update_entities_only():

--- a/tests/test_door_contact_health.py
+++ b/tests/test_door_contact_health.py
@@ -6,10 +6,18 @@ from jinja2 import Environment
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE = ROOT / "packages" / "device_connectivity.yaml"
-CRITICAL_DOOR_CONTACTS = {
+CRITICAL_CONTACTS = {
     "binary_sensor.entry_front_door": "Front Door Contact",
     "binary_sensor.kitchen_back_door": "Back Door Contact",
     "binary_sensor.garage_garage_interior_door": "Garage Interior Door Contact",
+    "binary_sensor.kitchen_kitchen_porch_window": "Kitchen Porch Window",
+    "binary_sensor.kitchen_kitchen_sink_window": "Kitchen Sink Window",
+    "binary_sensor.living_room_living_room_window": "Living Room Window",
+    "binary_sensor.master_bedroom_brian_s_window": "Brian's Window",
+    "binary_sensor.master_bedroom_hester_s_window": "Hester's Window",
+    "binary_sensor.porter_s_room_porter_s_window": "Porter's Room Window",
+    "binary_sensor.towner_s_room_towner_s_window": "Towner's Room Window",
+    "binary_sensor.office_window": "Office Window",
 }
 
 
@@ -31,36 +39,39 @@ def render(template, state_map):
     return environment.from_string(template).render()
 
 
-def test_critical_door_contact_sensor_flags_only_unavailable_or_unknown_contacts():
+def test_critical_contact_sensor_flags_only_unavailable_or_unknown_contacts():
     package = load_package()
-    sensor = sensor_by_name(package, "Device Connectivity Critical Door Contact Problems")
-    state_map = {
-        "binary_sensor.entry_front_door": "off",
-        "binary_sensor.kitchen_back_door": "unavailable",
-        "binary_sensor.garage_garage_interior_door": "unknown",
-    }
+    sensor = sensor_by_name(package, "Device Connectivity Critical Contact Problems")
+    state_map = {entity_id: "off" for entity_id in CRITICAL_CONTACTS}
+    state_map.update(
+        {
+            "binary_sensor.kitchen_back_door": "unavailable",
+            "binary_sensor.master_bedroom_brian_s_window": "unknown",
+        }
+    )
 
-    assert all(entity_id in sensor["state"] for entity_id in CRITICAL_DOOR_CONTACTS)
+    assert len(CRITICAL_CONTACTS) == 11
+    assert all(entity_id in sensor["state"] for entity_id in CRITICAL_CONTACTS)
     assert render(sensor["state"], state_map).strip() == "2"
     assert render(sensor["attributes"]["problem_contacts"], state_map).strip() == (
-        "Back Door Contact (unavailable), Garage Interior Door Contact (unknown)"
+        "Back Door Contact (unavailable), Brian's Window (unknown)"
     )
 
 
-def test_door_contact_recovery_clears_the_problem_sensor_and_notification():
+def test_healthy_critical_contacts_clear_the_problem_sensor_and_notification():
     package = load_package()
-    sensor = sensor_by_name(package, "Device Connectivity Critical Door Contact Problems")
+    sensor = sensor_by_name(package, "Device Connectivity Critical Contact Problems")
     alert = next(item for item in package["automation"] if item["id"] == "device_connectivity_issue_alert")
     reset = next(
         item for item in package["automation"] if item["id"] == "device_connectivity_issue_alert_reset"
     )
-    recovered_states = {entity_id: "off" for entity_id in CRITICAL_DOOR_CONTACTS}
+    recovered_states = {entity_id: "off" for entity_id in CRITICAL_CONTACTS}
 
     assert render(sensor["state"], recovered_states).strip() == "0"
     assert render(sensor["attributes"]["problem_contacts"], recovered_states).strip() == "None"
     assert alert["trigger"][0]["for"] == {"minutes": 15}
-    assert "door_contact_count" in alert["action"][1]["variables"]
-    assert "door_contact_summary" in alert["action"][1]["variables"]
+    assert "critical_contact_count" in alert["action"][1]["variables"]
+    assert "critical_contact_summary" in alert["action"][1]["variables"]
     assert alert["action"][2]["data"]["data"]["tag"] == "device-connectivity-alert"
     assert reset["action"][-1] == {
         "service": "notify.all_mobile_devices",
@@ -76,4 +87,8 @@ def test_connectivity_summary_consumes_critical_door_contact_problem_count():
     assert (
         "sensor.device_connectivity_critical_door_contact_problems"
         in summary["attributes"]["critical_door_contact_problems"]
+    )
+    assert (
+        "sensor.device_connectivity_critical_door_contact_problems"
+        in summary["attributes"]["critical_contact_problems"]
     )

--- a/tests/test_door_contact_health.py
+++ b/tests/test_door_contact_health.py
@@ -1,3 +1,4 @@
+import ast
 from pathlib import Path
 
 import yaml
@@ -6,19 +7,7 @@ from jinja2 import Environment
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE = ROOT / "packages" / "device_connectivity.yaml"
-CRITICAL_CONTACTS = {
-    "binary_sensor.entry_front_door": "Front Door Contact",
-    "binary_sensor.kitchen_back_door": "Back Door Contact",
-    "binary_sensor.garage_garage_interior_door": "Garage Interior Door Contact",
-    "binary_sensor.kitchen_kitchen_porch_window": "Kitchen Porch Window",
-    "binary_sensor.kitchen_kitchen_sink_window": "Kitchen Sink Window",
-    "binary_sensor.living_room_living_room_window": "Living Room Window",
-    "binary_sensor.master_bedroom_brian_s_window": "Brian's Window",
-    "binary_sensor.master_bedroom_hester_s_window": "Hester's Window",
-    "binary_sensor.porter_s_room_porter_s_window": "Porter's Room Window",
-    "binary_sensor.towner_s_room_towner_s_window": "Towner's Room Window",
-    "binary_sensor.office_window": "Office Window",
-}
+PROTECTED_CONTACTS = ROOT / "packages" / "protected_contacts.yaml"
 
 
 def load_package():
@@ -33,29 +22,57 @@ def sensor_by_name(package, sensor_name):
     raise AssertionError(f"sensor {sensor_name!r} not found")
 
 
-def render(template, state_map):
+def inventory_contacts():
+    package = yaml.safe_load(PROTECTED_CONTACTS.read_text())
+    inventory = sensor_by_name(package, "Protected Contact Inventory")
+    rendered = Environment().from_string(inventory["attributes"]["contacts"]).render()
+    return ast.literal_eval(rendered)
+
+
+def render(template, state_map, contacts=None):
     environment = Environment(trim_blocks=True, lstrip_blocks=True)
-    environment.globals["states"] = lambda entity_id: state_map.get(entity_id, "unknown")
+    environment.globals.update(
+        states=lambda entity_id: state_map.get(entity_id, "unknown"),
+        state_attr=lambda entity_id, attribute: (
+            contacts
+            if (entity_id, attribute)
+            == ("sensor.protected_contact_inventory", "contacts")
+            else None
+        ),
+    )
     return environment.from_string(template).render()
 
 
-def test_critical_contact_sensor_flags_only_unavailable_or_unknown_contacts():
+def test_critical_contact_sensor_consumes_canonical_inventory_for_all_contact_health_states():
     package = load_package()
     sensor = sensor_by_name(package, "Device Connectivity Critical Contact Problems")
-    state_map = {entity_id: "off" for entity_id in CRITICAL_CONTACTS}
+    contacts = inventory_contacts()
+    state_map = {contact["entity_id"]: "off" for contact in contacts}
     state_map.update(
         {
             "binary_sensor.kitchen_back_door": "unavailable",
-            "binary_sensor.master_bedroom_brian_s_window": "unknown",
+            "binary_sensor.porter_s_room_porter_s_window": "unknown",
+            "binary_sensor.towner_s_room_towner_s_window": "unavailable",
         }
     )
 
-    assert len(CRITICAL_CONTACTS) == 11
-    assert all(entity_id in sensor["state"] for entity_id in CRITICAL_CONTACTS)
-    assert render(sensor["state"], state_map).strip() == "2"
-    assert render(sensor["attributes"]["problem_contacts"], state_map).strip() == (
-        "Back Door Contact (unavailable), Brian's Window (unknown)"
+    assert len(contacts) == 11
+    assert "state_attr('sensor.protected_contact_inventory', 'contacts')" in sensor["state"]
+    assert "state_attr('sensor.protected_contact_inventory', 'contacts')" in sensor["attributes"]["problem_contacts"]
+    assert "binary_sensor." not in sensor["state"]
+    assert "binary_sensor." not in sensor["attributes"]["problem_contacts"]
+    assert render(sensor["state"], state_map, contacts).strip() == "3"
+    assert render(sensor["attributes"]["problem_contacts"], state_map, contacts).strip() == (
+        "Porter's Window (unknown), Towner's Window (unavailable), Back Door (unavailable)"
     )
+
+
+def test_critical_contact_sensor_has_an_empty_inventory_fallback():
+    package = load_package()
+    sensor = sensor_by_name(package, "Device Connectivity Critical Contact Problems")
+
+    assert render(sensor["state"], {}, None).strip() == "0"
+    assert render(sensor["attributes"]["problem_contacts"], {}, None).strip() == "None"
 
 
 def test_healthy_critical_contacts_clear_the_problem_sensor_and_notification():
@@ -65,10 +82,11 @@ def test_healthy_critical_contacts_clear_the_problem_sensor_and_notification():
     reset = next(
         item for item in package["automation"] if item["id"] == "device_connectivity_issue_alert_reset"
     )
-    recovered_states = {entity_id: "off" for entity_id in CRITICAL_CONTACTS}
+    contacts = inventory_contacts()
+    recovered_states = {contact["entity_id"]: "off" for contact in contacts}
 
-    assert render(sensor["state"], recovered_states).strip() == "0"
-    assert render(sensor["attributes"]["problem_contacts"], recovered_states).strip() == "None"
+    assert render(sensor["state"], recovered_states, contacts).strip() == "0"
+    assert render(sensor["attributes"]["problem_contacts"], recovered_states, contacts).strip() == "None"
     assert alert["trigger"][0]["for"] == {"minutes": 15}
     assert "critical_contact_count" in alert["action"][1]["variables"]
     assert "critical_contact_summary" in alert["action"][1]["variables"]


### PR DESCRIPTION
## Summary
- Extend the existing critical-contact health sensor from the three protected doors to all eight installed window contacts.
- Keep the established sensor unique ID and summary attribute for compatibility, while adding a contact-neutral summary attribute and alert wording.
- Cover healthy, unavailable/unknown, stale last-seen, and sleeping-node scenarios with focused template tests.

## Validation
- python3 -m pytest -q tests (93 passed)
- Docker Home Assistant config check (passed)
- yamllint (passed with existing line-length warnings only)
- git diff --check

## Safety
- No live Home Assistant configuration, service, reload, or restart was used.

## Documentation impact
- No documentation changes required; the existing device-connectivity package documentation remains accurate.

Closes #186