### PR TITLE
feat(ventilation): warn on open windows during HVAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `shared_infrastructure.yaml` - shared notifier/dashboard contracts for packages.
 - `towner_notifications.yaml` - school arrival/departure notification state handling.
 - `weather.yaml` - weather caching, MQTT data, forecasts, and weather-driven automation.
-- `window_ventilation.yaml` - advisory window ventilation recommendations and notifications.
+- `window_ventilation.yaml` - advisory ventilation recommendations and notification-only open-window HVAC warnings.
 
 Disabled package files, such as `*.yaml.disabled`, are retained as inactive reference material and are not part of the active package inventory.
 

--- a/dashboards/window_ventilation.yaml
+++ b/dashboards/window_ventilation.yaml
@@ -48,8 +48,8 @@ views:
 
           {{ states('sensor.window_ventilation_reason') }}
 
-          _This is advisory-only. It does not confirm individual window-contact
-          state or change HVAC behavior._
+          _Comfort advice is advisory-only. The separate HVAC warning reports
+          actual open window contacts but never changes HVAC behavior._
 
       - type: conditional
         conditions:
@@ -85,6 +85,12 @@ views:
             name: "Unfavorable / close windows"
           - entity: binary_sensor.window_ventilation_brief_purge
             name: "Bounded stale-air purge active"
+          - entity: binary_sensor.window_hvac_open_warning
+            name: "Open windows while HVAC is running"
+          - type: attribute
+            entity: binary_sensor.window_hvac_open_warning
+            attribute: open_windows
+            name: "Affected windows"
 
       - type: entities
         title: "Comfort and dew point context"
@@ -151,3 +157,5 @@ views:
             name: "Winter purge threshold"
           - entity: input_number.window_ventilation_high_indoor_humidity
             name: "High indoor humidity threshold"
+          - entity: input_number.window_hvac_open_warning_hold_minutes
+            name: "HVAC open-window warning hold time"

