### PR TITLE
feat(reminders): include master bathroom closet LED

### DIFF
--- a/packages/trash_recycling_reminder.yaml
+++ b/packages/trash_recycling_reminder.yaml
@@ -19,6 +19,9 @@ homeassistant:
   customize:
     package.node_anchors:
       trash_recycling_led_snapshot_entities: &trash_recycling_led_snapshot_entities
+        - select.master_bathroom_master_bathroom_closet_led_indicator
+        - select.master_bathroom_master_bathroom_closet_led_indicator_color
+        - select.master_bathroom_master_bathroom_closet_led_indicator_brightness
         - select.dining_room_table_light_led_indicator
         - select.dining_room_table_light_led_indicator_color
         - select.dining_room_table_light_led_indicator_brightness
@@ -59,6 +62,7 @@ homeassistant:
         - select.coridor_led_indicator_color
         - select.coridor_led_indicator_brightness
       trash_recycling_led_mode_entities: &trash_recycling_led_mode_entities
+        - select.master_bathroom_master_bathroom_closet_led_indicator
         - select.dining_room_table_light_led_indicator
         - select.entry_led_indicator
         - select.living_room_right_led_indicator
@@ -73,6 +77,7 @@ homeassistant:
         - select.front_yard_lights_led_indicator
         - select.coridor_led_indicator
       trash_recycling_led_color_entities: &trash_recycling_led_color_entities
+        - select.master_bathroom_master_bathroom_closet_led_indicator_color
         - select.dining_room_table_light_led_indicator_color
         - select.entry_led_indicator_color
         - select.living_room_right_led_indicator_color
@@ -87,6 +92,7 @@ homeassistant:
         - select.front_yard_lights_led_indicator_color
         - select.coridor_led_indicator_color
       trash_recycling_led_brightness_entities: &trash_recycling_led_brightness_entities
+        - select.master_bathroom_master_bathroom_closet_led_indicator_brightness
         - select.dining_room_table_light_led_indicator_brightness
         - select.entry_led_indicator_brightness
         - select.living_room_right_led_indicator_brightness

--- a/tests/test_trash_recycling_reminder.py
+++ b/tests/test_trash_recycling_reminder.py
@@ -74,7 +74,10 @@ def test_start_automation_snapshots_and_sets_explicit_switch_style_targets():
     color_entities = anchors["trash_recycling_led_color_entities"]
     brightness_entities = anchors["trash_recycling_led_brightness_entities"]
 
-    assert len(mode_entities) == len(color_entities) == len(brightness_entities) == 13
+    assert len(mode_entities) == len(color_entities) == len(brightness_entities) == 14
+    assert mode_entities[0] == "select.master_bathroom_master_bathroom_closet_led_indicator"
+    assert color_entities[0] == "select.master_bathroom_master_bathroom_closet_led_indicator_color"
+    assert brightness_entities[0] == "select.master_bathroom_master_bathroom_closet_led_indicator_brightness"
     assert set(snapshot) == set(mode_entities + color_entities + brightness_entities)
     assert all("door" not in entity and "window" not in entity for entity in snapshot)
     assert all("remote" not in entity for entity in snapshot)


### PR DESCRIPTION
Adds the newly exposed master bathroom closet Zooz LED indicator, colour, and brightness selects to the existing municipal trash/recycling reminder.

- garbage-only remains Blue
- garbage plus recycling remains Green
- reminder brightness remains Bright (100%)
- prior settings remain captured/restored at midnight
- excludes unrelated configuration and diagnostic entities

Tests: pytest -q tests/test_trash_recycling_reminder.py