### PR TITLE
feat(kitchen): resolve configurable dinner targets

### DIFF
--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -44,6 +44,8 @@ views:
 
           **Planned / prep time:** {{ states('sensor.meal_prep_target_time') }}
 
+          **Target-time source:** {{ state_attr('sensor.meal_prep_target_time', 'source') | title }}
+
           **Preparation state:** {{ states('sensor.meal_prep_session_state') | replace('_', ' ') | title }}
 
           **Source status:** Ready
@@ -173,3 +175,7 @@ views:
             name: "Preparation state"
           - entity: sensor.meal_prep_target_time
             name: "Planned / prep time"
+          - type: attribute
+            entity: sensor.meal_prep_target_time
+            attribute: source
+            name: "Target-time source"

--- a/packages/README.md
+++ b/packages/README.md
@@ -32,6 +32,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `known_batteries.yaml` | Template sensors that normalize known battery-powered devices into consistent names and attributes for the battery-health package. |
 | `light_groups.yaml` | Logical Home Assistant light groups for easier control by rooms or household areas. |
 | `meal_prep.yaml` | Kitchen meal-preparation state model and deterministic manual Start/Done/Skip/Snooze/Finish/display/clear script seams. It owns persistent helper seams and read-only normalized meal/status/step/session/recipe-context sensors. |
+| `meal_prep_target_policy.yaml` | Explicit Kitchen Prep target-time resolution: valid Mealie scheduled timestamp, matching local per-day/per-meal override, then household default dinner time; no usable value remains unconfigured. |
 | `mealie_read_only.yaml` | Read-only Mealie GET adapter. It refreshes a bounded today/upcoming plan and linked recipe into `meal_prep.yaml` helpers every 15 minutes. |
 | `meal_prep_orchestration.yaml` | Kitchen Prep automatic start/cleanup and one-time Cast behavior, bounded by fresh source data, today’s target/prep window, household presence, and guest mode. |
 | `notifications.yaml` | Shared notification automations that do not belong to a larger feature package, currently including bus/school-day notification handling. |

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -521,13 +521,20 @@ template:
         icon: mdi:calendar-clock
         state: >
           {% set value = states('input_datetime.meal_prep_target_time') %}
-          {% if value in ['unknown', 'unavailable', '', none] %}
+          {% set source = states('input_text.meal_prep_target_time_source') | lower | trim %}
+          {% if source not in ['mealie', 'override', 'default'] %}
+            none
+          {% elif value in ['unknown', 'unavailable', '', none] %}
             none
           {% elif as_timestamp(value, default=none) is none %}
             unavailable
           {% else %}
             {{ value }}
           {% endif %}
+        attributes:
+          source: >
+            {% set source = states('input_text.meal_prep_target_time_source') | lower | trim %}
+            {{ source if source in ['mealie', 'override', 'default'] else 'none' }}
 
       - name: "Meal Prep Current Step"
         unique_id: meal_prep_current_step
@@ -590,6 +597,7 @@ template:
           source_status: "{{ states('sensor.meal_prep_source_status') }}"
           source_reason: "{{ state_attr('sensor.meal_prep_source_status', 'reason') }}"
           target_time: "{{ states('sensor.meal_prep_target_time') }}"
+          target_time_source: "{{ state_attr('sensor.meal_prep_target_time', 'source') }}"
           snooze_until: "{{ states('input_text.meal_prep_snooze_until') }}"
           session_key: "{{ states('input_text.meal_prep_session_key') }}"
           semantics: >

