### PR TITLE
feat(ventilation): surface open window contacts

### DIFF
--- a/dashboards/window_ventilation.yaml
+++ b/dashboards/window_ventilation.yaml
@@ -48,6 +48,8 @@ views:
 
           {{ states('sensor.window_ventilation_reason') }}
 
+          **Open window contacts:** {{ state_attr('sensor.window_ventilation_open_window_summary', 'summary') }}
+
           _Comfort advice is advisory-only. The separate HVAC warning reports
           actual open window contacts but never changes HVAC behavior._
 
@@ -75,6 +77,8 @@ views:
             name: "Recommendation state"
           - entity: sensor.window_ventilation_reason
             name: "Reason"
+          - entity: sensor.window_ventilation_open_window_summary
+            name: "Open window contacts"
           - type: attribute
             entity: sensor.window_ventilation_recommendation
             attribute: mode

--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -3,8 +3,10 @@
 # Advisory window ventilation recommendations using indoor/outdoor comfort,
 # moisture, rain forecast, HVAC state, and household-relative air-quality context.
 #
-# Comfort recommendations are advisory only. A separate notification-only guard
-# reports actual open window contacts while HVAC is actively heating or cooling.
+# Advisory only: window-contact state informs recommendations but is never
+# operated by this package.
+# The separate HVAC warning reports open windows while HVAC is active, but never
+# changes HVAC behavior.
 #
 # Entity mapping is based on GitHub issue #103 triage/recon:
 # - normalized weather seam sensors from packages/weather.yaml:
@@ -152,6 +154,20 @@ template:
           {% endif %}
         attributes:
           advisory_only: true
+          open_window_count: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set open_windows = namespace(count=0) %}
+            {% for contact in contacts if contact.category == 'window' and is_state(contact.entity_id, 'on') %}
+              {% set open_windows.count = open_windows.count + 1 %}
+            {% endfor %}
+            {{ open_windows.count }}
+          open_window_names: >
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+            {% set open_windows = namespace(names=[]) %}
+            {% for contact in contacts if contact.category == 'window' and is_state(contact.entity_id, 'on') %}
+              {% set open_windows.names = open_windows.names + [contact.name] %}
+            {% endfor %}
+            {{ open_windows.names | join(', ') }}
           indoor_temperature: >
             {% set invalid = ['unknown', 'unavailable', '', none] %}
             {% set temp_sensor = states('sensor.dining_room_thermostat_temperature') %}
@@ -320,6 +336,26 @@ template:
             {% set hvac_running = hvac_action in ['heating', 'cooling'] %}
             {{ outdoor_cooler and outdoor_drier and not raining and not hvac_running }}
 
+      - name: "Window Ventilation Open Window Summary"
+        unique_id: window_ventilation_open_window_summary
+        icon: mdi:window-open-variant
+        state: >
+          {{ state_attr('sensor.window_ventilation_decision_context', 'open_window_count') | int(0) }}
+        attributes:
+          advisory_only: true
+          open_window_count: >
+            {{ state_attr('sensor.window_ventilation_decision_context', 'open_window_count') | int(0) }}
+          open_window_names: >
+            {{ state_attr('sensor.window_ventilation_decision_context', 'open_window_names') | default('', true) }}
+          summary: >
+            {% set open_window_count = state_attr('sensor.window_ventilation_decision_context', 'open_window_count') | int(0) %}
+            {% set open_window_names = state_attr('sensor.window_ventilation_decision_context', 'open_window_names') | default('', true) %}
+            {% if open_window_count > 0 %}
+              {{ open_window_count }} open: {{ open_window_names }}
+            {% else %}
+              No monitored windows are open.
+            {% endif %}
+
       - name: "Window Ventilation Recommendation"
         unique_id: window_ventilation_recommendation
         icon: >
@@ -389,6 +425,8 @@ template:
           co2_baseline: "{{ state_attr('sensor.window_ventilation_decision_context', 'co2_baseline') }}"
           voc_current: "{{ state_attr('sensor.window_ventilation_decision_context', 'voc_current') }}"
           voc_baseline: "{{ state_attr('sensor.window_ventilation_decision_context', 'voc_baseline') }}"
