### PR TITLE
fix(kitchen): move diagnostics below prep controls

### DIFF
--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -105,25 +105,6 @@ views:
           {% endif %}
           {% endif %}
 
-      - type: entities
-        title: "Source details"
-        show_header_toggle: false
-        entities:
-          - entity: sensor.meal_prep_source_status
-            name: "Source status"
-          - type: attribute
-            entity: sensor.meal_prep_source_status
-            attribute: reason
-            name: "Source reason"
-          - type: attribute
-            entity: sensor.meal_prep_source_status
-            attribute: source_updated_at
-            name: "Source updated"
-          - entity: sensor.meal_prep_session_state
-            name: "Preparation state"
-          - entity: sensor.meal_prep_target_time
-            name: "Planned / prep time"
-
       - type: grid
         title: "Preparation controls"
         columns: 2
@@ -173,3 +154,22 @@ views:
             tap_action:
               action: perform-action
               perform_action: script.meal_prep_clear_session
+
+      - type: entities
+        title: "Source details"
+        show_header_toggle: false
+        entities:
+          - entity: sensor.meal_prep_source_status
+            name: "Source status"
+          - type: attribute
+            entity: sensor.meal_prep_source_status
+            attribute: reason
+            name: "Source reason"
+          - type: attribute
+            entity: sensor.meal_prep_source_status
+            attribute: source_updated_at
+            name: "Source updated"
+          - entity: sensor.meal_prep_session_state
+            name: "Preparation state"
+          - entity: sensor.meal_prep_target_time
+            name: "Planned / prep time"

--- a/tests/test_kitchen_prep_dashboard.py
+++ b/tests/test_kitchen_prep_dashboard.py
@@ -127,6 +127,19 @@ def test_kitchen_prep_dashboard_is_concise_and_fail_closed_when_source_is_unavai
     assert "full recipe" not in DASHBOARD.read_text().lower()
 
 
+def test_kitchen_prep_dashboard_keeps_diagnostics_after_preparation_controls():
+    cards = load_dashboard()["views"][0]["cards"]
+
+    assert [card["title"] for card in cards] == [
+        "Meal status",
+        "Current step",
+        "Next step",
+        "Recipe context",
+        "Preparation controls",
+        "Source details",
+    ]
+
+
 def test_kitchen_prep_dashboard_buttons_call_only_real_manual_script_services():
     cards = load_dashboard()["views"][0]["cards"]
     control_card = next(card for card in cards if card.get("title") == "Preparation controls")


### PR DESCRIPTION
## Summary
- move Kitchen Prep source/debug details below the manual preparation controls
- preserve all source status, freshness, failure, no-meal, and reason text
- add a focused card-order regression assertion

## Validation
- `python -m pytest tests/test_kitchen_prep_dashboard.py tests/test_meal_prep_controls.py tests/test_mealie_read_only_path.py` (26 passed)
- `python -m pytest` (166 passed)
- HA-tag-aware YAML load and Jinja parse of `dashboards/kitchen_prep.yaml`
- verified all 7 dashboard script references are registered in `packages/meal_prep.yaml`
- `git diff --check`

## Documentation impact
None; this is a presentation-only dashboard ordering change.

Closes #227