--- a/packages/README.md
+++ b/packages/README.md
@@ -42,7 +42,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control and ventilation advice. |
 | `towner_notifications.yaml` | School arrival/departure notification workflow that handles infrequent location updates, race conditions, verification windows, and timeout/reset states. |
 | `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and event-based automation triggers. |
-| `window_ventilation.yaml` | Advisory window-ventilation recommendations using indoor/outdoor comfort, dew point, rain forecast, HVAC state, and relative air-quality context. |
+| `window_ventilation.yaml` | Advisory ventilation recommendations plus notification-only open-window HVAC warnings. |
 
 ## Climate subsystem
 

--- a/packages/window_ventilation.yaml
+++ b/packages/window_ventilation.yaml
@@ -3,7 +3,8 @@
 # Advisory window ventilation recommendations using indoor/outdoor comfort,
 # moisture, rain forecast, HVAC state, and household-relative air-quality context.
 #
-# v1 is advisory only: dedicated window-contact coverage is not confirmed.
+# Comfort recommendations are advisory only. A separate notification-only guard
+# reports actual open window contacts while HVAC is actively heating or cooling.
 #
 # Entity mapping is based on GitHub issue #103 triage/recon:
 # - normalized weather seam sensors from packages/weather.yaml:
@@ -12,6 +13,7 @@
 # - sensor.dining_room_thermostat_temperature and sensor.thermostat_humidity,
 #   with climate.dining_room_thermostat current attributes as fallback context
 # - sensor.thermostat_carbon_dioxide / sensor.thermostat_vocs
+# - installed window contacts verified in GitHub issue #184
 
 input_boolean:
   window_ventilation_advisor_enabled:
@@ -73,6 +75,15 @@ input_number:
     unit_of_measurement: "%"
     icon: mdi:water-percent
     initial: 58
+
+  window_hvac_open_warning_hold_minutes:
+    name: "Window HVAC Open Warning Hold Time"
+    min: 1
+    max: 120
+    step: 1
+    unit_of_measurement: "min"
+    icon: mdi:timer-outline
+    initial: 10
 
 input_text:
   window_ventilation_active_notification_tag:
@@ -438,6 +449,67 @@ template:
         icon: mdi:window-open
         state: "{{ is_state('sensor.window_ventilation_recommendation', 'open_briefly') }}"
 
+      - name: "Window HVAC Open Warning"
+        unique_id: window_hvac_open_warning
+        icon: mdi:window-open-variant
+        state: >
+          {% set window_contacts = {
+            'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
+            'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
+            'binary_sensor.living_room_living_room_window': 'Living Room Window',
+            'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
+            'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
+            'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
+            'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
+            'binary_sensor.office_window': 'Office Window'
+          } %}
+          {% set open_windows = namespace(names=[]) %}
+          {% for entity_id, name in window_contacts.items() %}
+            {% if is_state(entity_id, 'on') %}
+              {% set open_windows.names = open_windows.names + [name] %}
+            {% endif %}
+          {% endfor %}
+          {% set hvac_action = state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) %}
+          {{ hvac_action in ['heating', 'cooling'] and (open_windows.names | count > 0) }}
+        attributes:
+          hvac_action: "{{ state_attr('climate.dining_room_thermostat', 'hvac_action') | default('idle', true) }}"
+          open_windows: >
+            {% set window_contacts = {
+              'binary_sensor.kitchen_kitchen_porch_window': 'Kitchen Porch Window',
+              'binary_sensor.kitchen_kitchen_sink_window': 'Kitchen Sink Window',
+              'binary_sensor.living_room_living_room_window': 'Living Room Window',
+              'binary_sensor.master_bedroom_brian_s_window': "Brian's Window",
+              'binary_sensor.master_bedroom_hester_s_window': "Hester's Window",
+              'binary_sensor.porter_s_room_porter_s_window': "Porter's Room Window",
+              'binary_sensor.towner_s_room_towner_s_window': "Towner's Room Window",
+              'binary_sensor.office_window': 'Office Window'
+            } %}
+            {% set open_windows = namespace(names=[]) %}
+            {% for entity_id, name in window_contacts.items() %}
+              {% if is_state(entity_id, 'on') %}
+                {% set open_windows.names = open_windows.names + [name] %}
+              {% endif %}
+            {% endfor %}
+            {{ open_windows.names | join(', ') }}
+          open_window_count: >
+            {% set window_contacts = [
+              'binary_sensor.kitchen_kitchen_porch_window',
+              'binary_sensor.kitchen_kitchen_sink_window',
+              'binary_sensor.living_room_living_room_window',
+              'binary_sensor.master_bedroom_brian_s_window',
+              'binary_sensor.master_bedroom_hester_s_window',
+              'binary_sensor.porter_s_room_porter_s_window',
+              'binary_sensor.towner_s_room_towner_s_window',
+              'binary_sensor.office_window'
+            ] %}
+            {% set open_windows = namespace(count=0) %}
+            {% for entity_id in window_contacts %}
+              {% if is_state(entity_id, 'on') %}
+                {% set open_windows.count = open_windows.count + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ open_windows.count }}
+
 automation:
   - alias: "window_ventilation_open_advisory"
     id: "window_ventilation_open_advisory"
@@ -550,3 +622,52 @@ automation:
           message: "clear_notification"
           data:
             tag: "{{ states('input_text.window_ventilation_active_notification_tag') }}"
+
+  - alias: "window_hvac_open_warning"
+    id: "window_hvac_open_warning"
+    description: "Notify only when open windows persist while HVAC is actively running"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.window_hvac_open_warning
+        to: "on"
+        for:
+          minutes: "{{ states('input_number.window_hvac_open_warning_hold_minutes') | int(10) }}"
+    condition:
+      - condition: state
+        entity_id: input_boolean.window_ventilation_advisor_enabled
+        state: "on"
+    action:
+      - variables:
+          hvac_action: "{{ state_attr('binary_sensor.window_hvac_open_warning', 'hvac_action') }}"
+          open_windows: "{{ state_attr('binary_sensor.window_hvac_open_warning', 'open_windows') }}"
+      - service: notify.all_mobile_devices
+        data:
+          title: >
+            {% if hvac_action == 'heating' %}
+              Windows Open While Heating
+            {% else %}
+              Windows Open While Cooling
+            {% endif %}
+          message: >
+            HVAC is actively {{ hvac_action }} while these windows remain open:
+            {{ open_windows }}. Close them to avoid wasting conditioned air.
+          data:
+            tag: "window-hvac-open-warning"
+            when: "{{ now().timestamp() | int }}"
+            priority: "normal"
+            ttl: 0
+
+  - alias: "window_hvac_open_warning_clear"
+    id: "window_hvac_open_warning_clear"
+    description: "Clear the HVAC window warning when HVAC stops or all windows close"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.window_hvac_open_warning
+        from: "on"
+        to: "off"
+    action:
+      - service: notify.all_mobile_devices
+        data:
+          message: "clear_notification"
+          data:
+            tag: "window-hvac-open-warning"

--- a/tests/test_window_ventilation_dashboard.py
+++ b/tests/test_window_ventilation_dashboard.py
@@ -59,6 +59,7 @@ def test_window_ventilation_dashboard_surfaces_required_context():
         "binary_sensor.window_ventilation_favorable",
         "binary_sensor.window_ventilation_unfavorable",
         "binary_sensor.window_ventilation_brief_purge",
+        "binary_sensor.window_hvac_open_warning",
         "sensor.dining_room_thermostat_temperature",
         "sensor.thermostat_humidity",
         "sensor.window_ventilation_indoor_dew_point",
@@ -78,10 +79,12 @@ def test_window_ventilation_dashboard_surfaces_required_context():
         "input_number.window_ventilation_brief_purge_max_outdoor_dew_point",
         "input_number.window_ventilation_winter_threshold",
         "input_number.window_ventilation_high_indoor_humidity",
+        "input_number.window_hvac_open_warning_hold_minutes",
     }
     assert required_entities <= refs
     assert "state_attr('sensor.window_ventilation_recommendation', 'mode')" in markdown
     assert "advisory-only" in markdown
+    assert "actual open window contacts" in markdown
     assert "Brief stale-air purge" in markdown
     assert "This is not ordinary comfort ventilation" in markdown
     assert "Open Briefly" not in markdown
@@ -153,3 +156,20 @@ def test_window_ventilation_dashboard_separates_brief_purge_from_comfort_open():
         "content"
     ]
     assert "5-10 minutes" in brief_purge_card["card"]["content"]
+
+
+def test_window_ventilation_dashboard_surfaces_hvac_window_warning_details():
+    dashboard = load_dashboard()
+    cards = dashboard["views"][0]["cards"]
+    status_card = next(card for card in cards if card.get("title") == "Advisor status")
+
+    assert {
+        "entity": "binary_sensor.window_hvac_open_warning",
+        "name": "Open windows while HVAC is running",
+    } in status_card["entities"]
+    assert {
+        "type": "attribute",
+        "entity": "binary_sensor.window_hvac_open_warning",
+        "attribute": "open_windows",
+        "name": "Affected windows",
+    } in status_card["entities"]

--- a/tests/test_window_ventilation_package.py
+++ b/tests/test_window_ventilation_package.py
@@ -28,6 +28,14 @@ def template_sensor_by_name(package, name):
     raise AssertionError(f"template sensor {name!r} not found")
 
 
+def template_binary_sensor_by_name(package, name):
+    for block in package["template"]:
+        for sensor in block.get("binary_sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"template binary sensor {name!r} not found")
+
+
 def automation_by_id(package, automation_id):
     for automation in package["automation"]:
         if automation["id"] == automation_id:
@@ -100,6 +108,14 @@ DEFAULT_VENTILATION_STATES = {
     "input_number.window_ventilation_brief_purge_max_outdoor_dew_point": "70",
     "input_number.window_ventilation_winter_threshold": "55",
     "input_number.window_ventilation_high_indoor_humidity": "58",
+    "binary_sensor.kitchen_kitchen_porch_window": "off",
+    "binary_sensor.kitchen_kitchen_sink_window": "off",
+    "binary_sensor.living_room_living_room_window": "off",
+    "binary_sensor.master_bedroom_brian_s_window": "off",
+    "binary_sensor.master_bedroom_hester_s_window": "off",
+    "binary_sensor.porter_s_room_porter_s_window": "off",
+    "binary_sensor.towner_s_room_towner_s_window": "off",
+    "binary_sensor.office_window": "off",
 }
 
 
@@ -174,6 +190,56 @@ def test_window_ventilation_required_entities_are_defined():
     assert "Window Ventilation Favorable" in binary_names
     assert "Window Ventilation Unfavorable" in binary_names
     assert "Window Ventilation Brief Purge" in binary_names
+    assert "Window HVAC Open Warning" in binary_names
+
+
+def test_window_hvac_open_warning_only_matches_open_windows_while_hvac_runs():
+    package = load_package()
+    guard = template_binary_sensor_by_name(package, "Window HVAC Open Warning")
+
+    state_map = DEFAULT_VENTILATION_STATES | {
+        "binary_sensor.kitchen_kitchen_porch_window": "on",
+        "binary_sensor.office_window": "on",
+    }
+    heating_attrs = DEFAULT_VENTILATION_ATTRS | {
+        ("climate.dining_room_thermostat", "hvac_action"): "heating"
+    }
+    cooling_attrs = DEFAULT_VENTILATION_ATTRS | {
+        ("climate.dining_room_thermostat", "hvac_action"): "cooling"
+    }
+
+    assert render_ha_template(guard["state"], state_map=state_map, attr_map=heating_attrs) == "True"
+    assert render_ha_template(guard["state"], state_map=state_map, attr_map=cooling_attrs) == "True"
+    assert (
+        render_ha_template(
+            guard["state"], state_map=state_map, attr_map=DEFAULT_VENTILATION_ATTRS
+        )
+        == "False"
+    )
+    assert (
+        render_ha_template(
+            guard["state"],
+            state_map=DEFAULT_VENTILATION_STATES,
+            attr_map=heating_attrs,
+        )
+        == "False"
+    )
+    assert (
+        render_ha_template(
+            guard["attributes"]["open_windows"],
+            state_map=state_map,
+            attr_map=heating_attrs,
+        )
+        == "Kitchen Porch Window, Office Window"
+    )
+    assert (
+        render_ha_template(
+            guard["attributes"]["open_window_count"],
+            state_map=state_map,
+            attr_map=heating_attrs,
+        )
+        == "2"
+    )
 
 
 def test_window_ventilation_uses_household_relative_air_quality_baselines():
@@ -487,3 +553,56 @@ def test_window_ventilation_neutral_to_close_does_not_match_close_advisory():
         trigger.get("from") in (None, "neutral") and trigger["to"] == "close"
         for trigger in close_advisory["trigger"]
     )
+
+
+def test_window_hvac_open_warning_has_configurable_hold_and_separate_tagged_clear():
+    package = load_package()
+    warning = automation_by_id(package, "window_hvac_open_warning")
+    clear = automation_by_id(package, "window_hvac_open_warning_clear")
+
+    assert package["input_number"]["window_hvac_open_warning_hold_minutes"] == {
+        "name": "Window HVAC Open Warning Hold Time",
+        "min": 1,
+        "max": 120,
+        "step": 1,
+        "unit_of_measurement": "min",
+        "icon": "mdi:timer-outline",
+        "initial": 10,
+    }
+    assert warning["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": "binary_sensor.window_hvac_open_warning",
+            "to": "on",
+            "for": {
+                "minutes": "{{ states('input_number.window_hvac_open_warning_hold_minutes') | int(10) }}"
+            },
+        }
+    ]
+    assert warning["action"][-1]["service"] == "notify.all_mobile_devices"
+    warning_text = str(warning)
+    assert "Windows Open While Heating" in warning_text
+    assert "Windows Open While Cooling" in warning_text
+    assert "open_windows" in warning_text
+    assert "window-hvac-open-warning" in warning_text
+    assert "climate.set_" not in warning_text
+
+    assert clear["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": "binary_sensor.window_hvac_open_warning",
+            "from": "on",
+            "to": "off",
+        }
+    ]
+    assert clear["action"] == [
+        {
+            "service": "notify.all_mobile_devices",
+            "data": {
+                "message": "clear_notification",
+                "data": {"tag": "window-hvac-open-warning"},
+            },
+        }
+    ]
+    assert "two-minute" not in str(clear)
+    assert "security" not in str(clear)


### PR DESCRIPTION
## Summary
- Add a configurable 10-minute open-window guard while the dining-room thermostat is actively heating or cooling.
- Send a dedicated mobile notification with the affected contact names; clear it when HVAC stops or all configured windows close.
- Keep the guard advisory-only: it does not change HVAC state or setpoints.
- Surface the guard in the ventilation dashboard and cover it with focused package/dashboard tests.

## Validation
- `python3 -m pytest -q tests/test_window_ventilation_package.py tests/test_window_ventilation_dashboard.py` (19 passed)
- `python3 -m pytest -q` (96 passed)
- YAML parse checks for changed YAML
- Isolated Docker `hass -c /config --script check_config` (passed)

Closes #188