+          open_window_count: "{{ state_attr('sensor.window_ventilation_decision_context', 'open_window_count') | int(0) }}"
+          open_window_names: "{{ state_attr('sensor.window_ventilation_decision_context', 'open_window_names') | default('', true) }}"
 
       - name: "Window Ventilation Reason"
         unique_id: window_ventilation_reason
@@ -409,20 +447,22 @@ template:
           {% set outdoor_more_humid = state_attr(ctx, 'outdoor_more_humid') | bool(false) %}
           {% set co2_relative = state_attr(ctx, 'co2_relative') | bool(false) %}
           {% set voc_relative = state_attr(ctx, 'voc_relative') | bool(false) %}
+          {% set open_window_count = state_attr(ctx, 'open_window_count') | int(0) %}
+          {% set open_window_names = state_attr(ctx, 'open_window_names') | default('', true) %}
           {% if rec == 'open' and mode == 'winter_purge' %}
-            Air out the house for 5-10 minutes: indoor air or humidity is above the home's recent baseline, outdoor dew point is acceptable, and HVAC is idle.
+            Recommendation: consider airing out the house for 5-10 minutes; indoor air or humidity is above the home's recent baseline, outdoor dew point is acceptable, and HVAC is idle.
           {% elif rec == 'open_briefly' %}
-            Briefly open windows for a short purge (5-10 minutes): indoor air is poor and worsening versus recent baselines, while outdoor temperature and dew point are within bounded compromise limits. Close windows after the short purge.
+            Recommendation: consider briefly opening windows for a short purge (5-10 minutes). Indoor air is poor and worsening versus recent baselines, while outdoor temperature and dew point are within bounded compromise limits; close windows after the short purge.
           {% elif rec == 'open' %}
-            Open windows: outside is {{ (indoor - outdoor) | round(0) }}°F cooler, outdoor dew point is {{ outdoor_dew | round(0) }}°F vs indoor {{ indoor_dew | round(0) }}°F, and no rain or HVAC conflict is active.
+            Recommendation: consider opening windows. Outside is {{ (indoor - outdoor) | round(0) }}°F cooler, outdoor dew point is {{ outdoor_dew | round(0) }}°F vs indoor {{ indoor_dew | round(0) }}°F, and no rain or HVAC conflict is active.
           {% elif rec == 'close' and raining %}
-            Close windows: rain or mixed precipitation is expected within the hour.
+            {% if open_window_count > 0 %}Close {{ open_window_names }}: {% else %}Keep windows closed: {% endif %}rain or mixed precipitation is expected within the hour.
           {% elif rec == 'close' and hvac_running %}
-            Close windows: HVAC is currently {{ hvac_action }}.
+            {% if open_window_count > 0 %}Close {{ open_window_names }}: {% else %}Keep windows closed: {% endif %}HVAC is currently {{ hvac_action }}.
           {% elif rec == 'close' and outdoor_more_humid %}
-            Close windows: outside air is more humid (dew point {{ outdoor_dew | round(0) }}°F vs indoor {{ indoor_dew | round(0) }}°F).
+            {% if open_window_count > 0 %}Close {{ open_window_names }}: {% else %}Keep windows closed: {% endif %}outside air is more humid (dew point {{ outdoor_dew | round(0) }}°F vs indoor {{ indoor_dew | round(0) }}°F).
           {% elif rec == 'close' %}
-            Close windows: outdoor conditions are no longer meaningfully better than indoors.
+            {% if open_window_count > 0 %}Close {{ open_window_names }}: {% else %}Keep windows closed: {% endif %}outdoor conditions are no longer meaningfully better than indoors.
           {% elif mode == 'winter_purge' %}
             Keep windows closed: outside is cold, HVAC/rain and indoor moisture checks do not justify a brief purge right now.
           {% elif co2_relative or voc_relative %}
@@ -453,60 +493,27 @@ template:
         unique_id: window_hvac_open_warning
         icon: mdi:window-open-variant
         state: >