--- a/packages/meal_prep_target_policy.md
+++ b/packages/meal_prep_target_policy.md
@@ -1,0 +1,32 @@
+# Kitchen Prep target-time policy
+
+`meal_prep_target_policy.yaml` resolves `sensor.meal_prep_target_time` without
+refreshing Mealie, calling devices, or making any Mealie write.
+
+## Configuration
+
+- Set `input_datetime.meal_prep_default_dinner_time` to the household's local
+  dinner target. It intentionally has no `initial`; leaving it unset means no
+  default time is fabricated.
+- For one meal, set both `input_datetime.meal_prep_target_time_override` (local
+  date and time) and `input_text.meal_prep_target_time_override_key` to the
+  exact `YYYY-MM-DD|dinner` meal identity, for example `2026-07-24|dinner`.
+
+## Fixed precedence and validation
+
+1. A valid Mealie scheduled time wins.
+2. Otherwise, a matching per-day/per-meal override wins.
+3. Otherwise, the configured default applies to a dinner meal only.
+4. If none is valid, the target remains explicitly `none`.
+
+Mealie's `date` field is a meal-date identity when it is `YYYY-MM-DD`. It is a
+scheduled target only when it is ISO-8601 with an explicit `Z` or numeric UTC
+offset. Timezone-less values, malformed values, and values whose converted Home
+Assistant local date differs from the meal date are rejected. This preserves
+local timezone behavior across UTC midnight and keeps the existing date+recipe
+session/orchestration identity from carrying a target into another day.
+
+The resolved sensor has a `source` attribute: `mealie`, `override`, `default`,
+or `none`. The Kitchen Prep dashboard shows the resolved time and source. A
+stale historical value in `input_datetime.meal_prep_target_time` is hidden when
+source is `none`, so automatic orchestration cannot silently use it.

--- a/packages/meal_prep_target_policy.yaml
+++ b/packages/meal_prep_target_policy.yaml
@@ -1,0 +1,133 @@
+# packages/meal_prep_target_policy.yaml
+#
+# Kitchen Prep target-time policy. This package has no Mealie requests or
+# household/device actions. It resolves a local target timestamp only from the
+# fresh, coherent source snapshot and explicit household configuration.
+#
+# Precedence is deliberately fixed:
+# 1. a valid Mealie scheduled timestamp (ISO-8601 with an explicit UTC offset),
+# 2. a matching local per-day/per-meal override, then
+# 3. the household's local default dinner time.
+#
+# The per-day/per-meal override key is YYYY-MM-DD|dinner and its value is a
+# local date+time. Both must match the current source meal date/type exactly.
+# Missing, malformed, timezone-ambiguous, or date-mismatched values resolve to
+# source=none; they never guess a dinner time. Mealie's date-only field remains
+# a meal-date identity, not a scheduled time.
+
+input_datetime:
+  meal_prep_default_dinner_time:
+    name: "Meal Prep Default Dinner Time"
+    icon: mdi:clock-outline
+    has_date: false
+    has_time: true
+
+  meal_prep_target_time_override:
+    name: "Meal Prep Target Time Override"
+    icon: mdi:calendar-edit
+    has_date: true
+    has_time: true
+
+input_text:
+  meal_prep_target_time_override_key:
+    name: "Meal Prep Target Time Override Key"
+    icon: mdi:key-variant
+    max: 32
+
+  meal_prep_target_time_source:
+    name: "Meal Prep Target Time Source"
+    icon: mdi:calendar-check-outline
+    max: 16
+
+  meal_prep_meal_date:
+    name: "Meal Prep Meal Date Input"
+    icon: mdi:calendar
+    max: 10
+
+  meal_prep_source_scheduled_time:
+    name: "Meal Prep Source Scheduled Time Input"
+    icon: mdi:calendar-clock
+    max: 40
+
+automation:
+  - alias: "Kitchen Prep: Resolve target time policy"
+    id: "meal_prep_resolve_target_time"
+    description: >
+      Resolve only a fresh source meal's local target according to the documented
+      Mealie, per-day/per-meal override, then household-default precedence. It
+      does not refresh sources, write Mealie, or control household devices.
+    mode: single
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: state
+        entity_id:
+          - sensor.meal_prep_source_status
+          - sensor.meal_prep_meal
+          - sensor.meal_prep_meal_type
+          - input_text.meal_prep_meal_date
+          - input_text.meal_prep_source_scheduled_time
+          - input_datetime.meal_prep_target_time_override
+          - input_text.meal_prep_target_time_override_key
+          - input_datetime.meal_prep_default_dinner_time
+    variables:
+      source_ready: "{{ states('sensor.meal_prep_source_status') == 'ready' }}"
+      meal_present: "{{ states('sensor.meal_prep_meal') not in ['none', 'unknown', 'unavailable'] }}"
+      meal_type: "{{ states('sensor.meal_prep_meal_type') | lower | trim }}"
+      meal_date: "{{ states('input_text.meal_prep_meal_date') | trim }}"
+      meal_date_valid: "{{ meal_date | regex_match('^\\d{4}-\\d{2}-\\d{2}$') }}"
+      source_scheduled_time: "{{ states('input_text.meal_prep_source_scheduled_time') | trim }}"
+      source_scheduled_timestamp: "{{ as_timestamp(source_scheduled_time, default=none) }}"
+      source_scheduled_valid: >
+        {{ source_scheduled_time | regex_match('^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d+)?)?(?:Z|[+-]\\d{2}:\\d{2})$') and
+           source_scheduled_timestamp is not none and
+           source_scheduled_timestamp > 0 and
+           source_scheduled_timestamp | timestamp_custom('%Y-%m-%d', true) == meal_date }}
+      override_key: "{{ states('input_text.meal_prep_target_time_override_key') | lower | trim }}"
+      override_time: "{{ states('input_datetime.meal_prep_target_time_override') }}"
+      override_timestamp: "{{ as_timestamp(override_time, default=none) }}"
+      override_valid: >
+        {{ override_key == meal_date ~ '|' ~ meal_type and
+           override_time.startswith(meal_date) and
+           override_timestamp is not none and override_timestamp > 0 }}
+      default_dinner_time: "{{ states('input_datetime.meal_prep_default_dinner_time') }}"
+      default_valid: "{{ default_dinner_time | regex_match('^\\d{2}:\\d{2}:\\d{2}$') }}"
+    action:
+      - action: input_text.set_value
+        target:
+          entity_id: input_text.meal_prep_target_time_source
+        data:
+          value: >
+            {% if not source_ready or not meal_present or not meal_date_valid %}
+              none
+            {% elif source_scheduled_valid %}
+              mealie
+            {% elif override_valid %}
+              override
+            {% elif meal_type == 'dinner' and default_valid %}
+              default
+            {% else %}
+              none
+            {% endif %}
+      - choose:
+          - conditions: "{{ source_ready and meal_present and meal_date_valid and source_scheduled_valid }}"
+            sequence:
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.meal_prep_target_time
+                data:
+                  datetime: "{{ source_scheduled_timestamp | timestamp_custom('%Y-%m-%d %H:%M:%S', true) }}"
+          - conditions: "{{ source_ready and meal_present and meal_date_valid and override_valid }}"
+            sequence:
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.meal_prep_target_time
+                data:
+                  datetime: "{{ override_time }}"
+          - conditions: "{{ source_ready and meal_present and meal_date_valid and meal_type == 'dinner' and default_valid }}"
+            sequence:
+              - action: input_datetime.set_datetime
+                target:
+                  entity_id: input_datetime.meal_prep_target_time
+                data:
+                  datetime: "{{ meal_date ~ ' ' ~ default_dinner_time }}"

