### PR TITLE
feat(kitchen): add read-only Mealie meal path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `garage_door_monitoring.yaml` - garage-door duration monitoring, reminders, and controls.
 - `known_batteries.yaml` - normalized template sensors for known battery-powered devices.
 - `light_groups.yaml` - logical light groups.
+- `meal_prep.yaml` and `mealie_read_only.yaml` - Kitchen Prep helper/state model and its bounded read-only Mealie adapter for fresh meal, recipe, instruction, timing, and ingredient context.
 - `notifications.yaml` - shared notification automations that do not belong to a larger package.
 - `presence.yaml` - presence, alarm-panel, and presence-related lighting behavior.
 - `remotes.yaml` - Z-Wave remote helper scripts and blueprint-backed automations.

--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -93,9 +93,15 @@ views:
           No recipe reference is available.
           {% endif %}
 
-          Prep time, cook time, servings, and concise ingredient context are
-          intentionally deferred to the read-only Mealie normalizer in #209;
-          this dashboard does not invent recipe content.
+          {% set recipe_summary = states('sensor.meal_prep_recipe_summary') %}
+          {% if recipe_summary not in ['none', 'unavailable', 'unknown'] %}
+          **Timing / servings:** {{ recipe_summary }}
+          {% endif %}
+
+          {% set ingredient_context = states('sensor.meal_prep_ingredient_context') %}
+          {% if ingredient_context not in ['none', 'unavailable', 'unknown'] %}
+          **Ingredients:** {{ ingredient_context }}
+          {% endif %}
           {% endif %}
 
       - type: entities

