### PR TITLE
feat(kitchen): automate prep-window display orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `garage_door_monitoring.yaml` - garage-door duration monitoring, reminders, and controls.
 - `known_batteries.yaml` - normalized template sensors for known battery-powered devices.
 - `light_groups.yaml` - logical light groups.
-- `meal_prep.yaml` and `mealie_read_only.yaml` - Kitchen Prep helper/state model, deterministic manual controls, and bounded read-only Mealie adapter for fresh meal, recipe, instruction, timing, and ingredient context.
+- `meal_prep.yaml`, `mealie_read_only.yaml`, and `meal_prep_orchestration.yaml` - Kitchen Prep helper/state model, deterministic manual controls, bounded read-only Mealie adapter, and once-per-meal automatic prep-window/Cast orchestration.
 - `notifications.yaml` - shared notification automations that do not belong to a larger package.
 - `presence.yaml` - presence, alarm-panel, and presence-related lighting behavior.
 - `remotes.yaml` - Z-Wave remote helper scripts and blueprint-backed automations.

--- a/packages/README.md
+++ b/packages/README.md
@@ -33,6 +33,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
 | `meal_prep.yaml` | Kitchen meal-preparation state model and deterministic manual Start/Done/Skip/Snooze/Finish/display/clear script seams. It owns persistent helper seams and read-only normalized meal/status/step/session/recipe-context sensors. |
 | `mealie_read_only.yaml` | Read-only Mealie GET adapter. It refreshes a bounded today/upcoming plan and linked recipe into `meal_prep.yaml` helpers every 15 minutes. |
+| `meal_prep_orchestration.yaml` | Kitchen Prep automatic start/cleanup and one-time Cast behavior, bounded by fresh source data, today’s target/prep window, household presence, and guest mode. |
 | `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |
 | `presence.yaml` | Presence-related behavior, including alarm-panel helpers and lighting automations tied to occupancy/time conditions. |
 | `protected_contacts.yaml` | Canonical, read-only inventory and open-state summary for eight window contacts plus Front Door, Back Door, and Garage Interior Door. Future packages should consume this seam rather than duplicate the protected-contact roster. |
@@ -77,6 +78,8 @@ inventing meal or instruction content.
 | `input_text.meal_prep_session_key` | Meal Prep Session Key | Date + recipe-reference identity that scopes restored active/done/snooze state. | Restored; no `initial` is set. |
 | `input_text.meal_prep_last_skipped_step` | Meal Prep Last Skipped Step | Bounded record of the most recent deliberate skip; it never marks the meal complete. | Restored; no `initial` is set. |
 | `input_text.meal_prep_remaining_steps` | Meal Prep Remaining Steps | Bounded escaped-delimiter source queue after the current/next steps, used only for deterministic manual advancement. | Restored; no `initial` is set. |
+| `input_text.meal_prep_recipe_prep_time` | Meal Prep Recipe Prep Time Input | Raw Mealie `prepTime` duration for automatic-window calculation. | Restored; no `initial` is set. |
+| `input_text.meal_prep_automatic_handled_key` | Meal Prep Automatic Handled Key | Date + recipe identity manually or automatically claimed to prevent repeat automatic starts/Casts. | Restored; no `initial` is set. |
 | `input_text.meal_prep_source_status` | Meal Prep Source Status Input | Future normalizer's raw status seam. | Restored; no `initial` is set. |
 | `input_text.meal_prep_meal_title`, `input_text.meal_prep_meal_type` | Meal Prep Meal Title/Type Input | Raw meal-identity seams. | Restored; no `initial` is set. |
 | `input_text.meal_prep_recipe_reference`, `input_text.meal_prep_recipe_url` | Meal Prep Recipe Reference/URL Input | Raw recipe seams. | Restored; no `initial` is set. |
@@ -117,6 +120,24 @@ stale, malformed, or non-matching source/session state. The normalizer preserves
 current/next values during an active matching session, so its 15-minute refresh
 cannot replay an already advanced step. Later source steps are held only in a
 bounded, delimiter-safe queue; controls never invent steps beyond that source data.
+
+### Kitchen Prep automatic orchestration
+
+`meal_prep_orchestration.yaml` starts only for a fresh, valid meal whose target
+timestamp is today, in the half-open prep window `[target - prepTime, target)`,
+with `zone.home` above zero and guest mode off. Mealie `prepTime` must be a
+positive ISO-8601 `PT#H#M` duration; missing, zero, or unsupported duration and
+missing/invalid target time deliberately result in no automatic start.
+
+The restored `input_text.meal_prep_automatic_handled_key` is set for both manual
+and automatic starts. It prevents refreshes, reloads, and restarts from repeating
+the same meal's Cast. The only automatic device action is
+`cast.show_lovelace_view` to `media_player.kitchen_display` with
+`dashboard_path` and `view_path` both `kitchen-prep`. It adds no lights,
+announcements, occupancy inference, or Mealie writes. Cleanup clears only local
+Kitchen Prep state for stale/invalid source, meal rollover, or everyone away
+outside guest mode; `presence_everyone_left` remains the authoritative
+display-off automation.
 
 ### Mealie read-only wiring
 

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -92,6 +92,13 @@ input_text:
     icon: mdi:timer-outline
     max: 160
 