-          {% set window_contacts = {
-            'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
-            'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
-            'binary_sensor.living_room_living_room_window': 'Living Room Window',
-            'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
-            'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
-            'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
-            'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
-            'binary_sensor.office_window': 'Office Window'
-          } %}
+          {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
           {% set open_windows = namespace(names=[]) %}
-          {% for entity_id, name in window_contacts.items() %}
-            {% if is_state(entity_id, 'on') %}
-              {% set open_windows.names = open_windows.names + [name] %}
-            {% endif %}
+          {% for contact in contacts if contact.category == 'window' and is_state(contact.entity_id, 'on') %}
+            {% set open_windows.names = open_windows.names + [contact.name] %}
           {% endfor %}
           {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
           {{ hvac_action in ['heating', 'cooling'] and (open_windows.names | count > 0) }}
         attributes:
           hvac_action: "{{ state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) }}"
           open_windows: >
-            {% set window_contacts = {
-              'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
-              'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
-              'binary_sensor.living_room_living_room_window': 'Living Room Window',
-              'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
-              'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
-              'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
-              'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
-              'binary_sensor.office_window': 'Office Window'
-            } %}
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
             {% set open_windows = namespace(names=[]) %}
-            {% for entity_id, name in window_contacts.items() %}
-              {% if is_state(entity_id, 'on') %}
-                {% set open_windows.names = open_windows.names + [name] %}
-              {% endif %}
+            {% for contact in contacts if contact.category == 'window' and is_state(contact.entity_id, 'on') %}
+              {% set open_windows.names = open_windows.names + [contact.name] %}
             {% endfor %}
             {{ open_windows.names | join(', ') }}
           open_window_count: >
-            {% set window_contacts = [
-              'binary_sensor.kitchen_kitchen_porch_window',
-              'binary_sensor.kitchen_kitchen_sink_window',
-              'binary_sensor.living_room_living_room_window',
-              'binary_sensor.master_bedroom_brian_s_window',
-              'binary_sensor.master_bedroom_hester_s_window',
-              'binary_sensor.porter_s_room_porter_s_window',
-              'binary_sensor.towner_s_room_towner_s_window',
-              'binary_sensor.office_window'
-            ] %}
+            {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
             {% set open_windows = namespace(count=0) %}
-            {% for entity_id in window_contacts %}
-              {% if is_state(entity_id, 'on') %}
-                {% set open_windows.count = open_windows.count + 1 %}
-              {% endif %}
+            {% for contact in contacts if contact.category == 'window' and is_state(contact.entity_id, 'on') %}
+              {% set open_windows.count = open_windows.count + 1 %}
             {% endfor %}
             {{ open_windows.count }}
 
@@ -550,11 +557,11 @@ automation:
         data:
           title: >
             {% if mode == 'winter_purge' %}
-              Window Ventilation: Brief Airing
+              Window Ventilation: Consider Brief Airing
             {% elif mode == 'brief_purge' %}
               Window Ventilation: Brief Purge
             {% else %}
-              Window Ventilation: Open Windows
+              Window Ventilation: Consider Opening Windows
             {% endif %}
           message: "{{ notification_message }}"
           data:

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -56,6 +56,7 @@ def test_window_ventilation_dashboard_surfaces_required_context():
         "input_boolean.window_ventilation_advisor_enabled",
         "sensor.window_ventilation_recommendation",
         "sensor.window_ventilation_reason",
+        "sensor.window_ventilation_open_window_summary",
         "binary_sensor.window_ventilation_favorable",
         "binary_sensor.window_ventilation_unfavorable",
         "binary_sensor.window_ventilation_brief_purge",
@@ -83,6 +84,7 @@ def test_window_ventilation_dashboard_surfaces_required_context():
     }
     assert required_entities <= refs
     assert "state_attr('sensor.window_ventilation_recommendation', 'mode')" in markdown
+    assert "state_attr('sensor.window_ventilation_open_window_summary', 'summary')" in markdown
     assert "advisory-only" in markdown
     assert "actual open window contacts" in markdown
     assert "Brief stale-air purge" in markdown

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -179,6 +179,7 @@ def test_window_ventilation_required_entities_are_defined():
 
     assert "Window Ventilation Indoor Dew Point" in sensor_names(package)
     assert "Window Ventilation Decision Context" in sensor_names(package)
+    assert "Window Ventilation Open Window Summary" in sensor_names(package)
     assert "Window Ventilation Recommendation" in sensor_names(package)
     assert "Window Ventilation Reason" in sensor_names(package)
 
@@ -291,6 +292,10 @@ def test_window_ventilation_reuses_canonical_decision_context():
         "sensor.window_ventilation_decision_context"
     )
 
+    summary = template_sensor_by_name(package, "Window Ventilation Open Window Summary")
+    assert summary["unique_id"] == "window_ventilation_open_window_summary"
+    assert "sensor.window_ventilation_decision_context" in str(summary)
+
     for canonical_attribute in (
         "outdoor_cooler",
         "outdoor_drier",
@@ -307,6 +312,16 @@ def test_window_ventilation_reuses_canonical_decision_context():
     ):
         assert canonical_attribute in context["attributes"]
         assert f"state_attr(ctx, '{canonical_attribute}')" in recommendation_text
+
+    for contact_attribute in ("open_window_count", "open_window_names"):
+        assert contact_attribute in context["attributes"]
+        assert contact_attribute in recommendation["attributes"]
+
+    assert "binary_sensor.kitchen_kitchen_porch_window" in context_text
+    assert "binary_sensor.office_window" in context_text
+    assert "friendly_name" in context_text
+    assert "open_window_count > 0" in reason_text
+    assert "Close {{ open_window_names }}" in reason_text
 
     for source_reference in (
         "states('sensor.dining_room_thermostat_temperature')",
@@ -364,7 +379,7 @@ def test_window_ventilation_favorable_conditions_still_recommend_open():
     assert result["context_attrs"]["brief_purge"] is False
     assert result["recommendation_state"] == "open"
     assert result["recommendation_attrs"]["mode"] == "comfort"
-    assert "Open windows:" in result["reason_state"]
+    assert "Recommendation: consider opening windows." in result["reason_state"]
     assert "short purge" not in result["reason_state"]
     assert "Briefly open" not in result["reason_state"]
 
@@ -391,7 +406,7 @@ def test_window_ventilation_severe_stale_air_can_recommend_bounded_brief_purge()
     assert result["recommendation_state"] == "open_briefly"
     assert result["recommendation_state"] != "open"
     assert result["recommendation_attrs"]["mode"] == "brief_purge"
-    assert "Briefly open windows for a short purge" in result["reason_state"]
+    assert "Recommendation: consider briefly opening windows for a short purge" in result["reason_state"]
     assert "bounded compromise limits" in result["reason_state"]
 
 
@@ -492,6 +507,33 @@ def test_window_ventilation_brief_purge_is_not_winter_purge_classification():
         in brief_purge_template
     )
     assert "not winter_mode" in brief_purge_template
+
+
+def test_window_ventilation_contact_context_names_open_windows_without_false_opens():
+    open_window = "binary_sensor.kitchen_kitchen_porch_window"
+    friendly_name = "Kitchen Porch Window"
+
+    all_closed = evaluate_window_ventilation(
+        {"sensor.precipitation_forecast_next_hour": "30"}
+    )
+    one_open = evaluate_window_ventilation(
+        {
+            "sensor.precipitation_forecast_next_hour": "30",
+            open_window: "on",
+        },
+        {(open_window, "friendly_name"): friendly_name},
+    )
+
+    assert all_closed["context_attrs"]["open_window_count"] == "0"
+    assert all_closed["context_attrs"]["open_window_names"] == ""
+    assert "Keep windows closed:" in all_closed["reason_state"]
+    assert friendly_name not in all_closed["reason_state"]
+
+    assert one_open["context_attrs"]["open_window_count"] == "1"
+    assert one_open["context_attrs"]["open_window_names"] == friendly_name
+    assert one_open["recommendation_attrs"]["open_window_count"] == "1"
+    assert one_open["recommendation_attrs"]["open_window_names"] == friendly_name
+    assert f"Close {friendly_name}:" in one_open["reason_state"]
 
 
 def test_window_ventilation_notifications_are_advisory_and_gated():

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -1,3 +1,4 @@
+import ast
 from pathlib import Path
 
 from jinja2 import Environment
@@ -6,10 +7,26 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE = ROOT / "packages" / "window_ventilation.yaml"
+PROTECTED_CONTACTS_PACKAGE = ROOT / "packages" / "protected_contacts.yaml"
 
 
 def load_package():
     return yaml.safe_load(PACKAGE.read_text())
+
+
+def canonical_protected_contacts():
+    package = yaml.safe_load(PROTECTED_CONTACTS_PACKAGE.read_text())
+    inventory = next(
+        sensor
+        for block in package["template"]
+        for sensor in block.get("sensor", [])
+        if sensor["name"] == "Protected Contact Inventory"
+    )
+    rendered = Environment().from_string(inventory["attributes"]["contacts"]).render()
+    return ast.literal_eval(rendered)
+
+
+CANONICAL_PROTECTED_CONTACTS = canonical_protected_contacts()
 
 
 def sensor_names(package):
@@ -123,6 +140,7 @@ DEFAULT_VENTILATION_ATTRS = {
     ("climate.dining_room_thermostat", "hvac_action"): "idle",
     ("climate.dining_room_thermostat", "current_temperature"): 72,
     ("climate.dining_room_thermostat", "current_humidity"): 45,
+    ("sensor.protected_contact_inventory", "contacts"): CANONICAL_PROTECTED_CONTACTS,
 }
 
 
@@ -317,9 +335,12 @@ def test_window_ventilation_reuses_canonical_decision_context():
         assert contact_attribute in context["attributes"]
         assert contact_attribute in recommendation["attributes"]
 
-    assert "binary_sensor.kitchen_kitchen_porch_window" in context_text
-    assert "binary_sensor.office_window" in context_text
-    assert "friendly_name" in context_text
+    assert "sensor.protected_contact_inventory" in context_text
+    assert "contact.category == 'window'" in context_text
+    assert "contact.name" in context_text
+    assert "friendly_name" not in context_text
+    assert "binary_sensor.kitchen_kitchen_porch_window" not in PACKAGE.read_text()
+    assert "binary_sensor.office_window" not in PACKAGE.read_text()
     assert "open_window_count > 0" in reason_text
     assert "Close {{ open_window_names }}" in reason_text
 
@@ -512,16 +533,18 @@ def test_window_ventilation_brief_purge_is_not_winter_purge_classification():
 def test_window_ventilation_contact_context_names_open_windows_without_false_opens():
     open_window = "binary_sensor.kitchen_kitchen_porch_window"
     friendly_name = "Kitchen Porch Window"
+    all_contacts_closed = {
+        contact["entity_id"]: "off" for contact in CANONICAL_PROTECTED_CONTACTS
+    }
 
     all_closed = evaluate_window_ventilation(
-        {"sensor.precipitation_forecast_next_hour": "30"}
+        all_contacts_closed | {"sensor.precipitation_forecast_next_hour": "30"}
     )
     one_open = evaluate_window_ventilation(
-        {
+        all_contacts_closed | {
             "sensor.precipitation_forecast_next_hour": "30",
             open_window: "on",
-        },
-        {(open_window, "friendly_name"): friendly_name},
+        }
     )
 
     assert all_closed["context_attrs"]["open_window_count"] == "0"


### PR DESCRIPTION
## Summary
- derive monitored open-window count and friendly-name summary from verified contact sensors
- show the advisory contact summary on the ventilation dashboard and include named contacts in close recommendations
- retain advisory-only behavior; this change does not operate contacts, windows, HVAC, or Home Assistant services

## Validation
- `python3 -m pytest -q` (94 passed)
- YAML parsed with `yaml.safe_load` for the changed package and dashboard
- `git diff --check`

## Documentation impact
- No README/DEVELOPMENT changes required; the YAML-managed dashboard exposes the new operator context.

Closes #187