### PR TITLE
feat(weather): warn about rain with open windows

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -42,8 +42,8 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `security_sanity.yaml` | Reusable secure-house sanity check workflow used by routines and presence flows to verify/notify about doors, locks, garage state, and other security context. |
 | `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control and ventilation advice. |
 | `towner_notifications.yaml` | School arrival/departure notification workflow that handles infrequent location updates, race conditions, verification windows, and timeout/reset states. |
-| `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and event-based automation triggers. |
-| `window_ventilation.yaml` | Advisory ventilation recommendations plus notification-only open-window HVAC warnings. |
+| `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and an open-window rain alert that names affected monitored windows and clears after they all close. |
+| `window_ventilation.yaml` | Advisory window-ventilation recommendations using indoor/outdoor comfort, dew point, rain forecast, HVAC state, and relative air-quality context. |
 
 ## Climate subsystem
 

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -26,10 +26,45 @@ input_number:
     icon: mdi:clock-outline
     initial: 30
 
+homeassistant:
+  customize:
+    package.node_anchors:
+      rain_window_contacts: &rain_window_contacts
+        binary_sensor.kitchen_kitchen_porch_window: "Kitchen Porch Window"
+        binary_sensor.kitchen_kitchen_sink_window: "Kitchen Sink Window"
+        binary_sensor.living_room_living_room_window: "Living Room Window"
+        binary_sensor.master_bedroom_brian_s_window: "Brian's Window"
+        binary_sensor.master_bedroom_hester_s_window: "Hester's Window"
+        binary_sensor.porter_s_room_porter_s_window: "Porter's Window"
+        binary_sensor.towner_s_room_towner_s_window: "Towner's Window"
+        binary_sensor.office_window: "Office Window"
+
 automation:
   - alias: "Rain Forecast Alert"
     id: "notification_rain_forecast"
-    description: "NWS-backed rain probability and condition notification"
+    description: >
+      NWS-backed rain probability and condition notification for monitored open
+      windows, with a tagged clear once every monitored window is closed.
+    variables:
+      rain_window_contacts: *rain_window_contacts
+      open_window_names: >
+        {% set windows = namespace(names=[]) %}
+        {% for entity_id, name in rain_window_contacts.items() %}
+          {% if is_state(entity_id, 'on') %}
+            {% set windows.names = windows.names + [name] %}
+          {% endif %}
+        {% endfor %}
+        {{ windows.names | join(', ') }}
+      forecast_basis: >
+        {% set probability = states('sensor.precipitation_forecast_next_hour') | float(0) %}
+        {% set condition = states('sensor.condition_forecast_next_hour') %}
+        {% if probability > 30 %}
+          {{ probability | round(0) }}% chance of precipitation in the next hour
+        {% elif condition in ['rainy', 'pouring', 'snowy', 'snowy-rainy'] %}
+          {{ condition | title }} conditions expected in the next hour
+        {% else %}
+          {{ states('weather.nws_home_kmle') | title }} conditions expected
+        {% endif %}
     trigger:
       # Primary: NWS precipitation probability sensor (percent chance)
       - platform: numeric_state
@@ -54,6 +89,20 @@ automation:
           - "snowy"
           - "snowy-rainy"
         id: "weather_fallback"
+      # Re-check an already-rainy forecast if a monitored window is opened.
+      - platform: state
+        entity_id:
+          - binary_sensor.kitchen_kitchen_porch_window
+          - binary_sensor.kitchen_kitchen_sink_window
+          - binary_sensor.living_room_living_room_window
+          - binary_sensor.master_bedroom_brian_s_window
+          - binary_sensor.master_bedroom_hester_s_window
+          - binary_sensor.porter_s_room_porter_s_window
+          - binary_sensor.towner_s_room_towner_s_window
+          - binary_sensor.office_window
+        from: "off"
+        to: "on"
+        id: "window_open_trigger"
     condition:
       # Wait for weather data to be available after startup
       - condition: template
@@ -65,6 +114,19 @@ automation:
       - condition: time
         after: "05:00:00"
         before: "22:00:00"
+      # A contact opening re-checks the same near-term criteria as the weather
+      # triggers, so a dry forecast can never produce an open-window alert.
+      - condition: template
+        value_template: >
+          {% set probability = states('sensor.precipitation_forecast_next_hour') | float(0) %}
+          {% set condition = states('sensor.condition_forecast_next_hour') %}
+          {% set weather_condition = states('weather.nws_home_kmle') %}
+          {{ probability > 30 or
+             condition in ['rainy', 'pouring', 'snowy', 'snowy-rainy'] or
+             weather_condition in ['rainy', 'pouring', 'snowy', 'snowy-rainy'] }}
+      # Alert only while at least one configured window contact is open.
+      - condition: template
+        value_template: "{{ open_window_names | trim != '' }}"
       # Avoid spam - only if no recent notification
       - condition: template
         value_template: >
@@ -78,14 +140,47 @@ automation:
       - action: notify.mobile_app_brian_phone
         data:
           message: >
-            {% if trigger.id == 'precipitation_probability_trigger' %}
-              ☔ Rain chance in the next hour: {{ states('sensor.precipitation_forecast_next_hour') }}%
-            {% elif trigger.id == 'condition_trigger' %}
-              ☔ {{ states('sensor.condition_forecast_next_hour') | title }} weather expected in the next hour
-            {% else %}
-              ☔ {{ states('weather.nws_home_kmle') | title }} weather conditions expected
-            {% endif %}
-          title: "Rain Alert"
+            ☔ Close {{ open_window_names }}: {{ forecast_basis }}.
+          title: "Rain Alert: Open Windows"
+          data:
+            tag: "rain-open-windows"
+    mode: single
+
+  - alias: "Rain Forecast Open Windows Clear"
+    id: "notification_rain_forecast_open_windows_clear"
+    description: >
+      Clear the rain open-window alert only after every monitored window is
+      closed; closing one of several open windows leaves the alert visible.
+    variables:
+      rain_window_contacts: *rain_window_contacts
+      has_open_windows: >
+        {% for entity_id in rain_window_contacts %}
+          {% if is_state(entity_id, 'on') %}
+            true
+          {% endif %}
+        {% endfor %}
+    trigger:
+      - platform: state
+        entity_id:
+          - binary_sensor.kitchen_kitchen_porch_window
+          - binary_sensor.kitchen_kitchen_sink_window
+          - binary_sensor.living_room_living_room_window
+          - binary_sensor.master_bedroom_brian_s_window
+          - binary_sensor.master_bedroom_hester_s_window
+          - binary_sensor.porter_s_room_porter_s_window
+          - binary_sensor.towner_s_room_towner_s_window
+          - binary_sensor.office_window
+        from: "on"
+        to: "off"
+    condition:
+      - condition: template
+        value_template: "{{ not has_open_windows }}"
+    action:
+      - action: notify.mobile_app_brian_phone
+        data:
+          message: "clear_notification"
+          data:
+            tag: "rain-open-windows"
     mode: single
 
   - alias: "weather_data_refresh"

--- a/packages/weather.yaml
+++ b/packages/weather.yaml
@@ -29,15 +29,18 @@ input_number:
 homeassistant:
   customize:
     package.node_anchors:
-      rain_window_contacts: &rain_window_contacts
-        binary_sensor.kitchen_kitchen_porch_window: "Kitchen Porch Window"
-        binary_sensor.kitchen_kitchen_sink_window: "Kitchen Sink Window"
-        binary_sensor.living_room_living_room_window: "Living Room Window"
-        binary_sensor.master_bedroom_brian_s_window: "Brian's Window"
-        binary_sensor.master_bedroom_hester_s_window: "Hester's Window"
-        binary_sensor.porter_s_room_porter_s_window: "Porter's Window"
-        binary_sensor.towner_s_room_towner_s_window: "Towner's Window"
-        binary_sensor.office_window: "Office Window"
+      # Home Assistant state triggers require entity IDs to be known while the
+      # automation is configured. Names and open-state evaluation below consume
+      # the canonical protected-contact inventory instead of this trigger list.
+      rain_window_trigger_entity_ids: &rain_window_trigger_entity_ids
+        - binary_sensor.kitchen_kitchen_porch_window
+        - binary_sensor.kitchen_kitchen_sink_window
+        - binary_sensor.living_room_living_room_window
+        - binary_sensor.master_bedroom_brian_s_window
+        - binary_sensor.master_bedroom_hester_s_window
+        - binary_sensor.porter_s_room_porter_s_window
+        - binary_sensor.towner_s_room_towner_s_window
+        - binary_sensor.office_window
 
 automation:
   - alias: "Rain Forecast Alert"
@@ -46,12 +49,14 @@ automation:
       NWS-backed rain probability and condition notification for monitored open
       windows, with a tagged clear once every monitored window is closed.
     variables:
-      rain_window_contacts: *rain_window_contacts
+      # The protected-contact inventory is the source of truth for window
+      # categories and names. Keep static IDs only in state triggers above.
       open_window_names: >
+        {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
         {% set windows = namespace(names=[]) %}
-        {% for entity_id, name in rain_window_contacts.items() %}
-          {% if is_state(entity_id, 'on') %}
-            {% set windows.names = windows.names + [name] %}
+        {% for contact in contacts %}
+          {% if contact.category | default('') == 'window' and is_state(contact.entity_id, 'on') %}
+            {% set windows.names = windows.names + [contact.name] %}
           {% endif %}
         {% endfor %}
         {{ windows.names | join(', ') }}
@@ -91,15 +96,7 @@ automation:
         id: "weather_fallback"
       # Re-check an already-rainy forecast if a monitored window is opened.
       - platform: state
-        entity_id:
-          - binary_sensor.kitchen_kitchen_porch_window
-          - binary_sensor.kitchen_kitchen_sink_window
-          - binary_sensor.living_room_living_room_window
-          - binary_sensor.master_bedroom_brian_s_window
-          - binary_sensor.master_bedroom_hester_s_window
-          - binary_sensor.porter_s_room_porter_s_window
-          - binary_sensor.towner_s_room_towner_s_window
-          - binary_sensor.office_window
+        entity_id: *rain_window_trigger_entity_ids
         from: "off"
         to: "on"
         id: "window_open_trigger"
@@ -152,24 +149,16 @@ automation:
       Clear the rain open-window alert only after every monitored window is
       closed; closing one of several open windows leaves the alert visible.
     variables:
-      rain_window_contacts: *rain_window_contacts
       has_open_windows: >
-        {% for entity_id in rain_window_contacts %}
-          {% if is_state(entity_id, 'on') %}
+        {% set contacts = state_attr('sensor.protected_contact_inventory', 'contacts') | default([], true) %}
+        {% for contact in contacts %}
+          {% if contact.category | default('') == 'window' and is_state(contact.entity_id, 'on') %}
             true
           {% endif %}
         {% endfor %}
     trigger:
       - platform: state
-        entity_id:
-          - binary_sensor.kitchen_kitchen_porch_window
-          - binary_sensor.kitchen_kitchen_sink_window
-          - binary_sensor.living_room_living_room_window
-          - binary_sensor.master_bedroom_brian_s_window
-          - binary_sensor.master_bedroom_hester_s_window
-          - binary_sensor.porter_s_room_porter_s_window
-          - binary_sensor.towner_s_room_towner_s_window
-          - binary_sensor.office_window
+        entity_id: *rain_window_trigger_entity_ids
         from: "on"
         to: "off"
     condition:

--- a/tests/test_weather_forecast_cache.py
+++ b/tests/test_weather_forecast_cache.py
@@ -1,3 +1,4 @@
+import ast
 from pathlib import Path
 
 import yaml
@@ -6,10 +7,25 @@ from jinja2 import Environment
 
 ROOT = Path(__file__).resolve().parents[1]
 WEATHER = ROOT / "packages" / "weather.yaml"
+PROTECTED_CONTACTS = ROOT / "packages" / "protected_contacts.yaml"
 
 
 def load_weather():
     return yaml.safe_load(WEATHER.read_text())
+
+
+def canonical_window_contacts():
+    package = yaml.safe_load(PROTECTED_CONTACTS.read_text())
+    inventory = next(
+        sensor
+        for block in package["template"]
+        for sensor in block.get("sensor", [])
+        if sensor["name"] == "Protected Contact Inventory"
+    )
+    contacts = ast.literal_eval(
+        Environment().from_string(inventory["attributes"]["contacts"]).render()
+    )
+    return [contact for contact in contacts if contact["category"] == "window"]
 
 
 def weather_refresh_action():
@@ -26,11 +42,13 @@ def automation_by_id(automation_id):
     raise AssertionError(f"automation {automation_id!r} not found")
 
 
-def render_template(template, state_map, **variables):
+def render_template(template, state_map, attributes=None, **variables):
+    attributes = attributes or {}
     environment = Environment(trim_blocks=True, lstrip_blocks=True)
     environment.globals.update(
         is_state=lambda entity_id, state: state_map.get(entity_id) == state,
         states=lambda entity_id: state_map.get(entity_id, "unknown"),
+        state_attr=lambda entity_id, attribute: attributes.get((entity_id, attribute)),
     )
     return environment.from_string(template).render(**variables).strip()
 
@@ -147,39 +165,54 @@ def test_precipitation_next_hour_uses_nws_probability_semantics():
     assert "precipitation_probability" in sensor["state"]
 
 
-def test_rain_alert_requires_open_monitored_windows_and_names_them():
+def test_rain_alert_uses_canonical_window_inventory_for_dynamic_names_and_static_trigger_parity():
     rain_alert = automation_by_id("notification_rain_forecast")
-    contacts = rain_alert["variables"]["rain_window_contacts"]
+    contacts = canonical_window_contacts()
+    window_contact_ids = [contact["entity_id"] for contact in contacts]
     open_window_names = rain_alert["variables"]["open_window_names"]
 
-    assert contacts == {
-        "binary_sensor.kitchen_kitchen_porch_window": "Kitchen Porch Window",
-        "binary_sensor.kitchen_kitchen_sink_window": "Kitchen Sink Window",
-        "binary_sensor.living_room_living_room_window": "Living Room Window",
-        "binary_sensor.master_bedroom_brian_s_window": "Brian's Window",
-        "binary_sensor.master_bedroom_hester_s_window": "Hester's Window",
-        "binary_sensor.porter_s_room_porter_s_window": "Porter's Window",
-        "binary_sensor.towner_s_room_towner_s_window": "Towner's Window",
-        "binary_sensor.office_window": "Office Window",
-    }
-    closed_states = {entity_id: "off" for entity_id in contacts}
+    assert "rain_window_contacts" not in rain_alert["variables"]
+    assert "sensor.protected_contact_inventory" in open_window_names
+    assert "contact.category" in open_window_names
+    assert all(name not in WEATHER.read_text() for name in (contact["name"] for contact in contacts))
+
+    closed_states = {entity_id: "off" for entity_id in window_contact_ids}
     open_states = {
         **closed_states,
         "binary_sensor.kitchen_kitchen_porch_window": "on",
         "binary_sensor.office_window": "on",
     }
+    attributes = {("sensor.protected_contact_inventory", "contacts"): contacts}
 
+    assert render_template(open_window_names, closed_states, attributes) == ""
     assert render_template(
-        open_window_names, closed_states, rain_window_contacts=contacts
-    ) == ""
-    assert render_template(
-        open_window_names, open_states, rain_window_contacts=contacts
+        open_window_names, open_states, attributes
     ) == "Kitchen Porch Window, Office Window"
+    renamed_contacts = [
+        {
+            **contact,
+            "name": "Study Window",
+        }
+        if contact["entity_id"] == "binary_sensor.office_window"
+        else contact
+        for contact in contacts
+    ] + [
+        {
+            "entity_id": "binary_sensor.example_door",
+            "name": "Example Door",
+            "category": "security_boundary_door",
+        }
+    ]
+    assert render_template(
+        open_window_names,
+        {**open_states, "binary_sensor.example_door": "on"},
+        {("sensor.protected_contact_inventory", "contacts"): renamed_contacts},
+    ) == "Kitchen Porch Window, Study Window"
     assert {
         tuple(trigger["entity_id"])
         for trigger in rain_alert["trigger"]
         if trigger.get("id") == "window_open_trigger"
-    } == {tuple(contacts)}
+    } == {tuple(window_contact_ids)}
     assert any(
         condition.get("value_template") == "{{ open_window_names | trim != '' }}"
         for condition in rain_alert["condition"]
@@ -221,24 +254,46 @@ def test_rain_alert_requires_open_monitored_windows_and_names_them():
 def test_rain_alert_reuses_its_throttle_and_clears_only_after_all_windows_close():
     rain_alert = automation_by_id("notification_rain_forecast")
     clear_alert = automation_by_id("notification_rain_forecast_open_windows_clear")
-    contacts = rain_alert["variables"]["rain_window_contacts"]
+    contacts = canonical_window_contacts()
+    window_contact_ids = [contact["entity_id"] for contact in contacts]
     has_open_windows = clear_alert["variables"]["has_open_windows"]
-    closed_states = {entity_id: "off" for entity_id in contacts}
+    closed_states = {entity_id: "off" for entity_id in window_contact_ids}
     one_open_state = {
         **closed_states,
         "binary_sensor.office_window": "on",
     }
+    attributes = {("sensor.protected_contact_inventory", "contacts"): contacts}
 
     assert "automation.notification_rain_forecast" in str(rain_alert["condition"])
+    assert "sensor.protected_contact_inventory" in has_open_windows
+    assert "contact.category" in has_open_windows
+    assert render_template(has_open_windows, closed_states, attributes) == ""
     assert render_template(
-        has_open_windows, closed_states, rain_window_contacts=contacts
+        has_open_windows,
+        {**closed_states, "binary_sensor.example_door": "on"},
+        {
+            (
+                "sensor.protected_contact_inventory",
+                "contacts",
+            ): contacts
+            + [
+                {
+                    "entity_id": "binary_sensor.example_door",
+                    "name": "Example Door",
+                    "category": "security_boundary_door",
+                }
+            ]
+        },
     ) == ""
-    assert render_template(
-        has_open_windows, one_open_state, rain_window_contacts=contacts
-    ) == "true"
+    assert render_template(has_open_windows, one_open_state, attributes) == "true"
     assert clear_alert["condition"] == [
         {"condition": "template", "value_template": "{{ not has_open_windows }}"}
     ]
+    assert {
+        tuple(trigger["entity_id"])
+        for trigger in clear_alert["trigger"]
+        if trigger.get("platform") == "state"
+    } == {tuple(window_contact_ids)}
     assert clear_alert["action"] == [
         {
             "action": "notify.mobile_app_brian_phone",

--- a/tests/test_weather_forecast_cache.py
+++ b/tests/test_weather_forecast_cache.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import yaml
+from jinja2 import Environment
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,6 +17,22 @@ def weather_refresh_action():
         if automation["id"] == "weather_data_refresh":
             return automation["action"]
     raise AssertionError("weather_data_refresh automation not found")
+
+
+def automation_by_id(automation_id):
+    for automation in load_weather()["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def render_template(template, state_map, **variables):
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals.update(
+        is_state=lambda entity_id, state: state_map.get(entity_id) == state,
+        states=lambda entity_id: state_map.get(entity_id, "unknown"),
+    )
+    return environment.from_string(template).render(**variables).strip()
 
 
 def mqtt_payload_for_topic(topic):
@@ -128,3 +145,109 @@ def test_precipitation_next_hour_uses_nws_probability_semantics():
 
     assert sensor["unit_of_measurement"] == "%"
     assert "precipitation_probability" in sensor["state"]
+
+
+def test_rain_alert_requires_open_monitored_windows_and_names_them():
+    rain_alert = automation_by_id("notification_rain_forecast")
+    contacts = rain_alert["variables"]["rain_window_contacts"]
+    open_window_names = rain_alert["variables"]["open_window_names"]
+
+    assert contacts == {
+        "binary_sensor.kitchen_kitchen_porch_window": "Kitchen Porch Window",
+        "binary_sensor.kitchen_kitchen_sink_window": "Kitchen Sink Window",
+        "binary_sensor.living_room_living_room_window": "Living Room Window",
+        "binary_sensor.master_bedroom_brian_s_window": "Brian's Window",
+        "binary_sensor.master_bedroom_hester_s_window": "Hester's Window",
+        "binary_sensor.porter_s_room_porter_s_window": "Porter's Window",
+        "binary_sensor.towner_s_room_towner_s_window": "Towner's Window",
+        "binary_sensor.office_window": "Office Window",
+    }
+    closed_states = {entity_id: "off" for entity_id in contacts}
+    open_states = {
+        **closed_states,
+        "binary_sensor.kitchen_kitchen_porch_window": "on",
+        "binary_sensor.office_window": "on",
+    }
+
+    assert render_template(
+        open_window_names, closed_states, rain_window_contacts=contacts
+    ) == ""
+    assert render_template(
+        open_window_names, open_states, rain_window_contacts=contacts
+    ) == "Kitchen Porch Window, Office Window"
+    assert {
+        tuple(trigger["entity_id"])
+        for trigger in rain_alert["trigger"]
+        if trigger.get("id") == "window_open_trigger"
+    } == {tuple(contacts)}
+    assert any(
+        condition.get("value_template") == "{{ open_window_names | trim != '' }}"
+        for condition in rain_alert["condition"]
+    )
+    forecast_basis = rain_alert["variables"]["forecast_basis"]
+    assert render_template(
+        forecast_basis,
+        {
+            "sensor.precipitation_forecast_next_hour": "45",
+            "sensor.condition_forecast_next_hour": "sunny",
+            "weather.nws_home_kmle": "sunny",
+        },
+    ) == "45.0% chance of precipitation in the next hour"
+    rain_criteria = next(
+        condition["value_template"]
+        for condition in rain_alert["condition"]
+        if "weather_condition in" in condition.get("value_template", "")
+    )
+    assert render_template(
+        rain_criteria,
+        {
+            **open_states,
+            "sensor.precipitation_forecast_next_hour": "0",
+            "sensor.condition_forecast_next_hour": "sunny",
+            "weather.nws_home_kmle": "sunny",
+        },
+    ) == "False"
+    assert render_template(
+        rain_criteria,
+        {
+            **open_states,
+            "sensor.precipitation_forecast_next_hour": "45",
+            "sensor.condition_forecast_next_hour": "sunny",
+            "weather.nws_home_kmle": "sunny",
+        },
+    ) == "True"
+
+
+def test_rain_alert_reuses_its_throttle_and_clears_only_after_all_windows_close():
+    rain_alert = automation_by_id("notification_rain_forecast")
+    clear_alert = automation_by_id("notification_rain_forecast_open_windows_clear")
+    contacts = rain_alert["variables"]["rain_window_contacts"]
+    has_open_windows = clear_alert["variables"]["has_open_windows"]
+    closed_states = {entity_id: "off" for entity_id in contacts}
+    one_open_state = {
+        **closed_states,
+        "binary_sensor.office_window": "on",
+    }
+
+    assert "automation.notification_rain_forecast" in str(rain_alert["condition"])
+    assert render_template(
+        has_open_windows, closed_states, rain_window_contacts=contacts
+    ) == ""
+    assert render_template(
+        has_open_windows, one_open_state, rain_window_contacts=contacts
+    ) == "true"
+    assert clear_alert["condition"] == [
+        {"condition": "template", "value_template": "{{ not has_open_windows }}"}
+    ]
+    assert clear_alert["action"] == [
+        {
+            "action": "notify.mobile_app_brian_phone",
+            "data": {
+                "message": "clear_notification",
+                "data": {"tag": "rain-open-windows"},
+            },
+        }
+    ]
+    notification = rain_alert["action"][0]
+    assert notification["data"]["data"]["tag"] == "rain-open-windows"
+    assert "{{ forecast_basis }}" in notification["data"]["message"]


### PR DESCRIPTION
## Summary
- limit the daytime rain alert to the monitored windows that are currently open
- name every affected window and state the next-hour forecast basis
- clear the tagged alert only after all monitored windows close

## Validation
- `python -m pytest -q` (104 passed)
- parsed all active package YAML files with PyYAML
- `git diff --check`

## Documentation impact
- Updated `packages/README.md` with the alert and clear behavior.

Closes #189