### PR TITLE
feat(reminders): add municipal trash and recycling LED alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `security_sanity.yaml` - reusable secure-house sanity check workflow.
 - `shared_infrastructure.yaml` - shared notifier/dashboard contracts for packages.
 - `towner_notifications.yaml` - school arrival/departure notification state handling.
+- `trash_recycling_reminder.yaml` - municipal calendar-driven Zooz wall-switch/dimmer LED reminder with per-device snapshot and midnight restore.
 - `weather.yaml` - weather caching, MQTT data, forecasts, and weather-driven automation.
 - `window_ventilation.yaml` - advisory ventilation recommendations and notification-only open-window HVAC warnings.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -42,6 +42,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `security_sanity.yaml` | Reusable secure-house sanity check workflow used by routines and presence flows to verify/notify about doors, locks, garage state, and other security context. |
 | `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control and ventilation advice. |
 | `towner_notifications.yaml` | School arrival/departure notification workflow that handles infrequent location updates, race conditions, verification windows, and timeout/reset states. |
+| `trash_recycling_reminder.yaml` | Municipality-calendar-driven trash/recycling-night Zooz LED reminder. It snapshots and restores explicitly scoped wall-switch/dimmer LED settings, shows blue for garbage-only and green when recycling is also listed, and safely ignores unknown or recycling-only calendar text. |
 | `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and an open-window rain alert that names affected monitored windows and clears after they all close. |
 | `window_ventilation.yaml` | Advisory window-ventilation recommendations using indoor/outdoor comfort, dew point, rain forecast, HVAC state, and relative air-quality context. |
 