--- a/packages/README.md
+++ b/packages/README.md
@@ -31,7 +31,8 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `garage_door_monitoring.yaml` | Garage-door open-duration monitoring, reminder/escalation helpers, actionable notifications, and related scripts/templates. |
 | `known_batteries.yaml` | Template sensors that normalize known battery-powered devices into consistent names and attributes for the battery-health package. |
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
-| `meal_prep.yaml` | Source-independent kitchen meal-preparation state model. It owns persistent helper seams for a future Mealie normalizer and read-only meal/status/step/session sensors; it makes no live API calls or automatic transitions. |
+| `meal_prep.yaml` | Kitchen meal-preparation state model. It owns persistent helper seams and read-only normalized meal/status/step/session/recipe-context sensors. |
+| `mealie_read_only.yaml` | Read-only Mealie GET adapter. It refreshes a bounded today/upcoming plan and linked recipe into `meal_prep.yaml` helpers every 15 minutes. |
 | `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |
 | `presence.yaml` | Presence-related behavior, including alarm-panel helpers and lighting automations tied to occupancy/time conditions. |
 | `protected_contacts.yaml` | Canonical, read-only inventory and open-state summary for eight window contacts plus Front Door, Back Door, and Garage Interior Door. Future packages should consume this seam rather than duplicate the protected-contact roster. |
@@ -90,8 +91,36 @@ meal: the operator check is that `sensor.meal_prep_source_status` is
 `unavailable` or `idle`. A future normalizer must write a coherent `ready`
 snapshot and its timestamp together. A non-`ready` status, a missing or
 unparseable update time, a future-dated timestamp, or a timestamp more than
-180 minutes old fails closed. The package has no automation that changes these
-helpers; source updates and manual controls belong to later cards.
+180 minutes old fails closed. `mealie_read_only.yaml` is the only automated
+writer for source helpers; manual controls belong to later cards.
+
+### Mealie read-only wiring
+
+`mealie_read_only.yaml` uses only `GET` requests: the today endpoint first, then
+one bounded today-to-seven-day range only when today is empty, and one linked
+recipe request for the selected entry. It refreshes at Home Assistant startup
+and every 15 minutes (a 15-minute cadence); the single automation mode prevents
+overlapping API calls. No meal, recipe, shopping, or food write endpoint is configured.
+
+Before deploying, the operator must add these values to the existing Home
+Assistant `secrets.yaml` (never commit that file):
+
+- `mealie_authorization_header`: the complete OAuth2 `Bearer ...` header value.
+- `mealie_today_url`: the full `/api/households/mealplans/today` URL.
+- `mealie_range_url`: the full bounded range URL containing literal Jinja
+  `{{ mealie_range_start }}` and `{{ mealie_range_end }}` placeholders.
+- `mealie_recipe_url`: the full recipe URL containing literal
+  `{{ mealie_recipe_id }}`.
+
+The adapter accepts the verified camelCase fields only (`entryType`, `recipeId`,
+`prepTime`, `cookTime`, `totalTime`, `recipeIngredient`, and
+`recipeInstructions`). It stores at most two instruction strings, six concise
+ingredient labels / 255 characters, and a 160-character timing/servings
+summary. Empty plans become the explicit ready/no-meal state. Missing recipe
+links, malformed payloads, auth errors, timeouts, and server errors fail closed.
+A prior snapshot may remain visible only for its 180-minute freshness bound and
+its source reason explicitly says it is a fresh cached snapshot after a Mealie
+failure; it is never presented as a newly fetched result.
 
 ## Notifications
 

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -51,6 +51,11 @@ input_text:
     icon: mdi:database-alert-outline
     max: 32
 
+  meal_prep_source_reason:
+    name: "Meal Prep Source Reason Input"
+    icon: mdi:database-search-outline
+    max: 255
+
   meal_prep_meal_title:
     name: "Meal Prep Meal Title Input"
     icon: mdi:food-outline
@@ -79,6 +84,16 @@ input_text:
   meal_prep_next_step:
     name: "Meal Prep Next Step Input"
     icon: mdi:skip-next-outline
+    max: 255
+
+  meal_prep_recipe_summary:
+    name: "Meal Prep Recipe Summary Input"
+    icon: mdi:timer-outline
+    max: 160
+
+  meal_prep_ingredient_context:
+    name: "Meal Prep Ingredient Context Input"
+    icon: mdi:format-list-bulleted
     max: 255
 
   meal_prep_snooze_until:
@@ -112,9 +127,11 @@ template:
         attributes:
           reason: >
             {% set raw_status = states('input_text.meal_prep_source_status') | lower | trim %}
+            {% set raw_reason = states('input_text.meal_prep_source_reason') | trim %}
+            {% set source_reason = '' if raw_reason | lower in ['unknown', 'unavailable', 'none'] else raw_reason %}
             {% set updated_at = as_timestamp(states('input_datetime.meal_prep_source_updated_at'), default=none) %}
             {% if raw_status in ['unavailable', 'error', 'stale'] %}
-              source reported {{ raw_status }}
+              {{ source_reason if source_reason != '' else 'source reported ' ~ raw_status }}
             {% elif raw_status != 'ready' %}
               invalid source status
             {% elif updated_at is none or updated_at <= 0 %}
@@ -123,6 +140,8 @@ template:
               source update is in the future
             {% elif now().timestamp() - updated_at > 10800 %}
               source update is older than 180 minutes
+            {% elif source_reason != '' %}
+              {{ source_reason }}
             {% else %}
               source snapshot is fresh
             {% endif %}
@@ -185,6 +204,32 @@ template:
             none
           {% elif value | lower in ['unknown', 'unavailable', 'none'] or ' ' in value or not (value.startswith('http://') or value.startswith('https://')) %}
             unavailable
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Recipe Summary"
+        unique_id: meal_prep_recipe_summary
+        icon: mdi:timer-outline
+        state: >
+          {% set value = states('input_text.meal_prep_recipe_summary') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value == '' %}
+            none
+          {% else %}
+            {{ value }}
+          {% endif %}
+
+      - name: "Meal Prep Ingredient Context"
+        unique_id: meal_prep_ingredient_context
+        icon: mdi:format-list-bulleted
+        state: >
+          {% set value = states('input_text.meal_prep_ingredient_context') | trim %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' %}
+            unavailable
+          {% elif value == '' %}
+            none
           {% else %}
             {{ value }}
           {% endif %}

--- a/packages/mealie_read_only.yaml
+++ b/packages/mealie_read_only.yaml
@@ -1,0 +1,283 @@
+# packages/mealie_read_only.yaml
+#
+# Read-only Mealie adapter for the Kitchen Prep state model. All endpoints are
+# GET-only. URLs and the complete Authorization header stay in secrets.yaml;
+# never add a token, header value, or response payload to this repository.
+#
+# The refresh runs at startup and every 15 minutes. It requests today's plan,
+# then one bounded today-to-+7-day range only when today has no entries. Recipe
+# content is fetched only for the selected entry and is normalized into short
+# helper values. Source status is set last so presentation never sees a partial
+# snapshot.
+
+rest_command:
+  mealie_get_today:
+    url: !secret mealie_today_url
+    method: GET
+    timeout: 15
+    headers:
+      Authorization: !secret mealie_authorization_header
+      Accept: application/json
+
+  mealie_get_range:
+    # Secret value must retain {{ mealie_range_start }} and
+    # {{ mealie_range_end }} for Home Assistant template evaluation.
+    url: !secret mealie_range_url
+    method: GET
+    timeout: 15
+    headers:
+      Authorization: !secret mealie_authorization_header
+      Accept: application/json
+
+  mealie_get_recipe:
+    # Secret value must retain {{ mealie_recipe_id }} for template evaluation.
+    url: !secret mealie_recipe_url
+    method: GET
+    timeout: 15
+    headers:
+      Authorization: !secret mealie_authorization_header
+      Accept: application/json
+
+automation:
+  - alias: "Refresh Meal Prep from Mealie"
+    id: "meal_prep_refresh_from_mealie"
+    description: >
+      Read today's or next bounded Mealie meal plan and its linked recipe into
+      Kitchen Prep helpers. GET-only; malformed payloads and non-fresh failures
+      fail closed. A prior snapshot remains visible only while it is fresh and
+      carries a visible cached reason.
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: time_pattern
+        minutes: "/15"
+    variables:
+      mealie_range_start: "{{ now().date().isoformat() }}"
+      mealie_range_end: "{{ (now() + timedelta(days=7)).date().isoformat() }}"
+    action:
+      - action: rest_command.mealie_get_today
+        response_variable: mealie_today_response
+        continue_on_error: true
+      - variables:
+          mealie_today_status: "{{ mealie_today_response.status | default(0, true) | int(0) }}"
+          mealie_today_payload: "{{ mealie_today_response.content | default([], true) }}"
+      - choose:
+          - conditions: "{{ mealie_today_status == 200 and mealie_today_payload is sequence and mealie_today_payload is not string and mealie_today_payload is not mapping and mealie_today_payload | count == 0 }}"
+            sequence:
+              - action: rest_command.mealie_get_range
+                response_variable: mealie_range_response
+                continue_on_error: true
+              - variables:
+                  mealie_plan_status: "{{ mealie_range_response.status | default(0, true) | int(0) }}"
+                  mealie_plan_payload: "{{ mealie_range_response.content | default([], true) }}"
+        default:
+          - variables:
+              mealie_plan_status: "{{ mealie_today_status }}"
+              mealie_plan_payload: "{{ mealie_today_payload }}"
+      - choose:
+          - conditions: "{{ mealie_plan_status != 200 }}"
+            sequence:
+              - choose:
+                  - conditions: >
+                      {% set updated = as_timestamp(states('input_datetime.meal_prep_source_updated_at'), default=none) %}
+                      {{ is_state('input_text.meal_prep_source_status', 'ready') and updated is not none and updated > 0 and now().timestamp() - updated <= 10800 }}
+                    sequence:
+                      - action: input_text.set_value
+                        target:
+                          entity_id: input_text.meal_prep_source_reason
+                        data:
+                          value: "using fresh cached snapshot after Mealie request failure"
+                default:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_reason
+                    data:
+                      value: "Mealie request failed (HTTP {{ mealie_plan_status }})"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_status
+                    data:
+                      value: unavailable
+          - conditions: "{{ mealie_plan_payload is not sequence or mealie_plan_payload is string or mealie_plan_payload is mapping }}"
+            sequence:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_source_reason
+                data:
+                  value: "malformed Mealie meal-plan payload"
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_source_status
+                data:
+                  value: unavailable
+          - conditions: "{{ mealie_plan_payload | count == 0 }}"
+            sequence:
+              - action: input_text.set_value
+                target:
+                  entity_id:
+                    - input_text.meal_prep_source_status
+                    - input_text.meal_prep_meal_title
+                    - input_text.meal_prep_meal_type
+                    - input_text.meal_prep_recipe_reference
+                    - input_text.meal_prep_recipe_url
+                    - input_text.meal_prep_current_step
+                    - input_text.meal_prep_next_step
+                    - input_text.meal_prep_recipe_summary
+                    - input_text.meal_prep_ingredient_context
+                data:
+                  value: ""
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_source_reason
+                data:
+                  value: "no meal planned"
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.meal_prep_source_updated_at
+                data:
+                  datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_source_status
+                data:
+                  value: ready
+        default:
+          - variables:
+              mealie_entry: "{{ mealie_plan_payload[0] }}"
+              mealie_recipe_id: "{{ mealie_plan_payload[0].recipeId | default('', true) | string | trim }}"
+          - choose:
+              - conditions: "{{ mealie_entry is not mapping or mealie_recipe_id == '' }}"
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_reason
+                    data:
+                      value: "meal plan entry has no recipeId"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_status
+                    data:
+                      value: unavailable
+            default:
+              - action: rest_command.mealie_get_recipe
+                response_variable: mealie_recipe_response
+                continue_on_error: true
+              - variables:
+                  mealie_recipe_status: "{{ mealie_recipe_response.status | default(0, true) | int(0) }}"
+                  mealie_recipe: "{{ mealie_recipe_response.content | default({}, true) }}"
+              - choose:
+                  - conditions: "{{ mealie_recipe_status != 200 }}"
+                    sequence:
+                      - action: input_text.set_value
+                        target:
+                          entity_id: input_text.meal_prep_source_reason
+                        data:
+                          value: "Mealie request failed (HTTP {{ mealie_recipe_status }})"
+                      - action: input_text.set_value
+                        target:
+                          entity_id: input_text.meal_prep_source_status
+                        data:
+                          value: unavailable
+                  - conditions: >
+                      {{ mealie_recipe is not mapping or
+                         (mealie_recipe.name | default('', true) | string | trim) == '' or
+                         mealie_recipe.recipeInstructions is not defined or
+                         mealie_recipe.recipeInstructions is not sequence or
+                         mealie_recipe.recipeInstructions is string or
+                         mealie_recipe.recipeIngredient is not defined or
+                         mealie_recipe.recipeIngredient is not sequence or
+                         mealie_recipe.recipeIngredient is string }}
+                    sequence:
+                      - action: input_text.set_value
+                        target:
+                          entity_id: input_text.meal_prep_source_reason
+                        data:
+                          value: "malformed Mealie recipe payload"
+                      - action: input_text.set_value
+                        target:
+                          entity_id: input_text.meal_prep_source_status
+                        data:
+                          value: unavailable
+                default:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_status
+                    data:
+                      value: unavailable
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_meal_title
+                    data:
+                      value: "{{ mealie_recipe.name | string | trim | truncate(255, true, '') }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_meal_type
+                    data:
+                      value: "{{ mealie_entry.entryType | default('', true) | string | trim | truncate(100, true, '') }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_recipe_reference
+                    data:
+                      value: "{{ mealie_recipe_id | truncate(255, true, '') }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_recipe_url
+                    data:
+                      value: ""
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_current_step
+                    data:
+                      value: >
+                        {% set steps = mealie_recipe.recipeInstructions %}
+                        {% set first = steps[0] if steps | count > 0 else {} %}
+                        {{ (first.text if first is mapping else first if first is string else '') | string | trim | truncate(255, true, '') }}
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_next_step
+                    data:
+                      value: >
+                        {% set steps = mealie_recipe.recipeInstructions %}
+                        {% set second = steps[1] if steps | count > 1 else {} %}
+                        {{ (second.text if second is mapping else second if second is string else '') | string | trim | truncate(255, true, '') }}
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_recipe_summary
+                    data:
+                      value: >
+                        {% set values = namespace(parts=[]) %}
+                        {% for label, value in [('Prep', mealie_recipe.prepTime), ('Cook', mealie_recipe.cookTime), ('Total', mealie_recipe.totalTime), ('Serves', mealie_recipe.recipeYield)] %}
+                          {% if value | default(none, true) is not none and value | string | trim != '' %}
+                            {% set values.parts = values.parts + [label ~ ': ' ~ (value | string | trim)] %}
+                          {% endif %}
+                        {% endfor %}
+                        {{ values.parts | join(' • ') | truncate(160, true, '') }}
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_ingredient_context
+                    data:
+                      value: >
+                        {% set values = namespace(parts=[]) %}
+                        {% for ingredient in mealie_recipe.recipeIngredient[:6] %}
+                          {% set text = ingredient.note if ingredient is mapping and ingredient.note is defined else ingredient.food.name if ingredient is mapping and ingredient.food is mapping and ingredient.food.name is defined else ingredient if ingredient is string else '' %}
+                          {% if text | string | trim != '' %}
+                            {% set values.parts = values.parts + [text | string | trim] %}
+                          {% endif %}
+                        {% endfor %}
+                        {{ values.parts | join(', ') | truncate(255, true, '') }}
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_reason
+                    data:
+                      value: "fresh Mealie snapshot"
+                  - action: input_datetime.set_datetime
+                    target:
+                      entity_id: input_datetime.meal_prep_source_updated_at
+                    data:
+                      datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_status
+                    data:
+                      value: ready
+    mode: single

--- a/tests/test_kitchen_prep_dashboard.py
+++ b/tests/test_kitchen_prep_dashboard.py
@@ -112,8 +112,10 @@ def test_kitchen_prep_dashboard_is_concise_and_fail_closed_when_source_is_unavai
     assert "## {{ states('sensor.meal_prep_current_step') }}" in current_step
     assert "No instruction is shown" in current_step
     assert "states('sensor.meal_prep_next_step')" in next_step
-    assert "Prep time, cook time, servings, and concise ingredient context" in recipe_context
-    assert "deferred to the read-only Mealie normalizer in #209" in recipe_context
+    assert "Timing / servings:" in recipe_context
+    assert "Ingredients:" in recipe_context
+    assert "sensor.meal_prep_recipe_summary" in recipe_context
+    assert "sensor.meal_prep_ingredient_context" in recipe_context
     assert "full recipe" not in DASHBOARD.read_text().lower()
 
 

--- a/tests/test_mealie_read_only_path.py
+++ b/tests/test_mealie_read_only_path.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "mealie_read_only.yaml"
+MEAL_PREP = ROOT / "packages" / "meal_prep.yaml"
+DASHBOARD = ROOT / "dashboards" / "kitchen_prep.yaml"
+PACKAGE_README = ROOT / "packages" / "README.md"
+
+
+def load_yaml(path):
+    class SecretLoader(yaml.SafeLoader):
+        pass
+
+    SecretLoader.add_constructor(
+        "!secret", lambda loader, node: f"!secret {loader.construct_scalar(node)}"
+    )
+    return yaml.load(path.read_text(), Loader=SecretLoader)
+
+
+def automation_by_alias(package, alias):
+    return next(item for item in package["automation"] if item["alias"] == alias)
+
+
+def test_mealie_read_path_has_only_bounded_get_requests_with_secret_backed_wiring():
+    package = load_yaml(PACKAGE)
+    commands = package["rest_command"]
+
+    assert set(commands) == {
+        "mealie_get_today",
+        "mealie_get_range",
+        "mealie_get_recipe",
+    }
+    for command in commands.values():
+        assert command["method"] == "GET"
+        assert command["timeout"] == 15
+        assert command["headers"]["Authorization"] == "!secret mealie_authorization_header"
+        assert command["headers"]["Accept"] == "application/json"
+
+    assert commands["mealie_get_today"]["url"] == "!secret mealie_today_url"
+    assert commands["mealie_get_range"]["url"] == "!secret mealie_range_url"
+    assert commands["mealie_get_recipe"]["url"] == "!secret mealie_recipe_url"
+
+    package_text = PACKAGE.read_text()
+    assert "POST" not in package_text
+    assert "PUT" not in package_text
+    assert "PATCH" not in package_text
+    assert "DELETE" not in package_text
+    assert "Bearer " not in package_text
+    assert "mealie_authorization_header" in package_text
+
+
+def test_refresh_uses_today_then_bounded_range_and_camel_case_fields_only():
+    package = load_yaml(PACKAGE)
+    refresh = automation_by_alias(package, "Refresh Meal Prep from Mealie")
+    text = PACKAGE.read_text()
+
+    assert refresh["mode"] == "single"
+    assert {trigger["platform"] for trigger in refresh["trigger"]} == {
+        "homeassistant",
+        "time_pattern",
+    }
+    assert any(trigger.get("minutes") == "/15" for trigger in refresh["trigger"])
+    assert "rest_command.mealie_get_today" in text
+    assert "rest_command.mealie_get_range" in text
+    assert "rest_command.mealie_get_recipe" in text
+    assert "mealie_range_start" in text
+    assert "mealie_range_end" in text
+    for field in (
+        "entryType",
+        "recipeId",
+        "prepTime",
+        "cookTime",
+        "totalTime",
+        "recipeIngredient",
+        "recipeInstructions",
+    ):
+        assert field in text
+    # The adapter's local variables may use snake case, but source payload
+    # access must remain the verified camelCase contract above.
+    assert ".recipe_id" not in text
+    assert ".entry_type" not in text
+    assert ".prep_time" not in text
+    assert ".recipe_ingredient" not in text
+
+
+def test_refresh_has_explicit_idle_missing_link_transport_and_malformed_payload_paths():
+    text = PACKAGE.read_text()
+
+    for status, reason in (
+        ("ready", "no meal planned"),
+        ("unavailable", "meal plan entry has no recipeId"),
+        ("unavailable", "Mealie request failed"),
+        ("unavailable", "malformed Mealie recipe payload"),
+    ):
+        assert status in text
+        assert reason in text
+
+    # A fresh previous snapshot can be retained only with a visible cached reason;
+    # otherwise failures must fail closed rather than look freshly fetched.
+    assert "using fresh cached snapshot after Mealie request failure" in text
+    assert "10800" in text
+    assert "input_text.meal_prep_source_status" in text
+    assert "input_datetime.meal_prep_source_updated_at" in text
+
+
+def test_normalized_recipe_output_is_bounded_and_populates_helper_seams():
+    meal_prep = load_yaml(MEAL_PREP)
+    helpers = meal_prep["input_text"]
+    text = PACKAGE.read_text()
+
+    assert helpers["meal_prep_recipe_summary"]["max"] == 160
+    assert helpers["meal_prep_ingredient_context"]["max"] == 255
+    assert "input_text.meal_prep_recipe_summary" in text
+    assert "input_text.meal_prep_ingredient_context" in text
+    assert "[:6]" in text
+    assert "truncate(255" in text
+    assert "truncate(160" in text
+    assert "steps[1]" in text
+
+    for sensor in ("Meal Prep Recipe Summary", "Meal Prep Ingredient Context"):
+        assert any(
+            item.get("name") == sensor
+            for block in meal_prep["template"]
+            for item in block.get("sensor", [])
+        )
+
+
+def test_dashboard_and_docs_only_show_new_recipe_context_when_source_is_fresh():
+    dashboard_text = DASHBOARD.read_text()
+    docs = PACKAGE_README.read_text()
+
+    assert "sensor.meal_prep_recipe_summary" in dashboard_text
+    assert "sensor.meal_prep_ingredient_context" in dashboard_text
+    assert "deferred to the read-only Mealie normalizer" not in dashboard_text
+    assert "mealie_read_only.yaml" in docs
+    assert "mealie_authorization_header" in docs
+    assert "15-minute" in docs
+    assert "fresh cached snapshot" in docs


### PR DESCRIPTION
## Summary
- add a GET-only Mealie refresh adapter for today/bounded upcoming meal plans and linked recipes
- normalize bounded meal, timing, ingredient, and instruction context into Kitchen Prep helper seams
- document secret wiring, cache/freshness behavior, and refresh cadence

## Validation
- `pytest -q` (141 passed)
- HA-tag-tolerant YAML parse of configuration, packages, and dashboards
- `git diff --check`

## Safety
- no live Home Assistant reload/restart/deploy or Mealie request was performed
- no Mealie write endpoint is configured
- live smoke check not run: transient credential source was not available

Closes #209