### PR TITLE
feat(kitchen): add configurable dinner lead time

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `garage_door_monitoring.yaml` - garage-door duration monitoring, reminders, and controls.
 - `known_batteries.yaml` - normalized template sensors for known battery-powered devices.
 - `light_groups.yaml` - logical light groups.
-- `meal_prep.yaml`, `mealie_read_only.yaml`, and `meal_prep_orchestration.yaml` - Kitchen Prep helper/state model, deterministic manual controls, bounded read-only Mealie adapter, and once-per-meal automatic prep-window/Cast orchestration.
+- `meal_prep.yaml`, `meal_prep_target_policy.yaml`, `mealie_read_only.yaml`, and `meal_prep_orchestration.yaml` - Kitchen Prep helper/state model, dinner-target and configurable lead-time policy, deterministic manual controls, bounded read-only Mealie adapter, and once-per-meal automatic prep-window/Cast orchestration.
 - `notifications.yaml` - shared notification automations that do not belong to a larger package.
 - `presence.yaml` - presence, alarm-panel, and presence-related lighting behavior.
 - `remotes.yaml` - Z-Wave remote helper scripts and blueprint-backed automations.
@@ -84,7 +84,7 @@ YAML-managed dashboards live in `dashboards/` and are registered by `packages/sh
 
 - `dashboards/climate_control.yaml` provides the mobile-first climate operator view, thermostat controls, temperature and air-quality trend graphs, extreme-heat overlay controls, and diagnostics.
 - `dashboards/window_ventilation.yaml` provides the advisory ventilation view, current recommendation, comfort/dew-point context, rain/HVAC context, air-quality baseline comparisons, and tuning helpers.
-- `dashboards/kitchen_prep.yaml` provides a hidden, phone-first Kitchen Prep view. It renders only fresh meal-prep source data, presents #210-owned manual controls that fail closed outside a valid session, and is the future direct-view target for the kitchen display.
+- `dashboards/kitchen_prep.yaml` provides a hidden, phone-first Kitchen Prep view. It renders only fresh meal-prep source data, exposes the selected dinner-ready timing policy and computed automatic start, presents #210-owned manual controls that fail closed outside a valid session, and is the future direct-view target for the kitchen display.
 
 ## Notifications and shared contracts
 

--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -46,6 +46,12 @@ views:
 
           **Target-time source:** {{ state_attr('sensor.meal_prep_target_time', 'source') | title }}
 
+          **Dinner-ready policy:** {{ states('input_select.meal_prep_automatic_lead_time_policy') | replace('_', ' ') | title }}
+
+          **Automatic start:** {{ states('sensor.meal_prep_automatic_start_time') }}
+
+          **Lead-time source:** {{ state_attr('sensor.meal_prep_automatic_start_time', 'duration_source') | replace('_', ' ') | title }}
+
           **Preparation state:** {{ states('sensor.meal_prep_session_state') | replace('_', ' ') | title }}
 
           **Source status:** Ready
@@ -179,3 +185,11 @@ views:
             entity: sensor.meal_prep_target_time
             attribute: source
             name: "Target-time source"
+          - entity: input_select.meal_prep_automatic_lead_time_policy
+            name: "Dinner-ready policy"
+          - entity: sensor.meal_prep_automatic_start_time
+            name: "Automatic start"
+          - type: attribute
+            entity: sensor.meal_prep_automatic_start_time
+            attribute: duration_source
+            name: "Lead-time source"

--- a/packages/README.md
+++ b/packages/README.md
@@ -73,13 +73,13 @@ inventing meal or instruction content.
 |---|---|---|---|
 | `input_boolean.meal_prep_active` | Meal Prep Active | Manual active-session flag for the matching meal/date identity. | Restored; no `initial` is set. |
 | `input_boolean.meal_prep_done` | Meal Prep Complete | Manual finish-for-today flag for the matching meal/date identity. | Restored; no `initial` is set. |
-| `input_datetime.meal_prep_target_time` | Meal Prep Target Time | Local planned/prep target-time seam. | Restored; no `initial` is set. |
+| `input_datetime.meal_prep_target_time` | Meal Prep Target Time | Local dinner-ready target-time seam. | Restored; no `initial` is set. |
 | `input_datetime.meal_prep_source_updated_at` | Meal Prep Source Updated At | Snapshot timestamp for freshness. | Restored; no `initial` is set. |
 | `input_text.meal_prep_snooze_until` | Meal Prep Snooze Until | ISO timestamp seam for a paused session. | Restored; no `initial` is set. |
 | `input_text.meal_prep_session_key` | Meal Prep Session Key | Date + recipe-reference identity that scopes restored active/done/snooze state. | Restored; no `initial` is set. |
 | `input_text.meal_prep_last_skipped_step` | Meal Prep Last Skipped Step | Bounded record of the most recent deliberate skip; it never marks the meal complete. | Restored; no `initial` is set. |
 | `input_text.meal_prep_remaining_steps` | Meal Prep Remaining Steps | Bounded escaped-delimiter source queue after the current/next steps, used only for deterministic manual advancement. | Restored; no `initial` is set. |
-| `input_text.meal_prep_recipe_prep_time` | Meal Prep Recipe Prep Time Input | Raw Mealie `prepTime` duration for automatic-window calculation. | Restored; no `initial` is set. |
+| `input_text.meal_prep_recipe_prep_time`, `input_text.meal_prep_recipe_cook_time`, `input_text.meal_prep_recipe_total_time` | Meal Prep Recipe Timing Inputs | Raw Mealie `prepTime`, `cookTime`, and `totalTime` durations for automatic lead-time calculation. | Restored; no `initial` is set. |
 | `input_text.meal_prep_automatic_handled_key` | Meal Prep Automatic Handled Key | Date + recipe identity manually or automatically claimed to prevent repeat automatic starts/Casts. | Restored; no `initial` is set. |
 | `input_text.meal_prep_source_status` | Meal Prep Source Status Input | Future normalizer's raw status seam. | Restored; no `initial` is set. |
 | `input_text.meal_prep_meal_title`, `input_text.meal_prep_meal_type` | Meal Prep Meal Title/Type Input | Raw meal-identity seams. | Restored; no `initial` is set. |
@@ -88,7 +88,9 @@ inventing meal or instruction content.
 | `sensor.meal_prep_source_status` | Meal Prep Source Status | Normalized freshness/status and visible reason. | Derived at runtime. |
 | `sensor.meal_prep_meal`, `sensor.meal_prep_meal_type` | Meal Prep Meal/Meal Type | Safe normalized meal identity. | Derived at runtime. |
 | `sensor.meal_prep_recipe_reference`, `sensor.meal_prep_recipe_url` | Meal Prep Recipe Reference/URL | Safe normalized recipe seams. | Derived at runtime. |
-| `sensor.meal_prep_target_time` | Meal Prep Target Time | Safe local target-time presentation. | Derived at runtime. |
+| `sensor.meal_prep_target_time` | Meal Prep Target Time | Safe local dinner-ready target-time presentation. | Derived at runtime. |
+| `input_select.meal_prep_automatic_lead_time_policy` | Meal Prep Automatic Lead-Time Policy | Configurable dinner-ready timing semantic. | Defaults to `total_time` by first option; selection is restored. |
+| `sensor.meal_prep_automatic_start_time` | Meal Prep Automatic Start Time | Safe calculated start from target minus selected lead time. | Derived at runtime. |
 | `sensor.meal_prep_current_step`, `sensor.meal_prep_next_step` | Meal Prep Current/Next Step | Safe normalized instruction seams. | Derived at runtime. |
 | `sensor.meal_prep_session_state` | Meal Prep Session State | `idle`, `planned`, `prep_due`, `active`, `paused`, `complete`, or `unavailable`. | Derived at runtime. |
 
@@ -125,10 +127,17 @@ bounded, delimiter-safe queue; controls never invent steps beyond that source da
 ### Kitchen Prep automatic orchestration
 
 `meal_prep_orchestration.yaml` starts only for a fresh, valid meal whose target
-timestamp is today, in the half-open prep window `[target - prepTime, target)`,
-with `zone.home` above zero and guest mode off. Mealie `prepTime` must be a
-positive ISO-8601 `PT#H#M` duration; missing, zero, or unsupported duration and
-missing/invalid target time deliberately result in no automatic start.
+timestamp is today, in the half-open `[automatic start, target)` window, with
+`zone.home` above zero and guest mode off. The dinner-ready policy is configured
+by `input_select.meal_prep_automatic_lead_time_policy`: `total_time` (the
+default) treats the target as ready-to-serve and uses valid Mealie `totalTime`;
+`prep_plus_cook` sums valid `prepTime` and `cookTime`; and `prep_only` uses valid
+`prepTime` alone when the target means cooking should begin. `total_time` falls
+back only to valid positive prep-plus-cook when `totalTime` is missing or invalid;
+it never adds total to either component, so it cannot double-count. The only
+accepted forms are positive ISO-8601 `PT#H#M` values. Zero, negative, malformed,
+partial, date/day, second, fractional, and otherwise unsupported values result
+in no automatic start rather than guessing.
 
 The restored `input_text.meal_prep_automatic_handled_key` is set for both manual
 and automatic starts. It prevents refreshes, reloads, and restarts from repeating

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -92,11 +92,22 @@ input_text:
     icon: mdi:timer-outline
     max: 160
 