+  # The read-only adapter stores Mealie's ISO-8601 `prepTime` here. Automatic
+  # orchestration is the only consumer and fails closed for unsupported values.
+  meal_prep_recipe_prep_time:
+    name: "Meal Prep Recipe Prep Time Input"
+    icon: mdi:timer-sand
+    max: 40
+
   meal_prep_ingredient_context:
     name: "Meal Prep Ingredient Context Input"
     icon: mdi:format-list-bulleted
@@ -107,6 +114,13 @@ input_text:
   meal_prep_session_key:
     name: "Meal Prep Session Key"
     icon: mdi:key-variant
+    max: 255
+
+  # Date+recipe identity already claimed by manual or automatic preparation.
+  # Restoring it prevents a reload/refresh from casting the same meal again.
+  meal_prep_automatic_handled_key:
+    name: "Meal Prep Automatic Handled Key"
+    icon: mdi:shield-check-outline
     max: 255
 
   meal_prep_last_skipped_step:
@@ -168,6 +182,11 @@ script:
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.meal_prep_active
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_automatic_handled_key
+        data:
+          value: "{{ meal_prep_identity }}"
 
   meal_prep_complete_current_step:
     alias: "Kitchen Prep: Done / advance current step"
@@ -325,6 +344,11 @@ script:
           entity_id: input_text.meal_prep_snooze_until
         data:
           value: ""
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_automatic_handled_key
+        data:
+          value: "{{ meal_prep_identity }}"
 
   meal_prep_show_dashboard:
     alias: "Kitchen Prep: Show dashboard"