--- a/packages/trash_recycling_reminder.yaml
+++ b/packages/trash_recycling_reminder.yaml
@@ -1,0 +1,175 @@
+# packages/trash_recycling_reminder.yaml
+#
+# Municipal collection-night reminder for explicitly scoped Zooz wall switches
+# and dimmers. Door/window contact indicators and remote button indicators are
+# intentionally excluded: they do not expose this switch-style LED trio.
+#
+# Calendar classification is deliberately based on the municipality event date
+# plus its message/description rather than any alternating-week calculation.
+# Only text containing "garbage" activates a reminder. Text also containing a
+# "recycl" stem selects green; otherwise garbage-only selects blue. Unknown or
+# recycling-only text is a safe no-op.
+
+input_boolean:
+  trash_recycling_led_reminder_active:
+    name: Trash and Recycling LED Reminder Active
+    icon: mdi:trash-can-outline
+
+homeassistant:
+  customize:
+    package.node_anchors:
+      trash_recycling_led_snapshot_entities: &trash_recycling_led_snapshot_entities
+        - select.dining_room_table_light_led_indicator
+        - select.dining_room_table_light_led_indicator_color
+        - select.dining_room_table_light_led_indicator_brightness
+        - select.entry_led_indicator
+        - select.entry_led_indicator_color
+        - select.entry_led_indicator_brightness
+        - select.living_room_right_led_indicator
+        - select.living_room_right_led_indicator_color
+        - select.living_room_right_led_indicator_brightness
+        - select.living_room_left_led_indicator
+        - select.living_room_left_led_indicator_color
+        - select.living_room_left_led_indicator_brightness
+        - select.living_room_center_led_indicator
+        - select.living_room_center_led_indicator_color
+        - select.living_room_center_led_indicator_brightness
+        - select.towners_room_light_led_indicator
+        - select.towners_room_light_led_indicator_color
+        - select.towners_room_light_led_indicator_brightness
+        - select.back_yard_light_led_indicator
+        - select.back_yard_light_led_indicator_color
+        - select.back_yard_light_led_indicator_brightness
+        - select.kitchen_fan_light_led_indicator
+        - select.kitchen_fan_light_led_indicator_color
+        - select.kitchen_fan_light_led_indicator_brightness
+        - select.kitchen_bar_lights_led_indicator
+        - select.kitchen_bar_lights_led_indicator_color
+        - select.kitchen_bar_lights_led_indicator_brightness
+        - select.kitchen_counter_lights_led_indicator_2
+        - select.kitchen_counter_lights_led_indicator_color_2
+        - select.kitchen_counter_lights_led_indicator_brightness_2
+        - select.dimmer_led_indicator
+        - select.dimmer_led_indicator_color
+        - select.dimmer_led_indicator_brightness
+        - select.front_yard_lights_led_indicator
+        - select.front_yard_lights_led_indicator_color
+        - select.front_yard_lights_led_indicator_brightness
+        - select.coridor_led_indicator
+        - select.coridor_led_indicator_color
+        - select.coridor_led_indicator_brightness
+      trash_recycling_led_mode_entities: &trash_recycling_led_mode_entities
+        - select.dining_room_table_light_led_indicator
+        - select.entry_led_indicator
+        - select.living_room_right_led_indicator
+        - select.living_room_left_led_indicator
+        - select.living_room_center_led_indicator
+        - select.towners_room_light_led_indicator
+        - select.back_yard_light_led_indicator
+        - select.kitchen_fan_light_led_indicator
+        - select.kitchen_bar_lights_led_indicator
+        - select.kitchen_counter_lights_led_indicator_2
+        - select.dimmer_led_indicator
+        - select.front_yard_lights_led_indicator
+        - select.coridor_led_indicator
+      trash_recycling_led_color_entities: &trash_recycling_led_color_entities
+        - select.dining_room_table_light_led_indicator_color
+        - select.entry_led_indicator_color
+        - select.living_room_right_led_indicator_color
+        - select.living_room_left_led_indicator_color
+        - select.living_room_center_led_indicator_color
+        - select.towners_room_light_led_indicator_color
+        - select.back_yard_light_led_indicator_color
+        - select.kitchen_fan_light_led_indicator_color
+        - select.kitchen_bar_lights_led_indicator_color
+        - select.kitchen_counter_lights_led_indicator_color_2
+        - select.dimmer_led_indicator_color
+        - select.front_yard_lights_led_indicator_color
+        - select.coridor_led_indicator_color
+      trash_recycling_led_brightness_entities: &trash_recycling_led_brightness_entities
+        - select.dining_room_table_light_led_indicator_brightness
+        - select.entry_led_indicator_brightness
+        - select.living_room_right_led_indicator_brightness
+        - select.living_room_left_led_indicator_brightness
+        - select.living_room_center_led_indicator_brightness
+        - select.towners_room_light_led_indicator_brightness
+        - select.back_yard_light_led_indicator_brightness
+        - select.kitchen_fan_light_led_indicator_brightness
+        - select.kitchen_bar_lights_led_indicator_brightness
+        - select.kitchen_counter_lights_led_indicator_brightness_2
+        - select.dimmer_led_indicator_brightness
+        - select.front_yard_lights_led_indicator_brightness
+        - select.coridor_led_indicator_brightness
+
+automation:
+  - alias: "Trash and Recycling LED Reminder Start"
+    id: trash_recycling_led_reminder_start
+    description: >
+      At 18:00, snapshot each targeted Zooz LED setting and show blue for a
+      garbage-only municipal collection or green when recycling is also listed.
+    variables:
+      calendar_entity: calendar.1112_limerick_rd_papillion
+      collection_type: >
+        {% set event_start = as_datetime(state_attr(calendar_entity, 'start_time'), none) %}
+        {% set event_date = as_local(event_start).date() if event_start is not none else none %}
+        {% set event_text = [
+          state_attr(calendar_entity, 'message') | default('', true),
+          state_attr(calendar_entity, 'description') | default('', true)
+        ] | join(' ') | lower %}
+        {% if event_date == (now() + timedelta(days=1)).date() and 'garbage' in event_text %}
+          {{ 'garbage_recycling' if 'recycl' in event_text else 'garbage' }}
+        {% else %}
+          none
+        {% endif %}
+      reminder_color: "{{ 'Green' if collection_type == 'garbage_recycling' else 'Blue' }}"
+    trigger:
+      - platform: time
+        at: "18:00:00"
+    condition:
+      - condition: template
+        value_template: "{{ collection_type in ['garbage', 'garbage_recycling'] }}"
+    action:
+      - action: scene.create
+        data:
+          scene_id: trash_recycling_led_reminder_prior_settings
+          snapshot_entities: *trash_recycling_led_snapshot_entities
+      - action: select.select_option
+        target:
+          entity_id: *trash_recycling_led_mode_entities
+        data:
+          option: "Always on"
+      - action: select.select_option
+        target:
+          entity_id: *trash_recycling_led_color_entities
+        data:
+          option: "{{ reminder_color }}"
+      - action: select.select_option
+        target:
+          entity_id: *trash_recycling_led_brightness_entities
+        data:
+          option: "Bright (100%)"
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.trash_recycling_led_reminder_active
+    mode: single
+
+  - alias: "Trash and Recycling LED Reminder Restore"
+    id: trash_recycling_led_reminder_restore
+    description: >
+      At midnight, restore each Zooz LED mode, colour, and brightness from the
+      snapshot captured when the reminder began.
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: input_boolean.trash_recycling_led_reminder_active
+        state: "on"
+    action:
+      - action: scene.turn_on
+        target:
+          entity_id: scene.trash_recycling_led_reminder_prior_settings
+      - action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.trash_recycling_led_reminder_active
+    mode: single

