### PR TITLE
feat(kitchen): add deterministic meal prep controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `garage_door_monitoring.yaml` - garage-door duration monitoring, reminders, and controls.
 - `known_batteries.yaml` - normalized template sensors for known battery-powered devices.
 - `light_groups.yaml` - logical light groups.
-- `meal_prep.yaml` and `mealie_read_only.yaml` - Kitchen Prep helper/state model and its bounded read-only Mealie adapter for fresh meal, recipe, instruction, timing, and ingredient context.
+- `meal_prep.yaml` and `mealie_read_only.yaml` - Kitchen Prep helper/state model, deterministic manual controls, and bounded read-only Mealie adapter for fresh meal, recipe, instruction, timing, and ingredient context.
 - `notifications.yaml` - shared notification automations that do not belong to a larger package.
 - `presence.yaml` - presence, alarm-panel, and presence-related lighting behavior.
 - `remotes.yaml` - Z-Wave remote helper scripts and blueprint-backed automations.
@@ -84,7 +84,7 @@ YAML-managed dashboards live in `dashboards/` and are registered by `packages/sh
 
 - `dashboards/climate_control.yaml` provides the mobile-first climate operator view, thermostat controls, temperature and air-quality trend graphs, extreme-heat overlay controls, and diagnostics.
 - `dashboards/window_ventilation.yaml` provides the advisory ventilation view, current recommendation, comfort/dew-point context, rain/HVAC context, air-quality baseline comparisons, and tuning helpers.
-- `dashboards/kitchen_prep.yaml` provides a hidden, phone-first Kitchen Prep view. It renders only fresh meal-prep source data, intentionally defers recipe metadata to the read-only Mealie normalizer and manual controls to their owning cards, and is the future direct-view target for the kitchen display.
+- `dashboards/kitchen_prep.yaml` provides a hidden, phone-first Kitchen Prep view. It renders only fresh meal-prep source data, presents #210-owned manual controls that fail closed outside a valid session, and is the future direct-view target for the kitchen display.
 
 ## Notifications and shared contracts
 

--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -1,8 +1,9 @@
 # dashboards/kitchen_prep.yaml
 #
 # Focused phone-first kitchen preparation view. The dashboard uses only the
-# read-only meal-prep state seams in packages/meal_prep.yaml. Manual controls
-# intentionally remain deferred to #210, which owns idempotent transitions.
+# read-only meal-prep state seams in packages/meal_prep.yaml and the #210
+# manual script seams. Controls fail closed in their scripts when the source,
+# meal, or session identity is invalid.
 #
 # The direct view URL is also the future cast target for
 # media_player.kitchen_display. Rendering it on the live display is an operator
@@ -123,5 +124,52 @@ views:
           - entity: sensor.meal_prep_target_time
             name: "Planned / prep time"
 
-      # #210 owns the stable Start, Done, Skip, Snooze, and Finish script
-      # seams. Do not add buttons until that card supplies real services.
+      - type: grid
+        title: "Preparation controls"
+        columns: 2
+        square: false
+        cards:
+          - type: button
+            name: "Start"
+            icon: mdi:play-circle-outline
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_start_preparation
+          - type: button
+            name: "Done"
+            icon: mdi:check-circle-outline
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_complete_current_step
+          - type: button
+            name: "Skip"
+            icon: mdi:skip-next-outline
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_skip_current_step
+          - type: button
+            name: "Snooze 30 min"
+            icon: mdi:pause-circle-outline
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_snooze_preparation
+              data:
+                snooze_minutes: 30
+          - type: button
+            name: "Finish today"
+            icon: mdi:flag-checkered
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_finish_for_today
+          - type: button
+            name: "Show display"
+            icon: mdi:cast-connected
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_show_dashboard
+          - type: button
+            name: "Clear session"
+            icon: mdi:close-circle-outline
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_clear_session

--- a/packages/README.md
+++ b/packages/README.md
@@ -31,7 +31,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `garage_door_monitoring.yaml` | Garage-door open-duration monitoring, reminder/escalation helpers, actionable notifications, and related scripts/templates. |
 | `known_batteries.yaml` | Template sensors that normalize known battery-powered devices into consistent names and attributes for the battery-health package. |
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
-| `meal_prep.yaml` | Kitchen meal-preparation state model. It owns persistent helper seams and read-only normalized meal/status/step/session/recipe-context sensors. |
+| `meal_prep.yaml` | Kitchen meal-preparation state model and deterministic manual Start/Done/Skip/Snooze/Finish/display/clear script seams. It owns persistent helper seams and read-only normalized meal/status/step/session/recipe-context sensors. |
 | `mealie_read_only.yaml` | Read-only Mealie GET adapter. It refreshes a bounded today/upcoming plan and linked recipe into `meal_prep.yaml` helpers every 15 minutes. |
 | `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |
 | `presence.yaml` | Presence-related behavior, including alarm-panel helpers and lighting automations tied to occupancy/time conditions. |
@@ -69,11 +69,14 @@ inventing meal or instruction content.
 
 | Entity ID | Friendly name | Purpose | Persistence decision |
 |---|---|---|---|
-| `input_boolean.meal_prep_active` | Meal Prep Active | Manual active-session flag for later controls. | Restored; no `initial` is set. |
-| `input_boolean.meal_prep_done` | Meal Prep Complete | Manual completion flag for later controls. | Restored; no `initial` is set. |
+| `input_boolean.meal_prep_active` | Meal Prep Active | Manual active-session flag for the matching meal/date identity. | Restored; no `initial` is set. |
+| `input_boolean.meal_prep_done` | Meal Prep Complete | Manual finish-for-today flag for the matching meal/date identity. | Restored; no `initial` is set. |
 | `input_datetime.meal_prep_target_time` | Meal Prep Target Time | Local planned/prep target-time seam. | Restored; no `initial` is set. |
 | `input_datetime.meal_prep_source_updated_at` | Meal Prep Source Updated At | Snapshot timestamp for freshness. | Restored; no `initial` is set. |
 | `input_text.meal_prep_snooze_until` | Meal Prep Snooze Until | ISO timestamp seam for a paused session. | Restored; no `initial` is set. |
