### PR TITLE
feat(kitchen): add meal prep state model

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -89,9 +89,9 @@ meal: the operator check is that `sensor.meal_prep_source_status` is
 `unavailable` with a reason and `sensor.meal_prep_session_state` is
 `unavailable` or `idle`. A future normalizer must write a coherent `ready`
 snapshot and its timestamp together. A non-`ready` status, a missing or
-unparseable update time, or an update older than 180 minutes fails closed. The
-package has no automation that changes these helpers; source updates and manual
-controls belong to later cards.
+unparseable update time, a future-dated timestamp, or a timestamp more than
+180 minutes old fails closed. The package has no automation that changes these
+helpers; source updates and manual controls belong to later cards.
 
 ## Notifications
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -31,6 +31,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `garage_door_monitoring.yaml` | Garage-door open-duration monitoring, reminder/escalation helpers, actionable notifications, and related scripts/templates. |
 | `known_batteries.yaml` | Template sensors that normalize known battery-powered devices into consistent names and attributes for the battery-health package. |
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
+| `meal_prep.yaml` | Source-independent kitchen meal-preparation state model. It owns persistent helper seams for a future Mealie normalizer and read-only meal/status/step/session sensors; it makes no live API calls or automatic transitions. |
 | `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |
 | `presence.yaml` | Presence-related behavior, including alarm-panel helpers and lighting automations tied to occupancy/time conditions. |
 | `protected_contacts.yaml` | Canonical, read-only inventory and open-state summary for eight window contacts plus Front Door, Back Door, and Garage Interior Door. Future packages should consume this seam rather than duplicate the protected-contact roster. |
@@ -57,6 +58,40 @@ Climate control is intentionally split across packages:
 - `dashboards/climate_control.yaml` is registered by `shared_infrastructure.yaml` and is the operator-facing view for the subsystem.
 
 Do not collapse these packages into one file just because they share a thermostat. The split keeps tuning helpers, behavioral automation, overlays, and diagnostics reviewable.
+
+## Kitchen meal-preparation state seam
+
+`meal_prep.yaml` is a state-model package, not an integration package. It is
+safe to load before a source is configured: the source-status sensor fails
+closed, and presentation sensors report `unavailable` or `none` rather than
+inventing meal or instruction content.
+
+| Entity ID | Friendly name | Purpose | Persistence decision |
+|---|---|---|---|
+| `input_boolean.meal_prep_active` | Meal Prep Active | Manual active-session flag for later controls. | Restored; no `initial` is set. |
+| `input_boolean.meal_prep_done` | Meal Prep Complete | Manual completion flag for later controls. | Restored; no `initial` is set. |
+| `input_datetime.meal_prep_target_time` | Meal Prep Target Time | Local planned/prep target-time seam. | Restored; no `initial` is set. |
+| `input_datetime.meal_prep_source_updated_at` | Meal Prep Source Updated At | Snapshot timestamp for freshness. | Restored; no `initial` is set. |
+| `input_text.meal_prep_snooze_until` | Meal Prep Snooze Until | ISO timestamp seam for a paused session. | Restored; no `initial` is set. |
+| `input_text.meal_prep_source_status` | Meal Prep Source Status Input | Future normalizer's raw status seam. | Restored; no `initial` is set. |
+| `input_text.meal_prep_meal_title`, `input_text.meal_prep_meal_type` | Meal Prep Meal Title/Type Input | Raw meal-identity seams. | Restored; no `initial` is set. |
+| `input_text.meal_prep_recipe_reference`, `input_text.meal_prep_recipe_url` | Meal Prep Recipe Reference/URL Input | Raw recipe seams. | Restored; no `initial` is set. |
+| `input_text.meal_prep_current_step`, `input_text.meal_prep_next_step` | Meal Prep Current/Next Step Input | Raw instruction-presentation seams. | Restored; no `initial` is set. |
+| `sensor.meal_prep_source_status` | Meal Prep Source Status | Normalized freshness/status and visible reason. | Derived at runtime. |
+| `sensor.meal_prep_meal`, `sensor.meal_prep_meal_type` | Meal Prep Meal/Meal Type | Safe normalized meal identity. | Derived at runtime. |
+| `sensor.meal_prep_recipe_reference`, `sensor.meal_prep_recipe_url` | Meal Prep Recipe Reference/URL | Safe normalized recipe seams. | Derived at runtime. |
+| `sensor.meal_prep_target_time` | Meal Prep Target Time | Safe local target-time presentation. | Derived at runtime. |
+| `sensor.meal_prep_current_step`, `sensor.meal_prep_next_step` | Meal Prep Current/Next Step | Safe normalized instruction seams. | Derived at runtime. |
+| `sensor.meal_prep_session_state` | Meal Prep Session State | `idle`, `planned`, `prep_due`, `active`, `paused`, `complete`, or `unavailable`. | Derived at runtime. |
+
+On a clean Home Assistant start, un-restored source helpers do not claim a
+meal: the operator check is that `sensor.meal_prep_source_status` is
+`unavailable` with a reason and `sensor.meal_prep_session_state` is
+`unavailable` or `idle`. A future normalizer must write a coherent `ready`
+snapshot and its timestamp together. A non-`ready` status, a missing or
+unparseable update time, or an update older than 180 minutes fails closed. The
+package has no automation that changes these helpers; source updates and manual
+controls belong to later cards.
 
 ## Notifications
 

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -17,7 +17,7 @@
 # - Set input_text.meal_prep_source_status to ready only after all source fields
 #   represent one coherent meal-plan snapshot.
 # - Set input_datetime.meal_prep_source_updated_at to that snapshot time.
-# - `ready` snapshots older than 180 minutes are stale and fail closed.
+# - `ready` snapshots older than 180 minutes or dated in the future fail closed.
 # - Valid non-ready status values are unavailable, error, and stale. Any other
 #   value is treated as unavailable.
 
@@ -102,6 +102,8 @@ template:
             unavailable
           {% elif updated_at is none or updated_at <= 0 %}
             unavailable
+          {% elif updated_at > now().timestamp() %}
+            unavailable
           {% elif now().timestamp() - updated_at > 10800 %}
             stale
           {% else %}
@@ -117,6 +119,8 @@ template:
               invalid source status
             {% elif updated_at is none or updated_at <= 0 %}
               missing source update time
+            {% elif updated_at > now().timestamp() %}
+              source update is in the future
             {% elif now().timestamp() - updated_at > 10800 %}
               source update is older than 180 minutes
             {% else %}

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -1,0 +1,262 @@
+# packages/meal_prep.yaml
+#
+# Kitchen meal-preparation state model.
+#
+# This package is intentionally source-independent: it defines the persistent
+# helper seams that #209 will populate from Mealie and the read-only template
+# entities that #208/#210 will present or control. It contains no REST calls,
+# scripts, automations, notifications, or device actions.
+#
+# Persistence: every input helper intentionally omits `initial`. Home Assistant
+# restores its last saved helper state after a restart; when no restored state
+# exists, the session derives a fail-closed idle/unavailable result from the
+# blank helpers. `input_boolean` helpers use Home Assistant's off default when
+# no stored state is available.
+#
+# Source contract for a future normalizer:
+# - Set input_text.meal_prep_source_status to ready only after all source fields
+#   represent one coherent meal-plan snapshot.
+# - Set input_datetime.meal_prep_source_updated_at to that snapshot time.
+# - `ready` snapshots older than 180 minutes are stale and fail closed.
+# - Valid non-ready status values are unavailable, error, and stale. Any other
+#   value is treated as unavailable.
+
+input_boolean:
+  meal_prep_active:
+    name: "Meal Prep Active"
+    icon: mdi:chef-hat
+
+  meal_prep_done:
+    name: "Meal Prep Complete"
+    icon: mdi:check-circle-outline
+
+input_datetime:
+  meal_prep_target_time:
+    name: "Meal Prep Target Time"
+    icon: mdi:calendar-clock
+    has_date: true
+    has_time: true
+
+  meal_prep_source_updated_at:
+    name: "Meal Prep Source Updated At"
+    icon: mdi:database-clock-outline
+    has_date: true
+    has_time: true
+
+input_text:
+  # Persistent raw source seams. They are not directly presented to operators;
+  # template sensors below normalize invalid data and source freshness.
+  meal_prep_source_status:
+    name: "Meal Prep Source Status Input"
+    icon: mdi:database-alert-outline
+    max: 32
+
+  meal_prep_meal_title:
+    name: "Meal Prep Meal Title Input"
+    icon: mdi:food-outline
+    max: 255
+
+  meal_prep_meal_type:
+    name: "Meal Prep Meal Type Input"
+    icon: mdi:format-list-bulleted-type
+    max: 100
+
+  meal_prep_recipe_reference:
+    name: "Meal Prep Recipe Reference Input"
+    icon: mdi:identifier
+    max: 255
+
+  meal_prep_recipe_url:
+    name: "Meal Prep Recipe URL Input"
+    icon: mdi:link-variant
+    max: 255
+
+  meal_prep_current_step:
+    name: "Meal Prep Current Step Input"
+    icon: mdi:format-list-numbered
+    max: 255
+
+  meal_prep_next_step:
+    name: "Meal Prep Next Step Input"
+    icon: mdi:skip-next-outline
+    max: 255
+
+  meal_prep_snooze_until:
+    name: "Meal Prep Snooze Until"
+    icon: mdi:pause-circle-outline
+    max: 40
+
+template:
+  - sensor:
+      # The 180-minute freshness bound is intentionally package-owned until a
+      # later operator-control card adds a reviewed tuning helper.
+      - name: "Meal Prep Source Status"
+        unique_id: meal_prep_source_status
+        icon: mdi:database-check-outline
+        state: >
+          {% set raw_status = states('input_text.meal_prep_source_status') | lower | trim %}
+          {% set updated_at = as_timestamp(states('input_datetime.meal_prep_source_updated_at'), default=none) %}
+          {% if raw_status in ['unavailable', 'error', 'stale'] %}
+            {{ raw_status }}
+          {% elif raw_status != 'ready' %}
+            unavailable
+          {% elif updated_at is none or updated_at <= 0 %}
+            unavailable
+          {% elif now().timestamp() - updated_at > 10800 %}
+            stale
+          {% else %}
+            ready
+          {% endif %}
+        attributes:
+          reason: >
+            {% set raw_status = states('input_text.meal_prep_source_status') | lower | trim %}
+            {% set updated_at = as_timestamp(states('input_datetime.meal_prep_source_updated_at'), default=none) %}
+            {% if raw_status in ['unavailable', 'error', 'stale'] %}
+              source reported {{ raw_status }}
+            {% elif raw_status != 'ready' %}
+              invalid source status
+            {% elif updated_at is none or updated_at <= 0 %}
+              missing source update time
+            {% elif now().timestamp() - updated_at > 10800 %}
+              source update is older than 180 minutes
+            {% else %}
+              source snapshot is fresh
+            {% endif %}
+          source_updated_at: "{{ states('input_datetime.meal_prep_source_updated_at') }}"
+          freshness_limit_minutes: 180
+
+      - name: "Meal Prep Meal"
+        unique_id: meal_prep_meal
+        icon: mdi:food-outline
+        state: >
+          {% set value = states('input_text.meal_prep_meal_title') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value | lower in ['unknown', 'unavailable', 'none'] %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Meal Type"
+        unique_id: meal_prep_meal_type
+        icon: mdi:format-list-bulleted-type
+        state: >
+          {% set value = states('input_text.meal_prep_meal_type') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value | lower in ['unknown', 'unavailable', 'none'] %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Recipe Reference"
+        unique_id: meal_prep_recipe_reference
+        icon: mdi:identifier
+        state: >
+          {% set value = states('input_text.meal_prep_recipe_reference') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value | lower in ['unknown', 'unavailable', 'none'] %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Recipe URL"
+        unique_id: meal_prep_recipe_url
+        icon: mdi:link-variant
+        state: >
+          {% set value = states('input_text.meal_prep_recipe_url') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% elif value | lower in ['unknown', 'unavailable', 'none'] or ' ' in value or not (value.startswith('http://') or value.startswith('https://')) %}
+            unavailable
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Target Time"
+        unique_id: meal_prep_target_time
+        icon: mdi:calendar-clock
+        state: >
+          {% set value = states('input_datetime.meal_prep_target_time') %}
+          {% if value in ['unknown', 'unavailable', '', none] %}
+            none
+          {% elif as_timestamp(value, default=none) is none %}
+            unavailable
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Current Step"
+        unique_id: meal_prep_current_step
+        icon: mdi:format-list-numbered
+        state: >
+          {% set value = states('input_text.meal_prep_current_step') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value | lower in ['unknown', 'unavailable', 'none'] %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Next Step"
+        unique_id: meal_prep_next_step
+        icon: mdi:skip-next-outline
+        state: >
+          {% set value = states('input_text.meal_prep_next_step') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value | lower in ['unknown', 'unavailable', 'none'] %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Session State"
+        unique_id: meal_prep_session_state
+        icon: mdi:chef-hat
+        state: >
+          {% set source_status = states('sensor.meal_prep_source_status') %}
+          {% set meal = states('sensor.meal_prep_meal') %}
+          {% set snooze_until = as_timestamp(states('input_text.meal_prep_snooze_until'), default=none) %}
+          {% set target_time = as_timestamp(states('input_datetime.meal_prep_target_time'), default=none) %}
+          {% if source_status != 'ready' or meal == 'unavailable' %}
+            unavailable
+          {% elif meal == 'none' %}
+            idle
+          {% elif is_state('input_boolean.meal_prep_done', 'on') %}
+            complete
+          {% elif snooze_until is not none and snooze_until > now().timestamp() %}
+            paused
+          {% elif is_state('input_boolean.meal_prep_active', 'on') %}
+            active
+          {% elif target_time is not none and now().timestamp() >= target_time %}
+            prep_due
+          {% else %}
+            planned
+          {% endif %}
+        attributes:
+          source_status: "{{ states('sensor.meal_prep_source_status') }}"
+          source_reason: "{{ state_attr('sensor.meal_prep_source_status', 'reason') }}"
+          target_time: "{{ states('sensor.meal_prep_target_time') }}"
+          snooze_until: "{{ states('input_text.meal_prep_snooze_until') }}"
+          semantics: >
+            idle=no valid meal; planned=fresh valid meal before target; prep_due=fresh valid meal at/after target;
+            active=manual active flag; paused=future snooze; complete=manual done flag;
+            unavailable=source is missing, invalid, error, or stale

--- a/tests/test_meal_prep_state_model.py
+++ b/tests/test_meal_prep_state_model.py
@@ -1,0 +1,261 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "meal_prep.yaml"
+PACKAGE_README = ROOT / "packages" / "README.md"
+NOW = datetime(2026, 7, 23, 18, 0, tzinfo=timezone.utc)
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def sensor_by_name(name):
+    for block in load_package()["template"]:
+        for sensor in block.get("sensor", []):
+            if sensor["name"] == name:
+                return sensor
+    raise AssertionError(f"template sensor {name!r} not found")
+
+
+def as_timestamp(value, default=None):
+    if value in (None, "", "unknown", "unavailable"):
+        return default
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    except (AttributeError, ValueError):
+        return default
+
+
+def render(template, state_map):
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals.update(
+        states=lambda entity_id: state_map.get(entity_id, "unknown"),
+        is_state=lambda entity_id, state: state_map.get(entity_id) == state,
+        state_attr=lambda entity_id, attribute: None,
+        as_timestamp=as_timestamp,
+        now=lambda: NOW,
+        none=None,
+    )
+    return environment.from_string(template).render().strip()
+
+
+def evaluate(state_map):
+    """Evaluate sensors in their dependency order using a fixed time fixture."""
+    state_map = dict(state_map)
+    source = sensor_by_name("Meal Prep Source Status")
+    state_map["sensor.meal_prep_source_status"] = render(source["state"], state_map)
+    for name, entity_id in (
+        ("Meal Prep Meal", "sensor.meal_prep_meal"),
+        ("Meal Prep Meal Type", "sensor.meal_prep_meal_type"),
+        ("Meal Prep Recipe Reference", "sensor.meal_prep_recipe_reference"),
+        ("Meal Prep Recipe URL", "sensor.meal_prep_recipe_url"),
+        ("Meal Prep Target Time", "sensor.meal_prep_target_time"),
+        ("Meal Prep Current Step", "sensor.meal_prep_current_step"),
+        ("Meal Prep Next Step", "sensor.meal_prep_next_step"),
+    ):
+        state_map[entity_id] = render(sensor_by_name(name)["state"], state_map)
+    state_map["sensor.meal_prep_session_state"] = render(
+        sensor_by_name("Meal Prep Session State")["state"], state_map
+    )
+    return state_map
+
+
+@pytest.fixture
+def ready_meal():
+    return {
+        "input_text.meal_prep_source_status": "ready",
+        "input_datetime.meal_prep_source_updated_at": "2026-07-23 17:30:00+00:00",
+        "input_text.meal_prep_meal_title": "Vegetable Lasagna",
+        "input_text.meal_prep_meal_type": "dinner",
+        "input_text.meal_prep_recipe_reference": "recipe-123",
+        "input_text.meal_prep_recipe_url": "https://mealie.example/recipe/recipe-123",
+        "input_text.meal_prep_current_step": "Chop vegetables",
+        "input_text.meal_prep_next_step": "Preheat oven",
+        "input_datetime.meal_prep_target_time": "2026-07-23 19:00:00+00:00",
+        "input_text.meal_prep_snooze_until": "",
+        "input_boolean.meal_prep_active": "off",
+        "input_boolean.meal_prep_done": "off",
+    }
+
+
+def test_helpers_are_stable_named_and_restored_without_initial_values():
+    package = load_package()
+    expected_helpers = {
+        "input_boolean": {
+            "meal_prep_active": ("Meal Prep Active", "mdi:chef-hat"),
+            "meal_prep_done": ("Meal Prep Complete", "mdi:check-circle-outline"),
+        },
+        "input_datetime": {
+            "meal_prep_target_time": ("Meal Prep Target Time", "mdi:calendar-clock"),
+            "meal_prep_source_updated_at": ("Meal Prep Source Updated At", "mdi:database-clock-outline"),
+        },
+        "input_text": {
+            "meal_prep_source_status": ("Meal Prep Source Status Input", "mdi:database-alert-outline"),
+            "meal_prep_meal_title": ("Meal Prep Meal Title Input", "mdi:food-outline"),
+            "meal_prep_meal_type": ("Meal Prep Meal Type Input", "mdi:format-list-bulleted-type"),
+            "meal_prep_recipe_reference": ("Meal Prep Recipe Reference Input", "mdi:identifier"),
+            "meal_prep_recipe_url": ("Meal Prep Recipe URL Input", "mdi:link-variant"),
+            "meal_prep_current_step": ("Meal Prep Current Step Input", "mdi:format-list-numbered"),
+            "meal_prep_next_step": ("Meal Prep Next Step Input", "mdi:skip-next-outline"),
+            "meal_prep_snooze_until": ("Meal Prep Snooze Until", "mdi:pause-circle-outline"),
+        },
+    }
+
+    for domain, helpers in expected_helpers.items():
+        for entity_id, (name, icon) in helpers.items():
+            assert package[domain][entity_id]["name"] == name
+            assert package[domain][entity_id]["icon"] == icon
+            assert "initial" not in package[domain][entity_id]
+
+    assert "Restored; no `initial` is set." in PACKAGE_README.read_text()
+
+
+@pytest.mark.parametrize(
+    ("name", "changes", "expected_source", "expected_session"),
+    [
+        (
+            "idle_no_meal",
+            {
+                "input_text.meal_prep_meal_title": "",
+                "input_datetime.meal_prep_target_time": "unknown",
+            },
+            "ready",
+            "idle",
+        ),
+        ("planned", {}, "ready", "planned"),
+        (
+            "prep_due",
+            {"input_datetime.meal_prep_target_time": "2026-07-23 17:59:00+00:00"},
+            "ready",
+            "prep_due",
+        ),
+        ("active", {"input_boolean.meal_prep_active": "on"}, "ready", "active"),
+        (
+            "paused_snoozed",
+            {"input_text.meal_prep_snooze_until": "2026-07-23 18:30:00+00:00"},
+            "ready",
+            "paused",
+        ),
+        ("complete", {"input_boolean.meal_prep_done": "on"}, "ready", "complete"),
+        (
+            "unavailable_source",
+            {"input_text.meal_prep_source_status": "error"},
+            "error",
+            "unavailable",
+        ),
+        (
+            "stale_source",
+            {"input_datetime.meal_prep_source_updated_at": "2026-07-23 14:59:00+00:00"},
+            "stale",
+            "unavailable",
+        ),
+    ],
+)
+def test_fixture_matrix_covers_every_session_state(
+    ready_meal, name, changes, expected_source, expected_session
+):
+    states = ready_meal | changes
+    evaluated = evaluate(states)
+
+    assert evaluated["sensor.meal_prep_source_status"] == expected_source, name
+    assert evaluated["sensor.meal_prep_session_state"] == expected_session, name
+
+
+def test_ready_snapshot_exposes_normalized_meal_recipe_and_instruction_seams(ready_meal):
+    evaluated = evaluate(ready_meal)
+
+    assert evaluated["sensor.meal_prep_meal"] == "Vegetable Lasagna"
+    assert evaluated["sensor.meal_prep_meal_type"] == "dinner"
+    assert evaluated["sensor.meal_prep_recipe_reference"] == "recipe-123"
+    assert evaluated["sensor.meal_prep_recipe_url"] == "https://mealie.example/recipe/recipe-123"
+    assert evaluated["sensor.meal_prep_target_time"] == "2026-07-23 19:00:00+00:00"
+    assert evaluated["sensor.meal_prep_current_step"] == "Chop vegetables"
+    assert evaluated["sensor.meal_prep_next_step"] == "Preheat oven"
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected_source", "expected_meal", "expected_step"),
+    [
+        (
+            {"input_text.meal_prep_source_status": "not-a-valid-status"},
+            "unavailable",
+            "unavailable",
+            "unavailable",
+        ),
+        (
+            {"input_datetime.meal_prep_source_updated_at": "not-a-timestamp"},
+            "unavailable",
+            "unavailable",
+            "unavailable",
+        ),
+        (
+            {"input_text.meal_prep_meal_title": "unknown"},
+            "ready",
+            "unavailable",
+            "Chop vegetables",
+        ),
+        (
+            {"input_text.meal_prep_current_step": "unavailable"},
+            "ready",
+            "Vegetable Lasagna",
+            "unavailable",
+        ),
+        (
+            {"input_text.meal_prep_recipe_url": "not a URL"},
+            "ready",
+            "Vegetable Lasagna",
+            "Chop vegetables",
+        ),
+    ],
+)
+def test_invalid_source_values_fail_closed_without_fabricating_content(
+    ready_meal, changes, expected_source, expected_meal, expected_step
+):
+    evaluated = evaluate(ready_meal | changes)
+
+    assert evaluated["sensor.meal_prep_source_status"] == expected_source
+    assert evaluated["sensor.meal_prep_meal"] == expected_meal
+    assert evaluated["sensor.meal_prep_current_step"] == expected_step
+    if changes.get("input_text.meal_prep_recipe_url") == "not a URL":
+        assert evaluated["sensor.meal_prep_recipe_url"] == "unavailable"
+
+
+def test_source_status_exposes_explicit_visible_reasons(ready_meal):
+    status = sensor_by_name("Meal Prep Source Status")
+
+    missing_time_reason = render(
+        status["attributes"]["reason"],
+        ready_meal | {"input_datetime.meal_prep_source_updated_at": "unknown"},
+    )
+    stale_reason = render(
+        status["attributes"]["reason"],
+        ready_meal | {"input_datetime.meal_prep_source_updated_at": "2026-07-23 14:59:00+00:00"},
+    )
+
+    assert missing_time_reason == "missing source update time"
+    assert stale_reason == "source update is older than 180 minutes"
+
+
+def test_package_is_source_independent_and_defers_actions_to_later_cards():
+    package = load_package()
+    package_text = PACKAGE.read_text()
+
+    assert set(package) == {"input_boolean", "input_datetime", "input_text", "template"}
+    assert "rest:" not in package_text
+    assert "automation:" not in package_text
+    assert "script:" not in package_text
+    assert "service:" not in package_text
+    assert "#209" in package_text
+    assert "#208/#210" in package_text
+    assert "180 minutes" in PACKAGE_README.read_text()

--- a/tests/test_meal_prep_state_model.py
+++ b/tests/test_meal_prep_state_model.py
@@ -160,6 +160,12 @@ def test_helpers_are_stable_named_and_restored_without_initial_values():
             "stale",
             "unavailable",
         ),
+        (
+            "future_source",
+            {"input_datetime.meal_prep_source_updated_at": "2026-07-23 18:01:00+00:00"},
+            "unavailable",
+            "unavailable",
+        ),
     ],
 )
 def test_fixture_matrix_covers_every_session_state(
@@ -242,9 +248,14 @@ def test_source_status_exposes_explicit_visible_reasons(ready_meal):
         status["attributes"]["reason"],
         ready_meal | {"input_datetime.meal_prep_source_updated_at": "2026-07-23 14:59:00+00:00"},
     )
+    future_reason = render(
+        status["attributes"]["reason"],
+        ready_meal | {"input_datetime.meal_prep_source_updated_at": "2026-07-23 18:01:00+00:00"},
+    )
 
     assert missing_time_reason == "missing source update time"
     assert stale_reason == "source update is older than 180 minutes"
+    assert future_reason == "source update is in the future"
 
 
 def test_package_is_source_independent_and_defers_actions_to_later_cards():


### PR DESCRIPTION
## Summary
- adds a source-independent `packages/meal_prep.yaml` state model for the kitchen meal-prep flow
- defines persistent helper seams plus fail-closed, dashboard-ready meal, recipe, step, source, target-time, and session-state sensors
- documents every stable entity, persistence behavior, the 180-minute freshness policy, and clean-start operator check
- adds a deterministic fixture matrix covering idle, planned, prep due, active, paused, complete, unavailable, and stale source states

## Validation
- `python3 -m pytest -q tests/test_meal_prep_state_model.py` (17 passed)
- `python3 -m pytest -q` (131 passed)
- parsed all 27 active package YAML files with `yaml.safe_load`
- `git diff --check`

## Documentation impact
- Updated `packages/README.md` with the active package inventory and a complete meal-preparation entity/persistence contract.

## Safety and scope
- No live Home Assistant actions, Mealie requests/writes, automations, scripts, dashboard changes, Cast behavior, or source credentials were added.
- Source normalization belongs to #209; dashboard and manual controls remain deferred to #208 and #210.

Closes #207