--- a/tests/test_trash_recycling_reminder.py
+++ b/tests/test_trash_recycling_reminder.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "trash_recycling_reminder.yaml"
+CALENDAR = "calendar.1112_limerick_rd_papillion"
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def automation_by_id(automation_id):
+    for automation in load_package()["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def render_collection_type(start_time, message, description, now):
+    template = automation_by_id("trash_recycling_led_reminder_start")["variables"][
+        "collection_type"
+    ]
+    attributes = {
+        (CALENDAR, "start_time"): start_time,
+        (CALENDAR, "message"): message,
+        (CALENDAR, "description"): description,
+    }
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals.update(
+        as_datetime=lambda value, default=None: datetime.fromisoformat(value)
+        if value
+        else default,
+        as_local=lambda value: value,
+        calendar_entity=CALENDAR,
+        state_attr=lambda entity_id, attribute: attributes.get((entity_id, attribute)),
+        now=lambda: now,
+        timedelta=timedelta,
+    )
+    return environment.from_string(template).render().strip()
+
+
+def test_collection_classifier_uses_tomorrows_actual_calendar_event_text():
+    now = datetime(2026, 7, 19, 18, 0)
+
+    assert render_collection_type(
+        "2026-07-20 00:00:00", "Garbage", "Garbage", now
+    ) == "garbage"
+    assert render_collection_type(
+        "2026-07-20 00:00:00", "Garbage and Recycling", "Garbage and Recycling", now
+    ) == "garbage_recycling"
+    assert render_collection_type(
+        "2026-07-20 00:00:00", "Recycling", "Recycling", now
+    ) == "none"
+    assert render_collection_type(
+        "2026-07-20 00:00:00", "Municipal holiday", "No collection", now
+    ) == "none"
+    assert render_collection_type(
+        "2026-07-21 00:00:00", "Garbage", "Garbage", now
+    ) == "none"
+
+
+def test_start_automation_snapshots_and_sets_explicit_switch_style_targets():
+    package = load_package()
+    anchors = package["homeassistant"]["customize"]["package.node_anchors"]
+    start = automation_by_id("trash_recycling_led_reminder_start")
+
+    snapshot = anchors["trash_recycling_led_snapshot_entities"]
+    mode_entities = anchors["trash_recycling_led_mode_entities"]
+    color_entities = anchors["trash_recycling_led_color_entities"]
+    brightness_entities = anchors["trash_recycling_led_brightness_entities"]
+
+    assert len(mode_entities) == len(color_entities) == len(brightness_entities) == 13
+    assert set(snapshot) == set(mode_entities + color_entities + brightness_entities)
+    assert all("door" not in entity and "window" not in entity for entity in snapshot)
+    assert all("remote" not in entity for entity in snapshot)
+
+    snapshot_action, mode_action, color_action, brightness_action, active_action = start[
+        "action"
+    ]
+    assert snapshot_action["action"] == "scene.create"
+    assert snapshot_action["data"]["scene_id"] == "trash_recycling_led_reminder_prior_settings"
+    assert snapshot_action["data"]["snapshot_entities"] == snapshot
+    assert mode_action["data"]["option"] == "Always on"
+    assert mode_action["target"]["entity_id"] == mode_entities
+    assert color_action["target"]["entity_id"] == color_entities
+    assert color_action["data"]["option"] == "{{ reminder_color }}"
+    assert brightness_action["data"]["option"] == "Bright (100%)"
+    assert brightness_action["target"]["entity_id"] == brightness_entities
+    assert active_action["target"]["entity_id"] == "input_boolean.trash_recycling_led_reminder_active"
+    assert "presence" not in str(start).lower()
+
+
+def test_restore_automation_restores_scene_at_midnight_only_after_a_reminder():
+    restore = automation_by_id("trash_recycling_led_reminder_restore")
+
+    assert restore["trigger"] == [{"platform": "time", "at": "00:00:00"}]
+    assert restore["condition"] == [
+        {
+            "condition": "state",
+            "entity_id": "input_boolean.trash_recycling_led_reminder_active",
+            "state": "on",
+        }
+    ]
+    assert restore["action"][0] == {
+        "action": "scene.turn_on",
+        "target": {"entity_id": "scene.trash_recycling_led_reminder_prior_settings"},
+    }
+    assert restore["action"][1]["action"] == "input_boolean.turn_off"


### PR DESCRIPTION
## Summary
- Adds a package-driven 18:00 municipal-calendar reminder for 13 explicitly scoped Zooz wall switch/dimmer LED trios.
- Snapshots each mode, colour, and brightness before applying Always on + blue for garbage-only or green when recycling is also listed; restores the snapshot at midnight.
- Documents safe no-op handling for unknown/recycling-only calendar text and excludes door/window and remote indicator entities.

## Validation
- `pytest -q tests/test_trash_recycling_reminder.py` (3 passed)
- `pytest -q` (114 passed)
- Home Assistant Core configuration check in an isolated Docker config copy (passed)
- Authenticated live HA smoke: verified calendar attributes; snapshot/set/observed blue and green mode/colour/brightness options on a representative target; restored the original state and removed the temporary smoke scene.

## Documentation impact
- Added the active package to both repository and package inventories.

Closes #203