+| `input_text.meal_prep_session_key` | Meal Prep Session Key | Date + recipe-reference identity that scopes restored active/done/snooze state. | Restored; no `initial` is set. |
+| `input_text.meal_prep_last_skipped_step` | Meal Prep Last Skipped Step | Bounded record of the most recent deliberate skip; it never marks the meal complete. | Restored; no `initial` is set. |
+| `input_text.meal_prep_remaining_steps` | Meal Prep Remaining Steps | Bounded escaped-delimiter source queue after the current/next steps, used only for deterministic manual advancement. | Restored; no `initial` is set. |
 | `input_text.meal_prep_source_status` | Meal Prep Source Status Input | Future normalizer's raw status seam. | Restored; no `initial` is set. |
 | `input_text.meal_prep_meal_title`, `input_text.meal_prep_meal_type` | Meal Prep Meal Title/Type Input | Raw meal-identity seams. | Restored; no `initial` is set. |
 | `input_text.meal_prep_recipe_reference`, `input_text.meal_prep_recipe_url` | Meal Prep Recipe Reference/URL Input | Raw recipe seams. | Restored; no `initial` is set. |
@@ -92,7 +95,28 @@ meal: the operator check is that `sensor.meal_prep_source_status` is
 snapshot and its timestamp together. A non-`ready` status, a missing or
 unparseable update time, a future-dated timestamp, or a timestamp more than
 180 minutes old fails closed. `mealie_read_only.yaml` is the only automated
-writer for source helpers; manual controls belong to later cards.
+writer for source helpers. Manual controls are script-only and perform no
+refresh, notification, or inferred cooking transition.
+
+### Kitchen Prep manual controls
+
+`meal_prep.yaml` owns these stable script service IDs:
+
+| Service | Deterministic behavior |
+|---|---|
+| `script.meal_prep_start_preparation` | Requires a fresh valid meal/current step, records a new date+recipe identity once, and activates the session. Re-running it for the same restored identity does not reset progress. |
+| `script.meal_prep_complete_current_step` | Requires an active matching fresh session and a valid supplied next step; promotes next to current once and clears next. It has no startup/reload trigger. |
+| `script.meal_prep_skip_current_step` | Records the skipped current step, promotes a valid next step when one exists, and never sets the completion flag or fabricates a later step. |
+| `script.meal_prep_snooze_preparation` | Requires an active matching fresh session and writes an ISO deadline bounded to 5–60 minutes (dashboard default: 30). |
+| `script.meal_prep_finish_for_today` | Stops the active matching session, clears its snooze, and sets its restored done flag; a different date/recipe identity does not inherit completion. |
+| `script.meal_prep_show_dashboard` | Statically configures `cast.show_lovelace_view` for `media_player.kitchen_display` and the registered `kitchen-prep` view; repository validation does not call it. |
+| `script.meal_prep_clear_session` | Clears only local session flags/audit state, never the Mealie snapshot. |
+
+All scripts use `mode: single`, have no triggers, and fail closed on missing,
+stale, malformed, or non-matching source/session state. The normalizer preserves
+current/next values during an active matching session, so its 15-minute refresh
+cannot replay an already advanced step. Later source steps are held only in a
+bounded, delimiter-safe queue; controls never invent steps beyond that source data.
 
 ### Mealie read-only wiring
 
@@ -114,9 +138,12 @@ Assistant `secrets.yaml` (never commit that file):
 
 The adapter accepts the verified camelCase fields only (`entryType`, `recipeId`,
 `prepTime`, `cookTime`, `totalTime`, `recipeIngredient`, and
-`recipeInstructions`). It stores at most two instruction strings, six concise
+`recipeInstructions`). It stores current/next instruction strings plus a
+255-character, escaped-delimiter bounded queue for later instructions, six concise
 ingredient labels / 255 characters, and a 160-character timing/servings
-summary. Empty plans become the explicit ready/no-meal state. Missing recipe
+summary. Empty plans become the explicit ready/no-meal state. During an active
+matching manual session, refresh preserves the current/next pair rather than
+overwriting manual progress. Missing recipe
 links, malformed payloads, auth errors, timeouts, and server errors fail closed.
 A prior snapshot may remain visible only for its 180-minute freshness bound and
 its source reason explicitly says it is a fresh cached snapshot after a Mealie
@@ -156,11 +183,11 @@ packages should read `sensor.protected_contact_inventory` and
 - `kitchen-prep` from `dashboards/kitchen_prep.yaml` (title: "Kitchen Prep", hidden from the sidebar)
 
 The Kitchen Prep dashboard presents only normalized, fresh state from