--- a/packages/meal_prep_orchestration.yaml
+++ b/packages/meal_prep_orchestration.yaml
@@ -1,0 +1,126 @@
+# packages/meal_prep_orchestration.yaml
+#
+# Bounded automatic Kitchen Prep orchestration. This package never reloads HA,
+# changes lights, announces steps, writes Mealie, or turns off the kitchen
+# display. `presence_everyone_left` remains the authoritative display-off flow.
+#
+# Automatic start needs all of: a fresh valid source, a valid recipe identity,
+# a target timestamp for today, a positive PT#H#M Mealie prep duration, someone
+# home, and guest mode off. Missing/unsupported timing intentionally does
+# nothing rather than guessing a preparation window.
+
+automation:
+  - alias: "Kitchen Prep: Automatically start useful preparation window"
+    id: "meal_prep_automatic_start"
+    description: >
+      Start and cast Kitchen Prep at most once per today+recipe identity during
+      its half-open [target - prepTime, target) window. Restored handled state
+      prevents repeat casts after refresh, reload, or Home Assistant restart.
+    mode: single
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: time_pattern
+        minutes: "/1"
+      - platform: state
+        entity_id:
+          - sensor.meal_prep_source_status
+          - sensor.meal_prep_meal
+          - sensor.meal_prep_recipe_reference
+          - sensor.meal_prep_target_time
+          - input_text.meal_prep_recipe_prep_time
+          - input_boolean.mode_guest
+          - zone.home
+    variables:
+      recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
+      target_time: "{{ states('sensor.meal_prep_target_time') }}"
+      target_timestamp: "{{ as_timestamp(target_time, default=none) }}"
+      prep_time: "{{ states('input_text.meal_prep_recipe_prep_time') | upper | trim }}"
+      prep_duration_valid: >
+        {{ prep_time | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and prep_time != 'PT' }}
+      prep_hours: >
+        {{ (prep_time | regex_findall('^PT([0-9]+)H') | first | default('0', true)) | int(0) }}
+      prep_minutes_part: >
+        {{ (prep_time | regex_findall('([0-9]+)M$') | first | default('0', true)) | int(0) }}
+      prep_minutes: "{{ prep_hours | int(0) * 60 + prep_minutes_part | int(0) }}"
+      snooze_until: "{{ as_timestamp(states('input_text.meal_prep_snooze_until'), default=none) }}"
+    condition:
+      - condition: template
+        value_template: >
+          {{ states('sensor.meal_prep_source_status') == 'ready' and
+             states('sensor.meal_prep_meal') not in ['none', 'unavailable', 'unknown'] and
+             states('sensor.meal_prep_current_step') not in ['none', 'unavailable', 'unknown'] and
+             recipe_reference == recipe_reference | regex_replace('\\s', '') and
+             recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+             '|' not in recipe_reference and
+             target_timestamp is not none and
+             target_time.startswith(now().date().isoformat()) and
+             prep_duration_valid and prep_minutes | int(0) > 0 and
+             states('zone.home') | float(0) > 0 and
+             is_state('input_boolean.mode_guest', 'off') and
+             is_state('input_boolean.meal_prep_active', 'off') and
+             is_state('input_boolean.meal_prep_done', 'off') and
+             (snooze_until is none or snooze_until <= now().timestamp()) and
+             states('input_text.meal_prep_automatic_handled_key') != meal_prep_identity and
+             now().timestamp() >= target_timestamp | float(0) - prep_minutes | int(0) * 60 and
+             now().timestamp() < target_timestamp | float(0) }}
+    action:
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_session_key
+        data:
+          value: "{{ meal_prep_identity }}"
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_automatic_handled_key
+        data:
+          value: "{{ meal_prep_identity }}"
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.meal_prep_active
+      - action: cast.show_lovelace_view
+        target:
+          entity_id: media_player.kitchen_display
+        data:
+          dashboard_path: kitchen-prep
+          view_path: kitchen-prep
+
+  - alias: "Kitchen Prep: Clear invalid or rolled-over preparation session"
+    id: "meal_prep_automatic_cleanup"
+    description: >
+      Clear local session flags when source data becomes unsafe, the meal/date
+      identity changes, or everyone leaves outside guest mode. It deliberately
+      does not issue media-player actions; presence owns display-off behavior.
+    mode: single
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: time
+        at: "00:00:00"
+      - platform: state
+        entity_id:
+          - sensor.meal_prep_source_status
+          - sensor.meal_prep_meal
+          - sensor.meal_prep_recipe_reference
+          - zone.home
+          - input_boolean.mode_guest
+    variables:
+      recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
+      session_key: "{{ states('input_text.meal_prep_session_key') }}"
+      recipe_reference_valid: >
+        {{ recipe_reference == recipe_reference | regex_replace('\\s', '') and
+           recipe_reference | lower not in ['', 'none', 'unavailable', 'unknown'] and
+           '|' not in recipe_reference }}
+    condition:
+      - condition: template
+        value_template: >
+          {{ session_key not in ['', 'unknown', 'unavailable'] and
+             (states('sensor.meal_prep_source_status') != 'ready' or
+              states('sensor.meal_prep_meal') in ['none', 'unavailable', 'unknown'] or
+              not recipe_reference_valid or
+              session_key != meal_prep_identity or
+              (is_state('input_boolean.mode_guest', 'off') and states('zone.home') | float(0) <= 0)) }}
+    action:
+      - action: script.meal_prep_clear_session

--- a/packages/mealie_read_only.yaml
+++ b/packages/mealie_read_only.yaml
@@ -124,6 +124,7 @@ automation:
                     - input_text.meal_prep_next_step
                     - input_text.meal_prep_remaining_steps
                     - input_text.meal_prep_recipe_summary
+                    - input_text.meal_prep_recipe_prep_time
                     - input_text.meal_prep_ingredient_context
                 data:
                   value: ""
@@ -279,6 +280,11 @@ automation:
                           {% endif %}
                         {% endfor %}
                         {{ values.parts | join(' • ') | truncate(160, true, '') }}
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_recipe_prep_time
+                    data:
+                      value: "{{ mealie_recipe.prepTime | default('', true) | string | trim | truncate(40, true, '') }}"
                   - action: input_text.set_value
                     target:
                       entity_id: input_text.meal_prep_ingredient_context

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -194,6 +194,7 @@ def test_finish_and_clear_are_local_persistent_state_transitions():
         "input_boolean.turn_off",
         "input_boolean.turn_on",
         "input_text.set_value",