--- a/packages/mealie_read_only.yaml
+++ b/packages/mealie_read_only.yaml
@@ -138,6 +138,8 @@ automation:
                     - input_text.meal_prep_recipe_summary
                     - input_text.meal_prep_recipe_prep_time
                     - input_text.meal_prep_ingredient_context
+                    - input_text.meal_prep_meal_date
+                    - input_text.meal_prep_source_scheduled_time
                 data:
                   value: ""
               - action: input_text.set_value
@@ -159,14 +161,29 @@ automation:
           - variables:
               mealie_entry: "{{ mealie_plan_payload[0] }}"
               mealie_recipe_id: "{{ mealie_plan_payload[0].recipeId | default('', true) | string | trim }}"
+              # Mealie's date-only entry field establishes date+recipe identity.
+              # An ISO timestamp with an explicit offset is additionally a
+              # scheduled-time candidate; a timezone-less timestamp is rejected.
+              mealie_entry_date: "{{ mealie_plan_payload[0].date | default('', true) | string | trim }}"
+              mealie_entry_timestamp: "{{ as_timestamp(mealie_plan_payload[0].date | default('', true) | string | trim, default=none) }}"
+              mealie_meal_date: >
+                {% set value = mealie_plan_payload[0].date | default('', true) | string | trim %}
+                {% if value | regex_match('^\\d{4}-\\d{2}-\\d{2}$') %}
+                  {{ value }}
+                {% elif value | regex_match('^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d+)?)?(?:Z|[+-]\\d{2}:\\d{2})$') and mealie_entry_timestamp is not none %}
+                  {{ mealie_entry_timestamp | timestamp_custom('%Y-%m-%d', true) }}
+                {% endif %}
+              mealie_scheduled_time: >
+                {% set value = mealie_plan_payload[0].date | default('', true) | string | trim %}
+                {{ value if value | regex_match('^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d+)?)?(?:Z|[+-]\\d{2}:\\d{2})$') else '' }}
           - choose:
-              - conditions: "{{ mealie_entry is not mapping or mealie_recipe_id == '' }}"
+              - conditions: "{{ mealie_entry is not mapping or mealie_recipe_id == '' or mealie_meal_date | trim == '' }}"
                 sequence:
                   - action: input_text.set_value
                     target:
                       entity_id: input_text.meal_prep_source_reason
                     data:
-                      value: "meal plan entry has no recipeId"
+                      value: "meal plan entry has no recipeId or valid date"
                   - action: input_text.set_value
                     target:
                       entity_id: input_text.meal_prep_source_status
@@ -245,6 +262,16 @@ automation:
                       entity_id: input_text.meal_prep_recipe_reference
                     data:
                       value: "{{ mealie_recipe_id | truncate(255, true, '') }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_meal_date
+                    data:
+                      value: "{{ mealie_meal_date | trim }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_source_scheduled_time
+                    data:
+                      value: "{{ mealie_scheduled_time | trim }}"
                   - action: input_text.set_value
                     target:
                       entity_id: input_text.meal_prep_recipe_url

--- a/tests/test_meal_prep_state_model.py
+++ b/tests/test_meal_prep_state_model.py
@@ -83,6 +83,7 @@ def ready_meal():
         "input_text.meal_prep_current_step": "Chop vegetables",
         "input_text.meal_prep_next_step": "Preheat oven",
         "input_datetime.meal_prep_target_time": "2026-07-23 19:00:00+00:00",
+        "input_text.meal_prep_target_time_source": "default",
         "input_text.meal_prep_snooze_until": "",
         "input_text.meal_prep_session_key": "2026-07-23|recipe-123",
         "input_text.meal_prep_last_skipped_step": "",