-`meal_prep.yaml`. It intentionally defers prep/cook metadata, servings, and
-concise ingredient context to the read-only Mealie normalizer (#209), and
-Start/Done/Skip/Snooze/Finish controls to the idempotent scripts in #210.
-Until those owner cards land, the dashboard has no action buttons or dangling
-service references. After deployment, an operator can smoke-test the direct
+`meal_prep.yaml`. It defers prep/cook metadata, servings, and concise ingredient
+context to the read-only Mealie normalizer (#209), and its seven manual buttons
+call the #210-owned stable Start/Done/Skip/Snooze/Finish/display/clear scripts.
+Each script guards invalid source/session state, so the buttons have no dangling
+service references or unsafe fallback behavior. After deployment, an operator can smoke-test the direct
 `kitchen-prep` Lovelace view with `cast.show_lovelace_view` on
 `media_player.kitchen_display`; that live check is not performed by repository
 validation.

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -5,7 +5,8 @@
 # This package is intentionally source-independent: it defines the persistent
 # helper seams that #209 will populate from Mealie and the read-only template
 # entities that #208/#210 will present or control. It contains no REST calls,
-# scripts, automations, notifications, or device actions.
+# automations, notifications, or device actions. The scripts below are manual
+# operator seams only; they do not announce, refresh a source, or infer cooking.
 #
 # Persistence: every input helper intentionally omits `initial`. Home Assistant
 # restores its last saved helper state after a restart; when no restored state
@@ -100,6 +101,224 @@ input_text:
     name: "Meal Prep Snooze Until"
     icon: mdi:pause-circle-outline
     max: 40
+
+  # Session-local, bounded audit state. The identity is date + recipe reference
+  # so a restored done/active flag never leaks into another day's meal.
+  meal_prep_session_key:
+    name: "Meal Prep Session Key"
+    icon: mdi:key-variant
+    max: 255
+
+  meal_prep_last_skipped_step:
+    name: "Meal Prep Last Skipped Step"
+    icon: mdi:skip-next-circle-outline
+    max: 255
+
+  # Escaped-delimiter instructions after current/next. The adapter only stores
+  # complete delimiter boundaries in this bounded helper.
+  meal_prep_remaining_steps:
+    name: "Meal Prep Remaining Steps"
+    icon: mdi:format-list-numbered
+    max: 255
+
+script:
+  meal_prep_start_preparation:
+    alias: "Kitchen Prep: Start preparation"
+    description: >
+      Manually begin the fresh current meal once. A matching restored session
+      retains its progress; a new date/recipe identity clears only local state.
+    mode: single
+    sequence:
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+      - condition: template
+        value_template: >
+          {{ states('sensor.meal_prep_source_status') == 'ready' and
+             states('sensor.meal_prep_meal') not in ['none', 'unavailable', 'unknown'] and
+             states('sensor.meal_prep_current_step') not in ['none', 'unavailable', 'unknown'] }}
+      - choose:
+          - conditions: "{{ states('input_text.meal_prep_session_key') != meal_prep_identity }}"
+            sequence:
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.meal_prep_done
+              - action: input_text.set_value
+                target:
+                  entity_id:
+                    - input_text.meal_prep_snooze_until
+                    - input_text.meal_prep_last_skipped_step
+                data:
+                  value: ""
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_session_key
+                data:
+                  value: "{{ meal_prep_identity }}"
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.meal_prep_active
+
+  meal_prep_complete_current_step:
+    alias: "Kitchen Prep: Done / advance current step"
+    description: >
+      Advance the active session once by promoting the supplied next step. The
+      script is single-run and never runs from startup/reload.
+    mode: single
+    sequence:
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          current_step: "{{ states('sensor.meal_prep_current_step') }}"
+          next_step: "{{ states('sensor.meal_prep_next_step') }}"
+          queued_step: "{{ states('input_text.meal_prep_remaining_steps').split('\\u001f')[0] if states('input_text.meal_prep_remaining_steps') not in ['', 'unknown', 'unavailable'] else '' }}"
+          following_steps: "{{ states('input_text.meal_prep_remaining_steps').split('\\u001f')[1:] | join('\\u001f') if states('input_text.meal_prep_remaining_steps') not in ['', 'unknown', 'unavailable'] else '' }}"
+      - condition: template
+        value_template: >
+          {{ states('sensor.meal_prep_source_status') == 'ready' and
+             is_state('input_boolean.meal_prep_active', 'on') and
+             states('input_text.meal_prep_session_key') == meal_prep_identity and
+             current_step not in ['none', 'unavailable', 'unknown'] and
+             next_step not in ['none', 'unavailable', 'unknown'] }}
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_current_step
+        data:
+          value: "{{ next_step }}"
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_next_step
+        data:
+          value: "{{ queued_step }}"
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_remaining_steps
+        data:
+          value: "{{ following_steps }}"
+
+  meal_prep_skip_current_step:
+    alias: "Kitchen Prep: Skip current step"
+    description: >
+      Record a deliberate skip, then advance without marking the meal complete.
+      A bounded source queue can supply later steps; no step is fabricated when
+      the current/next/queue source seams have no valid value.
+    mode: single
+    sequence:
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          current_step: "{{ states('sensor.meal_prep_current_step') }}"
+          next_step: "{{ states('sensor.meal_prep_next_step') }}"
+          queued_step: "{{ states('input_text.meal_prep_remaining_steps').split('\\u001f')[0] if states('input_text.meal_prep_remaining_steps') not in ['', 'unknown', 'unavailable'] else '' }}"
+          following_steps: "{{ states('input_text.meal_prep_remaining_steps').split('\\u001f')[1:] | join('\\u001f') if states('input_text.meal_prep_remaining_steps') not in ['', 'unknown', 'unavailable'] else '' }}"
+      - condition: template
+        value_template: >
+          {{ states('sensor.meal_prep_source_status') == 'ready' and
+             is_state('input_boolean.meal_prep_active', 'on') and
+             states('input_text.meal_prep_session_key') == meal_prep_identity and
+             current_step not in ['none', 'unavailable', 'unknown'] }}
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_last_skipped_step
+        data:
+          value: "{{ current_step }}"
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_current_step
+        data:
+          value: "{{ '' if next_step in ['none', 'unavailable', 'unknown'] else next_step }}"
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_next_step
+        data:
+          value: "{{ queued_step }}"
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_remaining_steps
+        data:
+          value: "{{ following_steps }}"
+
+  meal_prep_snooze_preparation:
+    alias: "Kitchen Prep: Snooze preparation"
+    description: "Pause the active session for a bounded 5-to-60-minute interval."
+    mode: single
+    fields:
+      snooze_minutes:
+        name: "Snooze minutes"
+        default: 30
+        selector:
+          number:
+            min: 5
+            max: 60
+            step: 5
+            unit_of_measurement: min
+    sequence:
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          bounded_snooze_minutes: "{{ [5, [snooze_minutes | default(30, true) | int(30), 60] | min] | max }}"
+      - condition: template
+        value_template: >
+          {{ states('sensor.meal_prep_source_status') == 'ready' and
+             is_state('input_boolean.meal_prep_active', 'on') and
+             states('input_text.meal_prep_session_key') == meal_prep_identity }}
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_snooze_until
+        data:
+          value: "{{ (now() + timedelta(minutes=bounded_snooze_minutes | int)).isoformat() }}"
+
+  meal_prep_finish_for_today:
+    alias: "Kitchen Prep: Finish for today"
+    description: "Suppress the matching current meal/date without changing source data."
+    mode: single
+    sequence:
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+      - condition: template
+        value_template: >
+          {{ states('sensor.meal_prep_source_status') == 'ready' and
+             states('input_text.meal_prep_session_key') == meal_prep_identity }}
+      - action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.meal_prep_active
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.meal_prep_done
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_snooze_until
+        data:
+          value: ""
+
+  meal_prep_show_dashboard:
+    alias: "Kitchen Prep: Show dashboard"
+    description: "Show the YAML-managed Kitchen Prep view on the kitchen display."
+    mode: single
+    sequence:
+      - action: cast.show_lovelace_view
+        target:
+          entity_id: media_player.kitchen_display
+        data:
+          dashboard_path: kitchen-prep
+          view_path: kitchen-prep
+
+  meal_prep_clear_session:
+    alias: "Kitchen Prep: Hide / clear preparation session"
+    description: >
+      Clear only local preparation state. It intentionally leaves the fresh
+      Mealie source snapshot intact for the dashboard's next planned session.
+    mode: single
+    sequence:
+      - action: input_boolean.turn_off
+        target:
+          entity_id:
+            - input_boolean.meal_prep_active
+            - input_boolean.meal_prep_done
+      - action: input_text.set_value
+        target:
+          entity_id:
+            - input_text.meal_prep_snooze_until
+            - input_text.meal_prep_session_key
+            - input_text.meal_prep_last_skipped_step
+        data:
+          value: ""
 
 template:
   - sensor:
@@ -283,17 +502,21 @@ template:
         state: >
           {% set source_status = states('sensor.meal_prep_source_status') %}
           {% set meal = states('sensor.meal_prep_meal') %}
+          {% set recipe_reference = states('sensor.meal_prep_recipe_reference') %}
+          {% set session_key = states('input_text.meal_prep_session_key') %}
+          {% set current_identity = now().date().isoformat() ~ '|' ~ recipe_reference %}
+          {% set session_matches_current_meal = recipe_reference not in ['none', 'unavailable', 'unknown'] and session_key == current_identity %}
           {% set snooze_until = as_timestamp(states('input_text.meal_prep_snooze_until'), default=none) %}
           {% set target_time = as_timestamp(states('input_datetime.meal_prep_target_time'), default=none) %}
           {% if source_status != 'ready' or meal == 'unavailable' %}
             unavailable
           {% elif meal == 'none' %}
             idle
-          {% elif is_state('input_boolean.meal_prep_done', 'on') %}
+          {% elif session_matches_current_meal and is_state('input_boolean.meal_prep_done', 'on') %}
             complete
-          {% elif snooze_until is not none and snooze_until > now().timestamp() %}
+          {% elif session_matches_current_meal and snooze_until is not none and snooze_until > now().timestamp() %}
             paused
-          {% elif is_state('input_boolean.meal_prep_active', 'on') %}
+          {% elif session_matches_current_meal and is_state('input_boolean.meal_prep_active', 'on') %}
             active
           {% elif target_time is not none and now().timestamp() >= target_time %}
             prep_due
@@ -305,7 +528,8 @@ template:
           source_reason: "{{ state_attr('sensor.meal_prep_source_status', 'reason') }}"
           target_time: "{{ states('sensor.meal_prep_target_time') }}"
           snooze_until: "{{ states('input_text.meal_prep_snooze_until') }}"
+          session_key: "{{ states('input_text.meal_prep_session_key') }}"
           semantics: >
             idle=no valid meal; planned=fresh valid meal before target; prep_due=fresh valid meal at/after target;
-            active=manual active flag; paused=future snooze; complete=manual done flag;
+            active=matching manual active flag; paused=matching future snooze; complete=matching manual done flag;
             unavailable=source is missing, invalid, error, or stale

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -130,7 +130,18 @@ script:
     mode: single
     sequence:
       - variables:
-          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      # Do not construct or mutate a session without a delimiter-safe recipe ID.
+      # The identity format is date|recipe-reference, so whitespace and `|` are
+      # malformed source values even when Home Assistant does not mark them
+      # unavailable.
+      - condition: template
+        value_template: >
+          {{ recipe_reference == recipe_reference | trim and
+             recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+             ' ' not in recipe_reference and '|' not in recipe_reference }}
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
       - condition: template
         value_template: >
           {{ states('sensor.meal_prep_source_status') == 'ready' and
@@ -166,7 +177,14 @@ script:
     mode: single
     sequence:
       - variables:
-          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      - condition: template
+        value_template: >
+          {{ recipe_reference == recipe_reference | trim and
+             recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+             ' ' not in recipe_reference and '|' not in recipe_reference }}
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
           current_step: "{{ states('sensor.meal_prep_current_step') }}"
           next_step: "{{ states('sensor.meal_prep_next_step') }}"
           queued_step: "{{ states('input_text.meal_prep_remaining_steps').split('\\u001f')[0] if states('input_text.meal_prep_remaining_steps') not in ['', 'unknown', 'unavailable'] else '' }}"
@@ -203,7 +221,14 @@ script:
     mode: single
     sequence:
       - variables:
-          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      - condition: template
+        value_template: >
+          {{ recipe_reference == recipe_reference | trim and
+             recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+             ' ' not in recipe_reference and '|' not in recipe_reference }}
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
           current_step: "{{ states('sensor.meal_prep_current_step') }}"
           next_step: "{{ states('sensor.meal_prep_next_step') }}"
           queued_step: "{{ states('input_text.meal_prep_remaining_steps').split('\\u001f')[0] if states('input_text.meal_prep_remaining_steps') not in ['', 'unknown', 'unavailable'] else '' }}"
@@ -251,7 +276,14 @@ script:
             unit_of_measurement: min
     sequence:
       - variables:
-          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      - condition: template
+        value_template: >
+          {{ recipe_reference == recipe_reference | trim and
+             recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+             ' ' not in recipe_reference and '|' not in recipe_reference }}
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
           bounded_snooze_minutes: "{{ [5, [snooze_minutes | default(30, true) | int(30), 60] | min] | max }}"
       - condition: template
         value_template: >
@@ -270,7 +302,14 @@ script:
     mode: single
     sequence:
       - variables:
-          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ states('sensor.meal_prep_recipe_reference') }}"
+          recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      - condition: template
+        value_template: >
+          {{ recipe_reference == recipe_reference | trim and
+             recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+             ' ' not in recipe_reference and '|' not in recipe_reference }}
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
       - condition: template
         value_template: >
           {{ states('sensor.meal_prep_source_status') == 'ready' and

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -137,9 +137,9 @@ script:
       # unavailable.
       - condition: template
         value_template: >
-          {{ recipe_reference == recipe_reference | trim and
+          {{ recipe_reference == recipe_reference | regex_replace('\\s', '') and
              recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
-             ' ' not in recipe_reference and '|' not in recipe_reference }}
+             '|' not in recipe_reference }}
       - variables:
           meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
       - condition: template
@@ -180,9 +180,9 @@ script:
           recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
       - condition: template
         value_template: >
-          {{ recipe_reference == recipe_reference | trim and
+          {{ recipe_reference == recipe_reference | regex_replace('\\s', '') and
              recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
-             ' ' not in recipe_reference and '|' not in recipe_reference }}
+             '|' not in recipe_reference }}
       - variables:
           meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
           current_step: "{{ states('sensor.meal_prep_current_step') }}"
@@ -224,9 +224,9 @@ script:
           recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
       - condition: template
         value_template: >
-          {{ recipe_reference == recipe_reference | trim and
+          {{ recipe_reference == recipe_reference | regex_replace('\\s', '') and
              recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
-             ' ' not in recipe_reference and '|' not in recipe_reference }}
+             '|' not in recipe_reference }}
       - variables:
           meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
           current_step: "{{ states('sensor.meal_prep_current_step') }}"
@@ -279,9 +279,9 @@ script:
           recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
       - condition: template
         value_template: >
-          {{ recipe_reference == recipe_reference | trim and
+          {{ recipe_reference == recipe_reference | regex_replace('\\s', '') and
              recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
-             ' ' not in recipe_reference and '|' not in recipe_reference }}
+             '|' not in recipe_reference }}
       - variables:
           meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
           bounded_snooze_minutes: "{{ [5, [snooze_minutes | default(30, true) | int(30), 60] | min] | max }}"
@@ -305,9 +305,9 @@ script:
           recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
       - condition: template
         value_template: >
-          {{ recipe_reference == recipe_reference | trim and
+          {{ recipe_reference == recipe_reference | regex_replace('\\s', '') and
              recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
-             ' ' not in recipe_reference and '|' not in recipe_reference }}
+             '|' not in recipe_reference }}
       - variables:
           meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
       - condition: template

--- a/packages/mealie_read_only.yaml
+++ b/packages/mealie_read_only.yaml
@@ -122,6 +122,7 @@ automation:
                     - input_text.meal_prep_recipe_url
                     - input_text.meal_prep_current_step
                     - input_text.meal_prep_next_step
+                    - input_text.meal_prep_remaining_steps
                     - input_text.meal_prep_recipe_summary
                     - input_text.meal_prep_ingredient_context
                 data:
@@ -165,6 +166,14 @@ automation:
               - variables:
                   mealie_recipe_status: "{{ mealie_recipe_response.status | default(0, true) | int(0) }}"
                   mealie_recipe: "{{ mealie_recipe_response.content | default({}, true) }}"
+                  # #210 owns manual advancement. Keep an active matching
+                  # session's current/next instruction values stable across a
+                  # scheduled source refresh; a new recipe/date still seeds a
+                  # fresh pair below.
+                  mealie_session_key: "{{ now().date().isoformat() ~ '|' ~ mealie_recipe_id }}"
+                  mealie_preserve_manual_progress: >
+                    {{ is_state('input_boolean.meal_prep_active', 'on') and
+                       states('input_text.meal_prep_session_key') == mealie_session_key }}
               - choose:
                   - conditions: "{{ mealie_recipe_status != 200 }}"
                     sequence:
@@ -224,22 +233,40 @@ automation:
                       entity_id: input_text.meal_prep_recipe_url
                     data:
                       value: ""
-                  - action: input_text.set_value
-                    target:
-                      entity_id: input_text.meal_prep_current_step
-                    data:
-                      value: >
-                        {% set steps = mealie_recipe.recipeInstructions %}
-                        {% set first = steps[0] if steps | count > 0 else {} %}
-                        {{ (first.text if first is mapping else first if first is string else '') | string | trim | truncate(255, true, '') }}
-                  - action: input_text.set_value
-                    target:
-                      entity_id: input_text.meal_prep_next_step
-                    data:
-                      value: >
-                        {% set steps = mealie_recipe.recipeInstructions %}
-                        {% set second = steps[1] if steps | count > 1 else {} %}
-                        {{ (second.text if second is mapping else second if second is string else '') | string | trim | truncate(255, true, '') }}
+                  - choose:
+                      - conditions: "{{ not mealie_preserve_manual_progress }}"
+                        sequence:
+                          - action: input_text.set_value
+                            target:
+                              entity_id: input_text.meal_prep_current_step
+                            data:
+                              value: >
+                                {% set steps = mealie_recipe.recipeInstructions %}
+                                {% set first = steps[0] if steps | count > 0 else {} %}
+                                {{ (first.text if first is mapping else first if first is string else '') | string | trim | truncate(255, true, '') }}
+                          - action: input_text.set_value
+                            target:
+                              entity_id: input_text.meal_prep_next_step
+                            data:
+                              value: >
+                                {% set steps = mealie_recipe.recipeInstructions %}
+                                {% set second = steps[1] if steps | count > 1 else {} %}
+                                {{ (second.text if second is mapping else second if second is string else '') | string | trim | truncate(255, true, '') }}
+                          - action: input_text.set_value
+                            target:
+                              entity_id: input_text.meal_prep_remaining_steps
+                            data:
+                              value: >
+                                {% set values = namespace(parts=[], length=0) %}
+                                {% for source_step in mealie_recipe.recipeInstructions[2:] %}
+                                  {% set step = (source_step.text if source_step is mapping else source_step if source_step is string else '') | string | trim | truncate(255, true, '') %}
+                                  {% set separator_length = 1 if values.parts | count > 0 else 0 %}
+                                  {% if step != '' and values.length + step | length + separator_length <= 255 %}
+                                    {% set values.parts = values.parts + [step] %}
+                                    {% set values.length = values.length + step | length + separator_length %}
+                                  {% endif %}
+                                {% endfor %}
+                                {{ values.parts | join('\u001f') }}
                   - action: input_text.set_value
                     target:
                       entity_id: input_text.meal_prep_recipe_summary

--- a/tests/test_kitchen_prep_dashboard.py
+++ b/tests/test_kitchen_prep_dashboard.py
@@ -56,7 +56,7 @@ def test_kitchen_prep_dashboard_is_yaml_managed_and_hidden():
     }
 
 
-def test_kitchen_prep_dashboard_presents_only_real_read_only_state_seams():
+def test_kitchen_prep_dashboard_presents_only_real_state_and_control_seams():
     dashboard = load_dashboard()
     cards = dashboard["views"][0]["cards"]
     refs = set(entity_refs(cards))
@@ -83,8 +83,16 @@ def test_kitchen_prep_dashboard_presents_only_real_read_only_state_seams():
 
     assert "media_player.kitchen_display" in dashboard_text
     assert "media_player.display_kitchen" not in dashboard_text
-    assert "service:" not in dashboard_text
-    assert "script." not in dashboard_text
+    for script_id in (
+        "script.meal_prep_start_preparation",
+        "script.meal_prep_complete_current_step",
+        "script.meal_prep_skip_current_step",
+        "script.meal_prep_snooze_preparation",
+        "script.meal_prep_finish_for_today",
+        "script.meal_prep_show_dashboard",
+        "script.meal_prep_clear_session",
+    ):
+        assert script_id in dashboard_text
 
 
 def test_kitchen_prep_dashboard_is_concise_and_fail_closed_when_source_is_unavailable():
@@ -119,10 +127,31 @@ def test_kitchen_prep_dashboard_is_concise_and_fail_closed_when_source_is_unavai
     assert "full recipe" not in DASHBOARD.read_text().lower()
 
 
-def test_kitchen_prep_dashboard_defers_controls_to_the_owner_card_without_dangling_services():
-    dashboard_text = DASHBOARD.read_text()
+def test_kitchen_prep_dashboard_buttons_call_only_real_manual_script_services():
+    cards = load_dashboard()["views"][0]["cards"]
+    control_card = next(card for card in cards if card.get("title") == "Preparation controls")
+    buttons = control_card["cards"]
 
-    assert "#210 owns the stable Start, Done, Skip, Snooze, and Finish script" in dashboard_text
-    assert "Do not add buttons until that card supplies real services." in dashboard_text
-    assert "type: button" not in dashboard_text
-    assert "tap_action:" not in dashboard_text
+    assert control_card["type"] == "grid"
+    assert [button["name"] for button in buttons] == [
+        "Start",
+        "Done",
+        "Skip",
+        "Snooze 30 min",
+        "Finish today",
+        "Show display",
+        "Clear session",
+    ]
+    assert [button["tap_action"] for button in buttons] == [
+        {"action": "perform-action", "perform_action": "script.meal_prep_start_preparation"},
+        {"action": "perform-action", "perform_action": "script.meal_prep_complete_current_step"},
+        {"action": "perform-action", "perform_action": "script.meal_prep_skip_current_step"},
+        {
+            "action": "perform-action",
+            "perform_action": "script.meal_prep_snooze_preparation",
+            "data": {"snooze_minutes": 30},
+        },
+        {"action": "perform-action", "perform_action": "script.meal_prep_finish_for_today"},
+        {"action": "perform-action", "perform_action": "script.meal_prep_show_dashboard"},
+        {"action": "perform-action", "perform_action": "script.meal_prep_clear_session"},
+    ]

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import yaml
+from jinja2 import Environment
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -47,6 +48,20 @@ def condition_templates(script):
     ]
 
 
+def render_recipe_guard(script, recipe_reference):
+    variables = script["sequence"][0]["variables"]
+    guard = condition_templates(script)[0]
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals["states"] = lambda entity_id: {
+        "sensor.meal_prep_recipe_reference": recipe_reference
+    }.get(entity_id, "unknown")
+
+    normalized_reference = environment.from_string(variables["recipe_reference"]).render()
+    return environment.from_string(guard).render(
+        recipe_reference=normalized_reference
+    ).strip()
+
+
 def test_start_preparation_has_a_stable_manual_script_seam():
     script = load_package()["script"]["meal_prep_start_preparation"]
 
@@ -86,9 +101,39 @@ def test_start_resets_only_new_session_identity_and_reactivation_keeps_progress(
     assert script_services(script).count("input_boolean.turn_on") == 1
 
 
+def test_state_changing_controls_reject_invalid_recipe_references_before_identity_or_mutation():
+    scripts = load_package()["script"]
+    state_changing_scripts = (
+        "meal_prep_start_preparation",
+        "meal_prep_complete_current_step",
+        "meal_prep_skip_current_step",
+        "meal_prep_snooze_preparation",
+        "meal_prep_finish_for_today",
+    )
+
+    for script_name in state_changing_scripts:
+        script = scripts[script_name]
+
+        assert list(script["sequence"][0]["variables"]) == ["recipe_reference"]
+        assert "meal_prep_identity" in script["sequence"][2]["variables"]
+        assert render_recipe_guard(script, "recipe-123") == "True"
+        for invalid_reference in (
+            "",
+            "none",
+            "unknown",
+            "unavailable",
+            "recipe reference",
+            "recipe|123",
+        ):
+            assert render_recipe_guard(script, invalid_reference) == "False", (
+                script_name,
+                invalid_reference,
+            )
+
+
 def test_done_advances_only_a_valid_active_matching_session_once():
     script = load_package()["script"]["meal_prep_complete_current_step"]
-    condition = condition_templates(script)[0]
+    condition = condition_templates(script)[1]
     actions = script_services(script)
 
     assert "sensor.meal_prep_source_status" in condition

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import yaml
@@ -52,6 +53,9 @@ def render_recipe_guard(script, recipe_reference):
     variables = script["sequence"][0]["variables"]
     guard = condition_templates(script)[0]
     environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.filters["regex_replace"] = lambda value, find, replace: re.sub(
+        find, replace, value
+    )
     environment.globals["states"] = lambda entity_id: {
         "sensor.meal_prep_recipe_reference": recipe_reference
     }.get(entity_id, "unknown")
@@ -122,7 +126,11 @@ def test_state_changing_controls_reject_invalid_recipe_references_before_identit
             "none",
             "unknown",
             "unavailable",
-            "recipe reference",
+            "recipe reference",  # ASCII space
+            "recipe\t123",  # tab
+            "recipe\n123",  # newline
+            "recipe\r123",  # carriage return
+            "recipe\u00a0123",  # non-breaking space
             "recipe|123",
         ):
             assert render_recipe_guard(script, invalid_reference) == "False", (

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "meal_prep.yaml"
+MEALIE = ROOT / "packages" / "mealie_read_only.yaml"
+
+
+def load_yaml(path):
+    class HomeAssistantLoader(yaml.SafeLoader):
+        pass
+
+    HomeAssistantLoader.add_constructor(
+        "!secret", lambda loader, node: f"!secret {loader.construct_scalar(node)}"
+    )
+    return yaml.load(path.read_text(), Loader=HomeAssistantLoader)
+
+
+def load_package():
+    return load_yaml(PACKAGE)
+
+
+def script_services(script):
+    services = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            if "action" in node:
+                services.append(node["action"])
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(script["sequence"])
+    return services
+
+
+def condition_templates(script):
+    return [
+        item["value_template"]
+        for item in script["sequence"]
+        if item.get("condition") == "template"
+    ]
+
+
+def test_start_preparation_has_a_stable_manual_script_seam():
+    script = load_package()["script"]["meal_prep_start_preparation"]
+
+    assert script["alias"] == "Kitchen Prep: Start preparation"
+    assert script["mode"] == "single"
+    assert "sensor.meal_prep_source_status" in str(script["sequence"])
+    assert "sensor.meal_prep_meal" in str(script["sequence"])
+    assert "input_boolean.turn_on" in script_services(script)
+
+
+def test_all_required_manual_control_scripts_are_stable_and_non_automatic():
+    scripts = load_package()["script"]
+
+    assert set(scripts) == {
+        "meal_prep_start_preparation",
+        "meal_prep_complete_current_step",
+        "meal_prep_skip_current_step",
+        "meal_prep_snooze_preparation",
+        "meal_prep_finish_for_today",
+        "meal_prep_show_dashboard",
+        "meal_prep_clear_session",
+    }
+    assert all(script["mode"] == "single" for script in scripts.values())
+    assert all("trigger" not in script for script in scripts.values())
+    assert "automation" not in load_package()
+
+
+def test_start_resets_only_new_session_identity_and_reactivation_keeps_progress():
+    script = load_package()["script"]["meal_prep_start_preparation"]
+    text = str(script["sequence"])
+
+    assert "input_text.meal_prep_session_key" in text
+    assert "input_boolean.meal_prep_done" in text
+    assert "input_text.meal_prep_snooze_until" in text
+    assert "input_text.meal_prep_last_skipped_step" in text
+    assert "!= meal_prep_identity" in text
+    assert script_services(script).count("input_boolean.turn_on") == 1
+
+
+def test_done_advances_only_a_valid_active_matching_session_once():
+    script = load_package()["script"]["meal_prep_complete_current_step"]
+    condition = condition_templates(script)[0]
+    actions = script_services(script)
+
+    assert "sensor.meal_prep_source_status" in condition
+    assert "input_boolean.meal_prep_active" in condition
+    assert "input_text.meal_prep_session_key" in condition
+    assert "next_step not in ['none', 'unavailable', 'unknown']" in condition
+    assert actions == [
+        "input_text.set_value",
+        "input_text.set_value",
+        "input_text.set_value",
+    ]
+    assert "value: \"{{ next_step }}\"" in PACKAGE.read_text()
+
+
+def test_skip_records_a_bounded_deliberate_skip_without_claiming_completion():
+    script = load_package()["script"]["meal_prep_skip_current_step"]
+    actions = script_services(script)
+
+    assert actions == [
+        "input_text.set_value",
+        "input_text.set_value",
+        "input_text.set_value",
+        "input_text.set_value",
+    ]
+    assert "input_text.meal_prep_last_skipped_step" in str(script["sequence"])
+    assert "input_boolean.turn_on" not in actions
+    assert "input_boolean.meal_prep_done" not in str(script["sequence"])
+
+
+def test_snooze_is_bounded_and_persistent_until_its_future_timestamp_expires():
+    script = load_package()["script"]["meal_prep_snooze_preparation"]
+
+    assert script["fields"]["snooze_minutes"]["selector"]["number"] == {
+        "min": 5,
+        "max": 60,
+        "step": 5,
+        "unit_of_measurement": "min",
+    }
+    assert "bounded_snooze_minutes" in str(script["sequence"])
+    assert "input_text.meal_prep_snooze_until" in str(script["sequence"])
+    assert "timedelta(minutes=bounded_snooze_minutes | int)" in str(script["sequence"])
+
+
+def test_finish_and_clear_are_local_persistent_state_transitions():
+    scripts = load_package()["script"]
+    finish_services = script_services(scripts["meal_prep_finish_for_today"])
+    clear_services = script_services(scripts["meal_prep_clear_session"])
+
+    assert finish_services == [
+        "input_boolean.turn_off",
+        "input_boolean.turn_on",
+        "input_text.set_value",
+    ]
+    assert clear_services == ["input_boolean.turn_off", "input_text.set_value"]
+    clear_text = str(scripts["meal_prep_clear_session"]["sequence"])
+    assert "input_text.meal_prep_session_key" in clear_text
+    assert "input_text.meal_prep_last_skipped_step" in clear_text
+    assert "input_text.meal_prep_meal_title" not in clear_text
+
+
+def test_show_dashboard_targets_the_registered_kitchen_display_view():
+    script = load_package()["script"]["meal_prep_show_dashboard"]
+
+    assert script_services(script) == ["cast.show_lovelace_view"]
+    action = script["sequence"][0]
+    assert action["target"]["entity_id"] == "media_player.kitchen_display"
+    assert action["data"] == {
+        "dashboard_path": "kitchen-prep",
+        "view_path": "kitchen-prep",
+    }
+
+
+def test_refresh_preserves_active_matching_manual_progress_but_can_seed_new_meals():
+    mealie = load_yaml(MEALIE)
+    text = MEALIE.read_text()
+
+    assert "mealie_preserve_manual_progress" in text
+    assert "input_text.meal_prep_session_key" in text
+    assert "not mealie_preserve_manual_progress" in text
+    assert "mealie_session_key" in text
+    assert "input_text.meal_prep_current_step" in text
+    assert "input_text.meal_prep_next_step" in text
+    assert "input_text.meal_prep_remaining_steps" in text
+    assert "values.parts | join('\\u001f')" in text
+    assert "input_boolean.meal_prep_done" not in text
+    assert "input_boolean.turn_on" not in str(mealie)
+
+
+def test_advance_uses_a_bounded_persistent_remaining_step_queue():
+    helpers = load_package()["input_text"]
+    done = load_package()["script"]["meal_prep_complete_current_step"]
+
+    assert helpers["meal_prep_remaining_steps"]["max"] == 255
+    assert "input_text.meal_prep_remaining_steps" in str(done["sequence"])
+    assert ".split('\\\\u001f')" in str(done["sequence"])
+
+
+def test_new_persistent_helpers_have_no_initial_values():
+    helpers = load_package()["input_text"]
+
+    for helper in (
+        "meal_prep_session_key",
+        "meal_prep_last_skipped_step",
+        "meal_prep_remaining_steps",
+    ):
+        assert helpers[helper]["max"] == 255
+        assert "initial" not in helpers[helper]

--- a/tests/test_meal_prep_state_model.py
+++ b/tests/test_meal_prep_state_model.py
@@ -84,6 +84,8 @@ def ready_meal():
         "input_text.meal_prep_next_step": "Preheat oven",
         "input_datetime.meal_prep_target_time": "2026-07-23 19:00:00+00:00",
         "input_text.meal_prep_snooze_until": "",
+        "input_text.meal_prep_session_key": "2026-07-23|recipe-123",
+        "input_text.meal_prep_last_skipped_step": "",
         "input_boolean.meal_prep_active": "off",
         "input_boolean.meal_prep_done": "off",
     }
@@ -109,6 +111,9 @@ def test_helpers_are_stable_named_and_restored_without_initial_values():
             "meal_prep_current_step": ("Meal Prep Current Step Input", "mdi:format-list-numbered"),
             "meal_prep_next_step": ("Meal Prep Next Step Input", "mdi:skip-next-outline"),
             "meal_prep_snooze_until": ("Meal Prep Snooze Until", "mdi:pause-circle-outline"),
+            "meal_prep_session_key": ("Meal Prep Session Key", "mdi:key-variant"),
+            "meal_prep_last_skipped_step": ("Meal Prep Last Skipped Step", "mdi:skip-next-circle-outline"),
+            "meal_prep_remaining_steps": ("Meal Prep Remaining Steps", "mdi:format-list-numbered"),
         },
     }
 
