### PR TITLE
feat(kitchen): add Kitchen Prep dashboard skeleton

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,6 +80,7 @@ Current YAML dashboards:
 
 - `dashboards/climate_control.yaml` for climate operations and diagnostics.
 - `dashboards/window_ventilation.yaml` for advisory ventilation recommendations.
+- `dashboards/kitchen_prep.yaml` for the hidden, phone-first Kitchen Prep view.
 
 ### 7. Notifications
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ YAML-managed dashboards live in `dashboards/` and are registered by `packages/sh
 
 - `dashboards/climate_control.yaml` provides the mobile-first climate operator view, thermostat controls, temperature and air-quality trend graphs, extreme-heat overlay controls, and diagnostics.
 - `dashboards/window_ventilation.yaml` provides the advisory ventilation view, current recommendation, comfort/dew-point context, rain/HVAC context, air-quality baseline comparisons, and tuning helpers.
+- `dashboards/kitchen_prep.yaml` provides a hidden, phone-first Kitchen Prep view. It renders only fresh meal-prep source data, intentionally defers recipe metadata to the read-only Mealie normalizer and manual controls to their owning cards, and is the future direct-view target for the kitchen display.
 
 ## Notifications and shared contracts
 

--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -1,0 +1,121 @@
+# dashboards/kitchen_prep.yaml
+#
+# Focused phone-first kitchen preparation view. The dashboard uses only the
+# read-only meal-prep state seams in packages/meal_prep.yaml. Manual controls
+# intentionally remain deferred to #210, which owns idempotent transitions.
+#
+# The direct view URL is also the future cast target for
+# media_player.kitchen_display. Rendering it on the live display is an operator
+# check after this dashboard has been deployed; this repository change performs
+# no Cast service call.
+
+title: "Kitchen Prep"
+views:
+  - title: "Kitchen Prep"
+    path: "kitchen-prep"
+    icon: mdi:chef-hat
+    badges: []
+    cards:
+      - type: markdown
+        title: "Meal status"
+        content: >-
+          {% set source_status = states('sensor.meal_prep_source_status') %}
+          {% set meal = states('sensor.meal_prep_meal') %}
+          {% if source_status != 'ready' %}
+          ## Meal source unavailable
+
+          Meal and instruction details are intentionally hidden until the
+          source reports a fresh, coherent snapshot.
+
+          **Source status:** {{ source_status | title }}
+
+          **Reason:** {{ state_attr('sensor.meal_prep_source_status', 'reason') }}
+          {% elif meal in ['none', 'unavailable', 'unknown'] %}
+          ## No meal planned
+
+          The fresh source does not currently provide a meal to prepare.
+
+          **Source status:** Ready
+          {% else %}
+          ## {{ meal }}
+
+          **Meal type:** {{ states('sensor.meal_prep_meal_type') | title }}
+
+          **Planned / prep time:** {{ states('sensor.meal_prep_target_time') }}
+
+          **Preparation state:** {{ states('sensor.meal_prep_session_state') | replace('_', ' ') | title }}
+
+          **Source status:** Ready
+          {% endif %}
+
+      - type: markdown
+        title: "Current step"
+        content: >-
+          {% set meal = states('sensor.meal_prep_meal') %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' or meal in ['none', 'unavailable', 'unknown'] %}
+          ## Waiting for a fresh meal source
+
+          No instruction is shown while the source is unavailable, stale, or
+          incomplete.
+          {% elif states('sensor.meal_prep_current_step') in ['none', 'unavailable'] %}
+          ## No current step is available
+
+          The source has not supplied an instruction to present.
+          {% else %}
+          ## {{ states('sensor.meal_prep_current_step') }}
+          {% endif %}
+
+      - type: markdown
+        title: "Next step"
+        content: >-
+          {% set meal = states('sensor.meal_prep_meal') %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' or meal in ['none', 'unavailable', 'unknown'] %}
+          The next instruction is unavailable until the meal source is fresh.
+          {% elif states('sensor.meal_prep_next_step') in ['none', 'unavailable'] %}
+          No next instruction is available.
+          {% else %}
+          {{ states('sensor.meal_prep_next_step') }}
+          {% endif %}
+
+      - type: markdown
+        title: "Recipe context"
+        content: >-
+          {% set meal = states('sensor.meal_prep_meal') %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' or meal in ['none', 'unavailable', 'unknown'] %}
+          Recipe details are unavailable until the source is fresh.
+          {% else %}
+          {% set recipe_url = states('sensor.meal_prep_recipe_url') %}
+          {% if recipe_url not in ['none', 'unavailable', 'unknown'] %}
+          **Recipe:** [Open recipe]({{ recipe_url }})
+          {% elif states('sensor.meal_prep_recipe_reference') not in ['none', 'unavailable', 'unknown'] %}
+          **Recipe reference:** {{ states('sensor.meal_prep_recipe_reference') }}
+          {% else %}
+          No recipe reference is available.
+          {% endif %}
+
+          Prep time, cook time, servings, and concise ingredient context are
+          intentionally deferred to the read-only Mealie normalizer in #209;
+          this dashboard does not invent recipe content.
+          {% endif %}
+
+      - type: entities
+        title: "Source details"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.meal_prep_source_status
+            name: "Source status"
+          - type: attribute
+            entity: sensor.meal_prep_source_status
+            attribute: reason
+            name: "Source reason"
+          - type: attribute
+            entity: sensor.meal_prep_source_status
+            attribute: source_updated_at
+            name: "Source updated"
+          - entity: sensor.meal_prep_session_state
+            name: "Preparation state"
+          - entity: sensor.meal_prep_target_time
+            name: "Planned / prep time"
+
+      # #210 owns the stable Start, Done, Skip, Snooze, and Finish script
+      # seams. Do not add buttons until that card supplies real services.

--- a/packages/README.md
+++ b/packages/README.md
@@ -41,7 +41,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `security_door_alerts.yaml` | Immediate high-priority alerts when front, back, or garage-interior security-boundary contacts open while the alarm is armed away/night. Uses a separate security tag namespace, clears only those tags on close, and announces once through the master bedroom display. |
 | `security_lights.yaml` | Security-focused lighting helpers and automations, including after-dark/security-event lighting behavior. |
 | `security_sanity.yaml` | Reusable secure-house sanity check workflow used by routines and presence flows to verify/notify about doors, locks, garage state, and other security context. |
-| `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control and ventilation advice. |
+| `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control, ventilation advice, and Kitchen Prep. |
 | `towner_notifications.yaml` | School arrival/departure notification workflow that handles infrequent location updates, race conditions, verification windows, and timeout/reset states. |
 | `trash_recycling_reminder.yaml` | Municipality-calendar-driven trash/recycling-night Zooz LED reminder. It snapshots and restores explicitly scoped wall-switch/dimmer LED settings, shows blue for garbage-only and green when recycling is also listed, and safely ignores unknown or recycling-only calendar text. |
 | `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and an open-window rain alert that names affected monitored windows and clears after they all close. |