-  # The read-only adapter stores Mealie's ISO-8601 `prepTime` here. Automatic
-  # orchestration is the only consumer and fails closed for unsupported values.
+  # The read-only adapter stores Mealie's verified ISO-8601 timing fields here.
+  # Automatic orchestration consumes only the selected, validated lead-time
+  # result and fails closed for unsupported values.
   meal_prep_recipe_prep_time:
     name: "Meal Prep Recipe Prep Time Input"
     icon: mdi:timer-sand
+    max: 40
+
+  meal_prep_recipe_cook_time:
+    name: "Meal Prep Recipe Cook Time Input"
+    icon: mdi:stove
+    max: 40
+
+  meal_prep_recipe_total_time:
+    name: "Meal Prep Recipe Total Time Input"
+    icon: mdi:timer-check-outline
     max: 40
 
   meal_prep_ingredient_context:

--- a/packages/meal_prep_orchestration.yaml
+++ b/packages/meal_prep_orchestration.yaml
@@ -5,16 +5,16 @@
 # display. `presence_everyone_left` remains the authoritative display-off flow.
 #
 # Automatic start needs all of: a fresh valid source, a valid recipe identity,
-# a target timestamp for today, a positive PT#H#M Mealie prep duration, someone
-# home, and guest mode off. Missing/unsupported timing intentionally does
-# nothing rather than guessing a preparation window.
+# a target timestamp for today, a configured and validated lead-time start,
+# someone home, and guest mode off. Missing/unsupported timing intentionally
+# does nothing rather than guessing a preparation window.
 
 automation:
   - alias: "Kitchen Prep: Automatically start useful preparation window"
     id: "meal_prep_automatic_start"
     description: >
       Start and cast Kitchen Prep at most once per today+recipe identity during