@@ -258,15 +263,38 @@ def test_source_status_exposes_explicit_visible_reasons(ready_meal):
     assert future_reason == "source update is in the future"
 
 
-def test_package_is_source_independent_and_defers_actions_to_later_cards():
+def test_restored_session_flags_are_scoped_to_the_current_date_and_recipe(ready_meal):
+    stale_identity = ready_meal | {
+        "input_boolean.meal_prep_active": "on",
+        "input_boolean.meal_prep_done": "on",
+        "input_text.meal_prep_snooze_until": "2026-07-23 18:30:00+00:00",
+        "input_text.meal_prep_session_key": "2026-07-22|recipe-123",
+    }
+
+    evaluated = evaluate(stale_identity)
+
+    assert evaluated["sensor.meal_prep_session_state"] == "planned"
+
+
+def test_expired_snooze_returns_to_the_matching_active_session(ready_meal):
+    evaluated = evaluate(
+        ready_meal
+        | {
+            "input_boolean.meal_prep_active": "on",
+            "input_text.meal_prep_snooze_until": "2026-07-23 17:59:00+00:00",
+        }
+    )
+
+    assert evaluated["sensor.meal_prep_session_state"] == "active"
+
+
+def test_package_is_source_independent_and_limits_actions_to_manual_controls():
     package = load_package()
     package_text = PACKAGE.read_text()
 
-    assert set(package) == {"input_boolean", "input_datetime", "input_text", "template"}
+    assert set(package) == {"input_boolean", "input_datetime", "input_text", "script", "template"}
     assert "rest:" not in package_text
     assert "automation:" not in package_text
-    assert "script:" not in package_text
-    assert "service:" not in package_text
     assert "#209" in package_text
     assert "#208/#210" in package_text
     assert "180 minutes" in PACKAGE_README.read_text()


### PR DESCRIPTION
## Summary
- add deterministic, fail-closed Kitchen Prep scripts for start, done, skip, snooze, finish, display, and clear actions
- scope restored active/done/snooze state to the current date and recipe; preserve manual progress across read-only Mealie refreshes
- wire the hidden Kitchen Prep dashboard to real script services and document bounded helper/script semantics

## Validation
- `pytest -q` — 154 passed
- HA-tag-aware YAML parsing for `packages/meal_prep.yaml`, `packages/mealie_read_only.yaml`, and `dashboards/kitchen_prep.yaml`
- `git diff --check`
- `python -m compileall -q tests`

Closes #210