@@ -193,6 +194,12 @@ def test_ready_snapshot_exposes_normalized_meal_recipe_and_instruction_seams(rea
     assert evaluated["sensor.meal_prep_target_time"] == "2026-07-23 19:00:00+00:00"
     assert evaluated["sensor.meal_prep_current_step"] == "Chop vegetables"
     assert evaluated["sensor.meal_prep_next_step"] == "Preheat oven"
+
+
+def test_target_time_is_hidden_when_no_policy_source_resolved_it(ready_meal):
+    evaluated = evaluate(ready_meal | {"input_text.meal_prep_target_time_source": "none"})
+
+    assert evaluated["sensor.meal_prep_target_time"] == "none"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meal_prep_target_policy.py
+++ b/tests/test_meal_prep_target_policy.py
@@ -1,0 +1,107 @@
+from datetime import datetime, time
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "packages" / "meal_prep_target_policy.yaml"
+MEALIE = ROOT / "packages" / "mealie_read_only.yaml"
+DASHBOARD = ROOT / "dashboards" / "kitchen_prep.yaml"
+
+
+def resolve_target(*, meal_date, meal_type="dinner", scheduled=None, override_key="", override=None, default=None, tz=ZoneInfo("America/Chicago")):
+    """Reference the documented policy; inputs are source/configuration seams."""
+    if not meal_date or not meal_type:
+        return None, "none"
+    if scheduled:
+        try:
+            value = datetime.fromisoformat(scheduled.replace("Z", "+00:00"))
+        except ValueError:
+            value = None
+        if value and value.tzinfo and value.astimezone(tz).date().isoformat() == meal_date:
+            return value.astimezone(tz), "mealie"
+    if override and override_key == f"{meal_date}|{meal_type}":
+        try:
+            value = datetime.fromisoformat(override)
+        except ValueError:
+            value = None
+        if value and value.date().isoformat() == meal_date:
+            return value.replace(tzinfo=tz) if value.tzinfo is None else value.astimezone(tz), "override"
+    if meal_type == "dinner" and default:
+        return datetime.combine(datetime.fromisoformat(meal_date).date(), time.fromisoformat(default), tz), "default"
+    return None, "none"
+
+
+def test_policy_declares_household_default_override_and_fixed_precedence():
+    policy = yaml.safe_load(POLICY.read_text())
+    helpers = policy["input_datetime"]
+
+    assert helpers["meal_prep_default_dinner_time"] == {
+        "name": "Meal Prep Default Dinner Time",
+        "icon": "mdi:clock-outline",
+        "has_date": False,
+        "has_time": True,
+    }
+    assert helpers["meal_prep_target_time_override"]["has_date"] is True
+    assert helpers["meal_prep_target_time_override"]["has_time"] is True
+    text = POLICY.read_text()
+    assert "valid Mealie scheduled timestamp" in text
+    assert "matching local per-day/per-meal override" in text
+    assert "household's local default dinner time" in text
+
+
+def test_default_override_and_valid_mealie_time_follow_precedence():
+    default = "18:00:00"
+    override = "2026-07-24 18:30:00"
+    value, source = resolve_target(
+        meal_date="2026-07-24", override_key="2026-07-24|dinner", override=override, default=default
+    )
+    assert (value.strftime("%H:%M:%S"), source) == ("18:30:00", "override")
+
+    value, source = resolve_target(
+        meal_date="2026-07-24",
+        scheduled="2026-07-24T23:00:00+00:00",
+        override_key="2026-07-24|dinner",
+        override=override,
+        default=default,
+    )
+    assert (value.strftime("%H:%M:%S"), source) == ("18:00:00", "mealie")
+
+    value, source = resolve_target(meal_date="2026-07-24", default=default)
+    assert (value.strftime("%H:%M:%S"), source) == ("18:00:00", "default")
+
+
+def test_missing_malformed_ambiguous_and_mismatched_values_never_guess_a_target():
+    assert resolve_target(meal_date="2026-07-24")[1] == "none"
+    assert resolve_target(meal_date="2026-07-24", scheduled="2026-07-24T18:00:00", default=None)[1] == "none"
+    assert resolve_target(meal_date="2026-07-24", scheduled="not-a-time", default=None)[1] == "none"
+    assert resolve_target(
+        meal_date="2026-07-24", override_key="2026-07-25|dinner", override="2026-07-24 18:00:00"
+    )[1] == "none"
+    assert resolve_target(meal_date="2026-07-24", meal_type="lunch", default="18:00:00")[1] == "none"
+
+
+def test_timezone_conversion_and_date_rollover_use_local_meal_date_identity():
+    # 00:30Z is still the prior local evening in America/Chicago.
+    value, source = resolve_target(
+        meal_date="2026-07-24", scheduled="2026-07-25T00:30:00+00:00"
+    )
+    assert (value.date().isoformat(), value.strftime("%H:%M"), source) == ("2026-07-24", "19:30", "mealie")
+    assert resolve_target(
+        meal_date="2026-07-25", scheduled="2026-07-25T00:30:00+00:00"
+    )[1] == "none"
+
+
+def test_mealie_mapping_and_dashboard_surface_resolved_target_source_without_writes():
+    mealie = MEALIE.read_text()
+    dashboard = DASHBOARD.read_text()
+
+    assert "mealie_meal_date" in mealie
+    assert "mealie_scheduled_time" in mealie
+    assert "timezone-less timestamp is rejected" in mealie
+    assert "input_text.meal_prep_source_scheduled_time" in mealie
+    assert "POST" not in mealie and "PUT" not in mealie and "PATCH" not in mealie and "DELETE" not in mealie
+    assert "Target-time source:" in dashboard
+    assert "attribute: source" in dashboard


### PR DESCRIPTION
## Summary
- Add documented Kitchen Prep target-time policy: valid explicit-offset Mealie time, matching per-day/per-meal override, then configured local dinner default.
- Reject malformed, timezone-ambiguous, cross-local-date, and missing target sources; expose the resolved source in the dashboard.
- Preserve Mealie's GET-only contract and cover precedence, missing/malformed cases, timezone conversion, and date rollover.

## Validation
- ........................................                                 [100%]
40 passed in 5.95s (40 passed)
- ........................................................................ [ 41%]
........................................................................ [ 83%]
............................                                             [100%]
172 passed in 11.85s (172 passed)
- YAML parsing for changed Kitchen Prep packages/dashboard and Jinja syntax parsing (131 templates)
- 
- GitHub repository/workflow configuration query

Closes #224