-      its half-open [target - prepTime, target) window. Restored handled state
+      its half-open [automatic start, target) window. Restored handled state
       prevents repeat casts after refresh, reload, or Home Assistant restart.
     mode: single
     trigger:
@@ -28,7 +28,11 @@ automation:
           - sensor.meal_prep_meal
           - sensor.meal_prep_recipe_reference
           - sensor.meal_prep_target_time
+          - sensor.meal_prep_automatic_start_time
+          - input_select.meal_prep_automatic_lead_time_policy
           - input_text.meal_prep_recipe_prep_time
+          - input_text.meal_prep_recipe_cook_time
+          - input_text.meal_prep_recipe_total_time
           - input_boolean.mode_guest
           - zone.home
     variables:
@@ -36,14 +40,8 @@ automation:
       meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
       target_time: "{{ states('sensor.meal_prep_target_time') }}"
       target_timestamp: "{{ as_timestamp(target_time, default=none) }}"
-      prep_time: "{{ states('input_text.meal_prep_recipe_prep_time') | upper | trim }}"
-      prep_duration_valid: >
-        {{ prep_time | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and prep_time != 'PT' }}
-      prep_hours: >
-        {{ (prep_time | regex_findall('^PT([0-9]+)H') | first | default('0', true)) | int(0) }}
-      prep_minutes_part: >
-        {{ (prep_time | regex_findall('([0-9]+)M$') | first | default('0', true)) | int(0) }}
-      prep_minutes: "{{ prep_hours | int(0) * 60 + prep_minutes_part | int(0) }}"
+      automatic_start_time: "{{ states('sensor.meal_prep_automatic_start_time') }}"
+      automatic_start_timestamp: "{{ as_timestamp(automatic_start_time, default=none) }}"
       snooze_until: "{{ as_timestamp(states('input_text.meal_prep_snooze_until'), default=none) }}"
     condition:
       - condition: template