@@ -124,6 +124,17 @@ packages should read `sensor.protected_contact_inventory` and
 
 - `climate-control` from `dashboards/climate_control.yaml`
 - `window-ventilation` from `dashboards/window_ventilation.yaml` (title: "Ventilation Advisor")
+- `kitchen-prep` from `dashboards/kitchen_prep.yaml` (title: "Kitchen Prep", hidden from the sidebar)
+
+The Kitchen Prep dashboard presents only normalized, fresh state from
+`meal_prep.yaml`. It intentionally defers prep/cook metadata, servings, and
+concise ingredient context to the read-only Mealie normalizer (#209), and
+Start/Done/Skip/Snooze/Finish controls to the idempotent scripts in #210.
+Until those owner cards land, the dashboard has no action buttons or dangling
+service references. After deployment, an operator can smoke-test the direct
+`kitchen-prep` Lovelace view with `cast.show_lovelace_view` on
+`media_player.kitchen_display`; that live check is not performed by repository
+validation.
 
 Packages should add dashboard-facing sensors/templates inside the feature package that owns the data, then wire the presentation in `dashboards/` when a dedicated operator view is needed.
 

--- a/packages/shared_infrastructure.yaml
+++ b/packages/shared_infrastructure.yaml
@@ -39,6 +39,12 @@ lovelace:
       icon: mdi:thermostat-auto
       show_in_sidebar: true
       filename: dashboards/climate_control.yaml
+    kitchen-prep:
+      mode: yaml
+      title: "Kitchen Prep"
+      icon: mdi:chef-hat
+      show_in_sidebar: false
+      filename: dashboards/kitchen_prep.yaml
 
 notify:
   - platform: group

--- a/tests/test_kitchen_prep_dashboard.py
+++ b/tests/test_kitchen_prep_dashboard.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SHARED_INFRASTRUCTURE = ROOT / "packages" / "shared_infrastructure.yaml"
+DASHBOARD = ROOT / "dashboards" / "kitchen_prep.yaml"
+
+
+def load_dashboard():
+    return yaml.safe_load(DASHBOARD.read_text())
+
+
+def load_shared_infrastructure():
+    return yaml.safe_load(SHARED_INFRASTRUCTURE.read_text())
+
+
+def iter_cards(cards):
+    for card in cards:
+        yield card
+        if card.get("card"):
+            yield from iter_cards([card["card"]])
+        if card.get("cards"):
+            yield from iter_cards(card["cards"])
+
+
+def entity_refs(cards):
+    refs = []
+    for card in iter_cards(cards):
+        if "entity" in card:
+            refs.append(card["entity"])
+        for row in card.get("entities", []):
+            if isinstance(row, str):
+                refs.append(row)
+            elif isinstance(row, dict) and "entity" in row:
+                refs.append(row["entity"])
+    return refs
+
+
+def markdown_by_title(cards, title):
+    return next(card["content"] for card in cards if card.get("title") == title)
+
+
+def test_kitchen_prep_dashboard_is_yaml_managed_and_hidden():
+    dashboard_config = load_shared_infrastructure()["lovelace"]["dashboards"][
+        "kitchen-prep"
+    ]
+
+    assert dashboard_config == {
+        "mode": "yaml",
+        "title": "Kitchen Prep",
+        "icon": "mdi:chef-hat",
+        "show_in_sidebar": False,
+        "filename": "dashboards/kitchen_prep.yaml",
+    }
+
+
+def test_kitchen_prep_dashboard_presents_only_real_read_only_state_seams():
+    dashboard = load_dashboard()
+    cards = dashboard["views"][0]["cards"]
+    refs = set(entity_refs(cards))
+
+    assert dashboard["title"] == "Kitchen Prep"
+    assert dashboard["views"][0]["path"] == "kitchen-prep"
+    assert dashboard["views"][0]["badges"] == []
+    assert refs == {
+        "sensor.meal_prep_source_status",
+        "sensor.meal_prep_session_state",
+        "sensor.meal_prep_target_time",
+    }
+
+    dashboard_text = DASHBOARD.read_text()
+    for entity_id in (
+        "sensor.meal_prep_meal",
+        "sensor.meal_prep_meal_type",
+        "sensor.meal_prep_current_step",
+        "sensor.meal_prep_next_step",
+        "sensor.meal_prep_recipe_url",
+        "sensor.meal_prep_recipe_reference",
+    ):
+        assert entity_id in dashboard_text
+
+    assert "media_player.kitchen_display" in dashboard_text
+    assert "media_player.display_kitchen" not in dashboard_text
+    assert "service:" not in dashboard_text
+    assert "script." not in dashboard_text
+
+
+def test_kitchen_prep_dashboard_is_concise_and_fail_closed_when_source_is_unavailable():
+    cards = load_dashboard()["views"][0]["cards"]
+    status = markdown_by_title(cards, "Meal status")
+    current_step = markdown_by_title(cards, "Current step")
+    next_step = markdown_by_title(cards, "Next step")
+    recipe_context = markdown_by_title(cards, "Recipe context")
+
+    assert "{% if source_status != 'ready' %}" in status
+    assert "{% elif meal in ['none', 'unavailable', 'unknown'] %}" in status
+    assert "No meal planned" in status
+    assert "## {{ meal }}" in status
+    for content in (current_step, next_step, recipe_context):
+        assert "states('sensor.meal_prep_source_status') != 'ready'" in content
+        assert "meal in ['none', 'unavailable', 'unknown']" in content
+
+    assert "Meal source unavailable" in status
+    assert "fresh, coherent snapshot" in status
+    assert "states('sensor.meal_prep_meal')" in status
+    assert "states('sensor.meal_prep_meal_type')" in status
+    assert "states('sensor.meal_prep_target_time')" in status
+    assert "state_attr('sensor.meal_prep_source_status', 'reason')" in status
+
+    assert "## {{ states('sensor.meal_prep_current_step') }}" in current_step
+    assert "No instruction is shown" in current_step
+    assert "states('sensor.meal_prep_next_step')" in next_step
+    assert "Prep time, cook time, servings, and concise ingredient context" in recipe_context
+    assert "deferred to the read-only Mealie normalizer in #209" in recipe_context
+    assert "full recipe" not in DASHBOARD.read_text().lower()
+
+
+def test_kitchen_prep_dashboard_defers_controls_to_the_owner_card_without_dangling_services():
+    dashboard_text = DASHBOARD.read_text()
+
+    assert "#210 owns the stable Start, Done, Skip, Snooze, and Finish script" in dashboard_text
+    assert "Do not add buttons until that card supplies real services." in dashboard_text
+    assert "type: button" not in dashboard_text
+    assert "tap_action:" not in dashboard_text

--- a/tests/test_shared_infrastructure.py
+++ b/tests/test_shared_infrastructure.py
@@ -24,6 +24,13 @@ def test_shared_infrastructure_owns_root_level_package_contracts():
     dashboards = shared["lovelace"]["dashboards"]
     assert dashboards["window-ventilation"]["filename"] == "dashboards/window_ventilation.yaml"
     assert dashboards["climate-control"]["filename"] == "dashboards/climate_control.yaml"
+    assert dashboards["kitchen-prep"] == {
+        "mode": "yaml",
+        "title": "Kitchen Prep",
+        "icon": "mdi:chef-hat",
+        "show_in_sidebar": False,
+        "filename": "dashboards/kitchen_prep.yaml",
+    }
 
     notify_groups = shared["notify"]
     assert notify_groups == [


### PR DESCRIPTION
## Summary
- Register the hidden YAML-managed `kitchen-prep` dashboard and add a focused phone/cast-ready Kitchen Prep view.
- Present fresh normalized meal, timing, current/next instruction, source status, and recipe-reference seams without showing fabricated content when the source or meal is unavailable.
- Document and explicitly defer recipe metadata/ingredient context to #209 and idempotent action buttons to #210; no dangling services or entities were introduced.

## Validation
- `pytest -q` (136 passed)
- Parsed all repository YAML with Home Assistant tag compatibility and parsed Kitchen Prep markdown templates with Jinja2.
- `git diff --check`

## Documentation impact
- Updated the repository, package, and development dashboard inventories plus the operator-only Cast smoke-test seam.

## Live Cast status
Not run: this change performs no live deployment or Cast service call. After deployment, an operator should render the `kitchen-prep` Lovelace view through `cast.show_lovelace_view` on `media_player.kitchen_display` and confirm markdown, dynamic updates, and future buttons are legible.

Closes #208