+        "input_text.set_value",
     ]
     assert clear_services == ["input_boolean.turn_off", "input_text.set_value"]
     clear_text = str(scripts["meal_prep_clear_session"]["sequence"])

--- a/tests/test_meal_prep_orchestration.py
+++ b/tests/test_meal_prep_orchestration.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import re
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "meal_prep_orchestration.yaml"
+STATE_MODEL = ROOT / "packages" / "meal_prep.yaml"
+MEALIE = ROOT / "packages" / "mealie_read_only.yaml"
+
+NOW = datetime(2026, 7, 23, 18, 30, tzinfo=timezone.utc)
+IDENTITY = "2026-07-23|recipe-123"
+
+
+def load_yaml(path):
+    class SecretLoader(yaml.SafeLoader):
+        pass
+
+    SecretLoader.add_constructor(
+        "!secret", lambda loader, node: f"!secret {loader.construct_scalar(node)}"
+    )
+    return yaml.load(path.read_text(), Loader=SecretLoader)
+
+
+def automation_by_id(package, automation_id):
+    return next(item for item in package["automation"] if item["id"] == automation_id)
+
+
+def actions(node):
+    found = []
+    if isinstance(node, dict):
+        if "action" in node:
+            found.append(node["action"])
+        for value in node.values():
+            found.extend(actions(value))
+    elif isinstance(node, list):
+        for value in node:
+            found.extend(actions(value))
+    return found
+
+
+def prep_minutes(value):
+    match = re.fullmatch(r"PT(?:(\d+)H)?(?:(\d+)M)?", value or "")
+    if not match or value == "PT":
+        return None
+    minutes = int(match.group(1) or 0) * 60 + int(match.group(2) or 0)
+    return minutes or None
+
+
+def automatic_start_is_eligible(
+    *,
+    source="ready",
+    meal="Dinner",
+    recipe="recipe-123",
+    target=NOW + timedelta(minutes=20),
+    prep_time="PT30M",
+    home=1,
+    guest=False,
+    active=False,
+    done=False,
+    snoozed=False,
+    handled_key="",
+):
+    minutes = prep_minutes(prep_time)
+    identity = f"{NOW.date().isoformat()}|{recipe}"
+    return (
+        source == "ready"
+        and meal not in {"none", "unknown", "unavailable"}
+        and bool(re.fullmatch(r"[^\s|]+", recipe or ""))
+        and target is not None
+        and target.date() == NOW.date()
+        and minutes is not None
+        and target - timedelta(minutes=minutes) <= NOW < target
+        and home > 0
+        and not guest
+        and not active
+        and not done
+        and not snoozed
+        and handled_key != identity
+    )
+
+
+def test_automatic_start_has_bounded_triggers_and_exact_cast_payload():
+    automatic = automation_by_id(load_yaml(PACKAGE), "meal_prep_automatic_start")
+    text = PACKAGE.read_text()
+
+    assert automatic["mode"] == "single"
+    assert {trigger["platform"] for trigger in automatic["trigger"]} == {
+        "homeassistant",
+        "time_pattern",
+        "state",
+    }
+    assert any(trigger.get("minutes") == "/1" for trigger in automatic["trigger"])
+    assert actions(automatic["action"]) == [
+        "input_text.set_value",
+        "input_text.set_value",
+        "input_boolean.turn_on",
+        "cast.show_lovelace_view",
+    ]
+    cast = automatic["action"][-1]
+    assert cast["target"]["entity_id"] == "media_player.kitchen_display"
+    assert cast["data"] == {
+        "dashboard_path": "kitchen-prep",
+        "view_path": "kitchen-prep",
+    }
+    assert automatic["action"][-1]["action"] == "cast.show_lovelace_view"
+    assert "homeassistant.turn_off" not in text
+
+
+def test_deterministic_window_and_missing_time_fallbacks_fail_closed():
+    assert prep_minutes("PT45M") == 45
+    assert prep_minutes("PT1H15M") == 75
+    assert prep_minutes("PT") is None
+    assert prep_minutes("") is None
+    assert prep_minutes("45 minutes") is None
+
+    assert automatic_start_is_eligible()
+    assert not automatic_start_is_eligible(target=None)
+    assert not automatic_start_is_eligible(target=NOW + timedelta(days=1))
+    assert not automatic_start_is_eligible(prep_time="")
+    assert not automatic_start_is_eligible(prep_time="PT0M")
+    assert not automatic_start_is_eligible(target=NOW + timedelta(minutes=90), prep_time="PT30M")
+    assert not automatic_start_is_eligible(target=NOW)
+
+
+def test_automatic_start_requires_fresh_valid_meal_home_and_non_guest_context():
+    for changes in (
+        {"source": "stale"},
+        {"source": "unavailable"},
+        {"meal": "none"},
+        {"recipe": "recipe 123"},
+        {"recipe": "recipe|123"},
+        {"home": 0},
+        {"guest": True},
+    ):
+        assert not automatic_start_is_eligible(**changes), changes
+
+
+def test_handled_identity_and_manual_overrides_prevent_repeat_start_or_cast():
+    assert not automatic_start_is_eligible(handled_key=IDENTITY)
+    assert not automatic_start_is_eligible(active=True)
+    assert not automatic_start_is_eligible(done=True)
+    assert not automatic_start_is_eligible(snoozed=True)
+
+    state_model = load_yaml(STATE_MODEL)
+    start = state_model["script"]["meal_prep_start_preparation"]
+    finish = state_model["script"]["meal_prep_finish_for_today"]
+    assert "input_text.meal_prep_automatic_handled_key" in str(start["sequence"])
+    assert "input_text.meal_prep_automatic_handled_key" in str(finish["sequence"])
+    assert "initial" not in state_model["input_text"]["meal_prep_automatic_handled_key"]
+
+
+def test_cleanup_covers_restart_rollover_away_and_stale_without_display_or_extras():
+    cleanup = automation_by_id(load_yaml(PACKAGE), "meal_prep_automatic_cleanup")
+    text = PACKAGE.read_text()
+
+    assert cleanup["mode"] == "single"
+    assert {trigger["platform"] for trigger in cleanup["trigger"]} == {
+        "homeassistant",
+        "time",
+        "state",
+    }
+    assert cleanup["action"] == [{"action": "script.meal_prep_clear_session"}]
+    condition = cleanup["condition"][0]["value_template"]
+    assert "sensor.meal_prep_source_status" in condition
+    assert "session_key != meal_prep_identity" in condition
+    assert "zone.home" in condition
+    assert "input_boolean.mode_guest" in condition
+    assert "media_player" not in str(cleanup)
+    assert "light." not in text
+    assert "notify." not in text
+    assert "rest_command" not in text
+    assert "kitchen occupancy" not in text.lower()
+
+
+def test_mealie_prep_time_is_bounded_source_data_and_no_write_endpoint_was_added():
+    mealie = load_yaml(MEALIE)
+    helpers = load_yaml(STATE_MODEL)["input_text"]
+    text = MEALIE.read_text()
+
+    assert helpers["meal_prep_recipe_prep_time"]["max"] == 40
+    assert "input_text.meal_prep_recipe_prep_time" in text
+    assert "mealie_recipe.prepTime" in text
+    assert all(command["method"] == "GET" for command in mealie["rest_command"].values())
+    for forbidden in ("POST", "PUT", "PATCH", "DELETE"):
+        assert forbidden not in text


### PR DESCRIPTION
## Summary
- add deterministic Kitchen Prep automatic start only during a fresh, today-scoped prep window and cast the registered Kitchen Prep view once per date+recipe identity
- persist manual/automatic handled identity, honor home presence and guest mode, and clear local sessions for stale source, rollover, or away state without duplicating presence display-off behavior
- preserve Mealie read-only behavior while retaining `prepTime` for validated `PT#H#M` window calculation; add focused regression coverage and operator documentation

## Validation
- `python3 -m pytest -q` (161 passed)
- parsed all active package YAML with a `!secret`-aware loader
- parsed 113 Jinja templates for syntax
- `git diff --check`
- Local Home Assistant Core config check not run: `homeassistant` Python package/environment is not installed; no live reload/restart/service calls were performed.

## Behavior and safety
- exact Cast target: `media_player.kitchen_display` via `cast.show_lovelace_view` with `dashboard_path: kitchen-prep` and `view_path: kitchen-prep`
- no automatic lights, announcements, kitchen-occupancy sensor, Mealie writes, or display-off duplication

Closes #211