@@ -56,14 +54,14 @@ automation:
              '|' not in recipe_reference and
              target_timestamp is not none and
              target_time.startswith(now().date().isoformat()) and
-             prep_duration_valid and prep_minutes | int(0) > 0 and
+             automatic_start_timestamp is not none and
              states('zone.home') | float(0) > 0 and
              is_state('input_boolean.mode_guest', 'off') and
              is_state('input_boolean.meal_prep_active', 'off') and
              is_state('input_boolean.meal_prep_done', 'off') and
              (snooze_until is none or snooze_until <= now().timestamp()) and
              states('input_text.meal_prep_automatic_handled_key') != meal_prep_identity and
-             now().timestamp() >= target_timestamp | float(0) - prep_minutes | int(0) * 60 and
+             now().timestamp() >= automatic_start_timestamp and
              now().timestamp() < target_timestamp | float(0) }}
     action:
       - action: input_text.set_value

--- a/packages/meal_prep_target_policy.yaml
+++ b/packages/meal_prep_target_policy.yaml
@@ -14,6 +14,23 @@
 # Missing, malformed, timezone-ambiguous, or date-mismatched values resolve to
 # source=none; they never guess a dinner time. Mealie's date-only field remains
 # a meal-date identity, not a scheduled time.
+#
+# Dinner-ready lead-time policy defaults to `total_time`: dinner should be ready
+# to serve at the resolved target. Operators may select `prep_only` when the
+# target means cooking should begin, or `prep_plus_cook` when Mealie's separate
+# preparation and cook fields are authoritative. Only positive PT#H#M values
+# are accepted. Under `total_time`, a missing or invalid total falls back only
+# to the sum of valid positive prep and cook values; total is never added to
+# either component, avoiding double-counting.
+
+input_select:
+  meal_prep_automatic_lead_time_policy:
+    name: "Meal Prep Automatic Lead-Time Policy"
+    icon: mdi:timer-cog-outline
+    options:
+      - total_time
+      - prep_plus_cook
+      - prep_only
 
 input_datetime:
   meal_prep_default_dinner_time:
@@ -48,6 +65,64 @@ input_text:
     name: "Meal Prep Source Scheduled Time Input"
     icon: mdi:calendar-clock
     max: 40
+
+template:
+  - sensor:
+      - name: "Meal Prep Automatic Start Time"
+        unique_id: meal_prep_automatic_start_time
+        icon: mdi:clock-start
+        state: >
+          {% set policy = states('input_select.meal_prep_automatic_lead_time_policy') | lower | trim %}
+          {% set target = states('sensor.meal_prep_target_time') %}
+          {% set target_timestamp = as_timestamp(target, default=none) %}
+          {% set prep = states('input_text.meal_prep_recipe_prep_time') | upper | trim %}
+          {% set cook = states('input_text.meal_prep_recipe_cook_time') | upper | trim %}
+          {% set total = states('input_text.meal_prep_recipe_total_time') | upper | trim %}
+          {% set prep_valid = prep | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and prep != 'PT' %}
+          {% set cook_valid = cook | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and cook != 'PT' %}
+          {% set total_valid = total | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and total != 'PT' %}
+          {% set prep_minutes = (prep | regex_findall('^PT([0-9]+)H') | first | default('0', true) | int(0)) * 60 + (prep | regex_findall('([0-9]+)M$') | first | default('0', true) | int(0)) %}
+          {% set cook_minutes = (cook | regex_findall('^PT([0-9]+)H') | first | default('0', true) | int(0)) * 60 + (cook | regex_findall('([0-9]+)M$') | first | default('0', true) | int(0)) %}
+          {% set total_minutes = (total | regex_findall('^PT([0-9]+)H') | first | default('0', true) | int(0)) * 60 + (total | regex_findall('([0-9]+)M$') | first | default('0', true) | int(0)) %}
+          {% if states('sensor.meal_prep_source_status') != 'ready' or target_timestamp is none %}
+            none
+          {% elif policy == 'prep_only' and prep_valid and prep_minutes > 0 %}
+            {{ (target_timestamp - prep_minutes * 60) | timestamp_custom('%Y-%m-%d %H:%M:%S', true) }}
+          {% elif policy == 'prep_plus_cook' and prep_valid and cook_valid and prep_minutes > 0 and cook_minutes > 0 %}
+            {{ (target_timestamp - (prep_minutes + cook_minutes) * 60) | timestamp_custom('%Y-%m-%d %H:%M:%S', true) }}
+          {% elif policy == 'total_time' and total_valid and total_minutes > 0 %}
+            {{ (target_timestamp - total_minutes * 60) | timestamp_custom('%Y-%m-%d %H:%M:%S', true) }}
+          {% elif policy == 'total_time' and prep_valid and cook_valid and prep_minutes > 0 and cook_minutes > 0 %}
+            {{ (target_timestamp - (prep_minutes + cook_minutes) * 60) | timestamp_custom('%Y-%m-%d %H:%M:%S', true) }}
+          {% else %}
+            none
+          {% endif %}
+        attributes:
+          policy: >
+            {% set policy = states('input_select.meal_prep_automatic_lead_time_policy') | lower | trim %}
+            {{ policy if policy in ['total_time', 'prep_plus_cook', 'prep_only'] else 'none' }}
+          duration_source: >
+            {% set policy = states('input_select.meal_prep_automatic_lead_time_policy') | lower | trim %}
+            {% set prep = states('input_text.meal_prep_recipe_prep_time') | upper | trim %}
+            {% set cook = states('input_text.meal_prep_recipe_cook_time') | upper | trim %}
+            {% set total = states('input_text.meal_prep_recipe_total_time') | upper | trim %}
+            {% set prep_valid = prep | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and prep != 'PT' %}
+            {% set cook_valid = cook | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and cook != 'PT' %}
+            {% set total_valid = total | regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$') and total != 'PT' %}
+            {% set prep_minutes = (prep | regex_findall('^PT([0-9]+)H') | first | default('0', true) | int(0)) * 60 + (prep | regex_findall('([0-9]+)M$') | first | default('0', true) | int(0)) %}
+            {% set cook_minutes = (cook | regex_findall('^PT([0-9]+)H') | first | default('0', true) | int(0)) * 60 + (cook | regex_findall('([0-9]+)M$') | first | default('0', true) | int(0)) %}
+            {% set total_minutes = (total | regex_findall('^PT([0-9]+)H') | first | default('0', true) | int(0)) * 60 + (total | regex_findall('([0-9]+)M$') | first | default('0', true) | int(0)) %}
+            {% if policy == 'prep_only' and prep_valid and prep_minutes > 0 %}
+              prep_time
+            {% elif policy == 'prep_plus_cook' and prep_valid and cook_valid and prep_minutes > 0 and cook_minutes > 0 %}
+              prep_plus_cook
+            {% elif policy == 'total_time' and total_valid and total_minutes > 0 %}
+              total_time
+            {% elif policy == 'total_time' and prep_valid and cook_valid and prep_minutes > 0 and cook_minutes > 0 %}
+              prep_plus_cook_fallback
+            {% else %}
+              none
+            {% endif %}
 
 automation:
   - alias: "Kitchen Prep: Resolve target time policy"

--- a/packages/mealie_read_only.yaml
+++ b/packages/mealie_read_only.yaml
@@ -330,6 +330,16 @@ automation:
                       value: "{{ mealie_recipe.prepTime | default('', true) | string | trim | truncate(40, true, '') }}"
                   - action: input_text.set_value
                     target:
+                      entity_id: input_text.meal_prep_recipe_cook_time
+                    data:
+                      value: "{{ mealie_recipe.cookTime | default('', true) | string | trim | truncate(40, true, '') }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_recipe_total_time
+                    data:
+                      value: "{{ mealie_recipe.totalTime | default('', true) | string | trim | truncate(40, true, '') }}"
+                  - action: input_text.set_value
+                    target:
                       entity_id: input_text.meal_prep_ingredient_context
                     data:
                       value: >

--- a/tests/test_kitchen_prep_dashboard.py
+++ b/tests/test_kitchen_prep_dashboard.py
@@ -65,6 +65,8 @@ def test_kitchen_prep_dashboard_presents_only_real_state_and_control_seams():
     assert dashboard["views"][0]["path"] == "kitchen-prep"
     assert dashboard["views"][0]["badges"] == []
     assert refs == {
+        "input_select.meal_prep_automatic_lead_time_policy",
+        "sensor.meal_prep_automatic_start_time",
         "sensor.meal_prep_source_status",
         "sensor.meal_prep_session_state",
         "sensor.meal_prep_target_time",
@@ -115,6 +117,9 @@ def test_kitchen_prep_dashboard_is_concise_and_fail_closed_when_source_is_unavai
     assert "states('sensor.meal_prep_meal')" in status
     assert "states('sensor.meal_prep_meal_type')" in status
     assert "states('sensor.meal_prep_target_time')" in status
+    assert "states('input_select.meal_prep_automatic_lead_time_policy')" in status
+    assert "states('sensor.meal_prep_automatic_start_time')" in status
+    assert "duration_source" in status
     assert "state_attr('sensor.meal_prep_source_status', 'reason')" in status
 
     assert "## {{ states('sensor.meal_prep_current_step') }}" in current_step

--- a/tests/test_meal_prep_orchestration.py
+++ b/tests/test_meal_prep_orchestration.py
@@ -41,12 +41,32 @@ def actions(node):
     return found
 
 
-def prep_minutes(value):
+def duration_minutes(value):
     match = re.fullmatch(r"PT(?:(\d+)H)?(?:(\d+)M)?", value or "")
     if not match or value == "PT":
         return None
     minutes = int(match.group(1) or 0) * 60 + int(match.group(2) or 0)
     return minutes or None
+
+
+def resolve_lead_time(*, policy="total_time", prep="PT30M", cook="PT20M", total="PT50M"):
+    prep_minutes = duration_minutes(prep)
+    cook_minutes = duration_minutes(cook)
+    total_minutes = duration_minutes(total)
+    if policy == "prep_only":
+        return (prep_minutes, "prep_time") if prep_minutes else (None, "none")
+    if policy == "prep_plus_cook":
+        return (
+            (prep_minutes + cook_minutes, "prep_plus_cook")
+            if prep_minutes and cook_minutes
+            else (None, "none")
+        )
+    if policy == "total_time":
+        if total_minutes:
+            return total_minutes, "total_time"
+        if prep_minutes and cook_minutes:
+            return prep_minutes + cook_minutes, "prep_plus_cook_fallback"
+    return None, "none"
 
 
 def automatic_start_is_eligible(
@@ -55,7 +75,10 @@ def automatic_start_is_eligible(
     meal="Dinner",
     recipe="recipe-123",
     target=NOW + timedelta(minutes=20),
+    policy="total_time",
     prep_time="PT30M",
+    cook_time="PT20M",
+    total_time="PT50M",
     home=1,
     guest=False,
     active=False,
@@ -63,7 +86,9 @@ def automatic_start_is_eligible(
     snoozed=False,
     handled_key="",
 ):
-    minutes = prep_minutes(prep_time)
+    minutes, _duration_source = resolve_lead_time(
+        policy=policy, prep=prep_time, cook=cook_time, total=total_time
+    )
     identity = f"{NOW.date().isoformat()}|{recipe}"
     return (
         source == "ready"
@@ -109,19 +134,31 @@ def test_automatic_start_has_bounded_triggers_and_exact_cast_payload():
     assert "homeassistant.turn_off" not in text
 
 
-def test_deterministic_window_and_missing_time_fallbacks_fail_closed():
-    assert prep_minutes("PT45M") == 45
-    assert prep_minutes("PT1H15M") == 75
-    assert prep_minutes("PT") is None
-    assert prep_minutes("") is None
-    assert prep_minutes("45 minutes") is None
+def test_lead_time_policy_selects_only_verified_duration_forms_and_fails_closed():
+    assert duration_minutes("PT45M") == 45
+    assert duration_minutes("PT1H15M") == 75
+    for invalid in ("PT", "", "PT0M", "PT0H", "-PT30M", "45 minutes", "P1D", "PT30S", "PT1.5H"):
+        assert duration_minutes(invalid) is None, invalid
+
+    assert resolve_lead_time(policy="prep_only", prep="PT30M") == (30, "prep_time")
+    assert resolve_lead_time(policy="prep_plus_cook", prep="PT30M", cook="PT20M") == (50, "prep_plus_cook")
+    assert resolve_lead_time(policy="total_time", prep="PT30M", cook="PT20M", total="PT45M") == (45, "total_time")
+    assert resolve_lead_time(policy="total_time", prep="PT30M", cook="PT20M", total="") == (50, "prep_plus_cook_fallback")
+    assert resolve_lead_time(policy="total_time", prep="PT30M", cook="PT20M", total="PT0M") == (50, "prep_plus_cook_fallback")
+    assert resolve_lead_time(policy="prep_plus_cook", prep="PT30M", cook="") == (None, "none")
+    assert resolve_lead_time(policy="prep_only", prep="PT0M") == (None, "none")
+    assert resolve_lead_time(policy="unexpected", prep="PT30M", cook="PT20M", total="PT50M") == (None, "none")
 
     assert automatic_start_is_eligible()
+    assert automatic_start_is_eligible(policy="prep_only", prep_time="PT30M")
+    assert automatic_start_is_eligible(policy="prep_plus_cook", prep_time="PT30M", cook_time="PT20M")
+    assert automatic_start_is_eligible(policy="total_time", prep_time="PT30M", cook_time="PT20M", total_time="")
     assert not automatic_start_is_eligible(target=None)
     assert not automatic_start_is_eligible(target=NOW + timedelta(days=1))
-    assert not automatic_start_is_eligible(prep_time="")
-    assert not automatic_start_is_eligible(prep_time="PT0M")
-    assert not automatic_start_is_eligible(target=NOW + timedelta(minutes=90), prep_time="PT30M")
+    assert not automatic_start_is_eligible(policy="prep_only", prep_time="")
+    assert not automatic_start_is_eligible(policy="prep_plus_cook", cook_time="PT0M")
+    assert not automatic_start_is_eligible(policy="total_time", prep_time="", cook_time="", total_time="PT0M")
+    assert not automatic_start_is_eligible(target=NOW + timedelta(minutes=90), total_time="PT30M")
     assert not automatic_start_is_eligible(target=NOW)
 
 

--- a/tests/test_meal_prep_target_policy.py
+++ b/tests/test_meal_prep_target_policy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import yaml
+from jinja2 import Environment
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -105,3 +106,27 @@ def test_mealie_mapping_and_dashboard_surface_resolved_target_source_without_wri
     assert "POST" not in mealie and "PUT" not in mealie and "PATCH" not in mealie and "DELETE" not in mealie
     assert "Target-time source:" in dashboard
     assert "attribute: source" in dashboard
+
+
+def test_lead_time_policy_defaults_to_total_time_and_exposes_safe_start_calculation():
+    policy = yaml.safe_load(POLICY.read_text())
+    selector = policy["input_select"]["meal_prep_automatic_lead_time_policy"]
+    start = next(
+        item
+        for block in policy["template"]
+        for item in block["sensor"]
+        if item["name"] == "Meal Prep Automatic Start Time"
+    )
+    text = POLICY.read_text()
+
+    assert selector["options"] == ["total_time", "prep_plus_cook", "prep_only"]
+    assert "Dinner-ready lead-time policy defaults to `total_time`" in text
+    assert "regex_match('^PT(?:[0-9]+H)?(?:[0-9]+M)?$')" in start["state"]
+    assert "prep_plus_cook_fallback" in start["attributes"]["duration_source"]
+    assert "total is never added" in text
+    for duration in ("prep_time", "cook_time", "total_time"):
+        assert f"input_text.meal_prep_recipe_{duration}" in text
+    environment = Environment()
+    environment.parse(start["state"])
+    environment.parse(start["attributes"]["policy"])
+    environment.parse(start["attributes"]["duration_source"])

--- a/tests/test_mealie_read_only_path.py
+++ b/tests/test_mealie_read_only_path.py
@@ -260,6 +260,13 @@ def test_normalized_recipe_output_is_bounded_and_populates_helper_seams():
 
     assert helpers["meal_prep_recipe_summary"]["max"] == 160
     assert helpers["meal_prep_ingredient_context"]["max"] == 255
+    for helper in (
+        "meal_prep_recipe_prep_time",
+        "meal_prep_recipe_cook_time",
+        "meal_prep_recipe_total_time",
+    ):
+        assert helpers[helper]["max"] == 40
+        assert f"input_text.{helper}" in text
     assert "input_text.meal_prep_recipe_summary" in text
     assert "input_text.meal_prep_ingredient_context" in text
     assert "[:6]" in text


### PR DESCRIPTION
## Summary
- Adds a restored, selectable Kitchen Prep dinner-ready policy: total time (default), prep plus cook, or prep only.
- Computes and displays a fail-closed automatic start time; total-time falls back only to valid prep-plus-cook and never double-counts.
- Maps all verified Mealie timing fields and retains the existing date+recipe, presence, guest, snooze, no-write, and exact-once safeguards.

## Validation
- ...............................................                          [100%]
47 passed in 6.37s (47 passed)
- ........................................................................ [ 41%]
........................................................................ [ 83%]
.............................                                            [100%]
173 passed in 12.49s (173 passed)
- 
- Confirmed active GitHub Check workflow configuration.

## Documentation impact
- Updated root and Kitchen Prep package documentation for the policy, fallback behavior, duration forms, operator control, and dashboard presentation.

Closes #225