### PR TITLE
feat(kitchen): add opt-in Mealie made-this write-back

### DIFF
--- a/dashboards/kitchen_prep.yaml
+++ b/dashboards/kitchen_prep.yaml
@@ -151,6 +151,16 @@ views:
               action: perform-action
               perform_action: script.meal_prep_finish_for_today
           - type: button
+            name: "Mark made in Mealie"
+            icon: mdi:cloud-check-outline
+            tap_action:
+              action: perform-action
+              perform_action: script.meal_prep_mark_made_in_mealie
+              data:
+                confirm: true
+              confirmation:
+                text: "Set this linked recipe's Last made timestamp in Mealie? Finish today stays local-only."
+          - type: button
             name: "Show display"
             icon: mdi:cast-connected
             tap_action:
@@ -187,6 +197,12 @@ views:
             name: "Target-time source"
           - entity: input_select.meal_prep_automatic_lead_time_policy
             name: "Dinner-ready policy"
+          - entity: input_boolean.meal_prep_mealie_writeback_enabled
+            name: "Enable Mealie made-this write-back"
+          - entity: input_text.meal_prep_mealie_write_status
+            name: "Mealie write-back status"
+          - entity: input_text.meal_prep_mealie_write_reason
+            name: "Mealie write-back result"
           - entity: sensor.meal_prep_automatic_start_time
             name: "Automatic start"
           - type: attribute

--- a/packages/README.md
+++ b/packages/README.md
@@ -81,6 +81,9 @@ inventing meal or instruction content.
 | `input_text.meal_prep_remaining_steps` | Meal Prep Remaining Steps | Bounded escaped-delimiter source queue after the current/next steps, used only for deterministic manual advancement. | Restored; no `initial` is set. |
 | `input_text.meal_prep_recipe_prep_time`, `input_text.meal_prep_recipe_cook_time`, `input_text.meal_prep_recipe_total_time` | Meal Prep Recipe Timing Inputs | Raw Mealie `prepTime`, `cookTime`, and `totalTime` durations for automatic lead-time calculation. | Restored; no `initial` is set. |
 | `input_text.meal_prep_automatic_handled_key` | Meal Prep Automatic Handled Key | Date + recipe identity manually or automatically claimed to prevent repeat automatic starts/Casts. | Restored; no `initial` is set. |
+| `input_boolean.meal_prep_mealie_writeback_enabled` | Enable Mealie made-this write-back | Explicit opt-in for the separate confirmed Mealie last-made PATCH. Defaults off when no state is restored. | Restored; off without a prior state. |
+| `input_text.meal_prep_mealie_marked_key`, `input_text.meal_prep_mealie_write_pending_key`, `input_text.meal_prep_mealie_write_pending_timestamp` | Mealie write identity | Local stable identity and timestamp used to prevent duplicates and make an unknown-outcome retry send the same PATCH body. | Restored; no `initial` is set. |
+| `input_text.meal_prep_mealie_write_status`, `input_text.meal_prep_mealie_write_reason` | Mealie write-back result | Bounded local success/failure result only; never stores a Mealie payload, URL, or credential. | Restored; no `initial` is set. |
 | `input_text.meal_prep_source_status` | Meal Prep Source Status Input | Future normalizer's raw status seam. | Restored; no `initial` is set. |
 | `input_text.meal_prep_meal_title`, `input_text.meal_prep_meal_type` | Meal Prep Meal Title/Type Input | Raw meal-identity seams. | Restored; no `initial` is set. |
 | `input_text.meal_prep_recipe_reference`, `input_text.meal_prep_recipe_url` | Meal Prep Recipe Reference/URL Input | Raw recipe seams. | Restored; no `initial` is set. |
@@ -115,6 +118,7 @@ refresh, notification, or inferred cooking transition.
 | `script.meal_prep_skip_current_step` | Records the skipped current step, promotes a valid next step when one exists, and never sets the completion flag or fabricates a later step. |
 | `script.meal_prep_snooze_preparation` | Requires an active matching fresh session and writes an ISO deadline bounded to 5–60 minutes (dashboard default: 30). |
 | `script.meal_prep_finish_for_today` | Stops the active matching session, clears its snooze, and sets its restored done flag; a different date/recipe identity does not inherit completion. |
+| `script.meal_prep_mark_made_in_mealie` | Separate, disabled-by-default Mealie write. It requires the dashboard's confirmation and a fresh UUID-linked recipe, then PATCHes only that recipe's `last-made` timestamp. It never runs from Start or Finish today; local identity/timestamp state blocks duplicates and makes unknown-outcome retries safe. |
 | `script.meal_prep_show_dashboard` | Statically configures `cast.show_lovelace_view` for `media_player.kitchen_display` and the registered `kitchen-prep` view; repository validation does not call it. |
 | `script.meal_prep_clear_session` | Clears only local session flags/audit state, never the Mealie snapshot. |
 
@@ -155,7 +159,38 @@ display-off automation.
 one bounded today-to-seven-day range only when today is empty, and one linked
 recipe request for the selected entry. It refreshes at Home Assistant startup
 and every 15 minutes (a 15-minute cadence); the single automation mode prevents
-overlapping API calls. No meal, recipe, shopping, or food write endpoint is configured.
+overlapping API calls. No meal, recipe, shopping, or food write endpoint is configured by the
+refresh automation.
+
+### Optional confirmed Mealie made-this write-back
+
+The separate `script.meal_prep_mark_made_in_mealie` is the only Kitchen Prep
+write path. It is disabled by default through
+`input_boolean.meal_prep_mealie_writeback_enabled`; `Finish today`, Start, the
+15-minute refresh, and automatic orchestration remain local/read-only. When an
+operator enables the toggle, the dashboard's **Mark made in Mealie** button
+still presents a confirmation dialog and sends `confirm: true` to the script.
+
+The verified Mealie `mealie-next` contract (upstream commit
+`23603cc218f04d8cebfbf99d19d9877c69cb95dd`, 2026-07-24) is
+`PATCH /api/recipes/{slug}/last-made` with JSON `{"timestamp":"<ISO-8601>"}`.
+The Kitchen Prep adapter accepts only a fresh UUID-linked recipe and verifies a
+200 JSON recipe response with the same ID before recording local success. This
+changes only Mealie's linked recipe **Last made** timestamp; it does not create
+a meal plan, timeline event, shopping entry, or any Home Assistant completion
+state.
+
+Before enabling it, add `mealie_mark_made_url` to `secrets.yaml` as the full
+`/api/recipes/{{ mealie_recipe_id }}/last-made` URL. Do not commit or display
+that URL, its authorization header, request payload, or response. The script
+persists the date+recipe identity and a single ISO timestamp before the PATCH:
+a successful identity prevents duplicate writes, while a timeout or transport
+failure leaves the identity unmarked so a retry sends the exact same timestamp.
+Unauthorized, duplicate, malformed, unavailable, timeout, transport, and
+unsupported-endpoint responses fail closed and store only a bounded local
+status/reason. To disable the feature immediately, turn off
+`input_boolean.meal_prep_mealie_writeback_enabled`; no restart or reload is
+needed.
 
 Before deploying, the operator must add these values to the existing Home
 Assistant `secrets.yaml` (never commit that file):
@@ -166,6 +201,8 @@ Assistant `secrets.yaml` (never commit that file):
   `{{ mealie_range_start }}` and `{{ mealie_range_end }}` placeholders.
 - `mealie_recipe_url`: the full recipe URL containing literal
   `{{ mealie_recipe_id }}`.
+- `mealie_mark_made_url`: only when enabling optional write-back, the full
+  `/api/recipes/{{ mealie_recipe_id }}/last-made` URL.
 
 The adapter passes those values as explicit `rest_command` service data when it
 calls the range and recipe endpoints. Do not rely on automation-local variables

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -31,6 +31,12 @@ input_boolean:
     name: "Meal Prep Complete"
     icon: mdi:check-circle-outline
 
+  # This is off unless an operator explicitly enables the supported Mealie
+  # last-made write-back. Finish today always remains local-only.
+  meal_prep_mealie_writeback_enabled:
+    name: "Enable Mealie made-this write-back"
+    icon: mdi:cloud-sync-outline
+
 input_datetime:
   meal_prep_target_time:
     name: "Meal Prep Target Time"
@@ -132,6 +138,34 @@ input_text:
   meal_prep_automatic_handled_key:
     name: "Meal Prep Automatic Handled Key"
     icon: mdi:shield-check-outline
+    max: 255
+
+  # Local, bounded write-back audit seams. The pending identity/timestamp make a
+  # retry use the exact same PATCH body after a timeout or transport failure.
+  # No response body, URL, or credential is ever stored here.
+  meal_prep_mealie_marked_key:
+    name: "Meal Prep Mealie Marked Key"
+    icon: mdi:cloud-check-outline
+    max: 255
+
+  meal_prep_mealie_write_pending_key:
+    name: "Meal Prep Mealie Write Pending Key"
+    icon: mdi:key-clock
+    max: 255
+
+  meal_prep_mealie_write_pending_timestamp:
+    name: "Meal Prep Mealie Write Pending Timestamp"
+    icon: mdi:clock-check-outline
+    max: 40
+
+  meal_prep_mealie_write_status:
+    name: "Meal Prep Mealie Write Status"
+    icon: mdi:cloud-alert-outline
+    max: 32
+
+  meal_prep_mealie_write_reason:
+    name: "Meal Prep Mealie Write Reason"
+    icon: mdi:information-outline
     max: 255
 
   meal_prep_last_skipped_step:
@@ -360,6 +394,199 @@ script:
           entity_id: input_text.meal_prep_automatic_handled_key
         data:
           value: "{{ meal_prep_identity }}"
+
+  meal_prep_mark_made_in_mealie:
+    alias: "Kitchen Prep: Mark made in Mealie"
+    description: >
+      Explicitly set the linked recipe's Mealie last-made timestamp. This is
+      disabled by default, requires dashboard confirmation, and never runs from
+      Start or Finish today. A stable meal identity and timestamp make retries
+      safe after an unknown transport outcome.
+    mode: single
+    fields:
+      confirm:
+        name: "Confirm Mealie write-back"
+        description: "Must be explicitly true; the dashboard also shows a confirmation dialog."
+        required: true
+        selector:
+          boolean:
+    sequence:
+      - variables:
+          recipe_reference: "{{ states('sensor.meal_prep_recipe_reference') }}"
+      - variables:
+          meal_prep_identity: "{{ now().date().isoformat() ~ '|' ~ recipe_reference }}"
+      - choose:
+          - conditions: "{{ not is_state('input_boolean.meal_prep_mealie_writeback_enabled', 'on') }}"
+            sequence:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_status
+                data:
+                  value: disabled
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_reason
+                data:
+                  value: "Mealie write-back is disabled"
+          - conditions: >
+              {{ not (recipe_reference | regex_match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$')) or
+                 states('sensor.meal_prep_source_status') != 'ready' or
+                 states('sensor.meal_prep_meal') in ['none', 'unavailable', 'unknown'] }}
+            sequence:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_status
+                data:
+                  value: invalid
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_reason
+                data:
+                  value: "Mealie write-back requires a fresh linked recipe"
+          - conditions: "{{ confirm | default(false) | bool == false }}"
+            sequence:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_status
+                data:
+                  value: unconfirmed
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_reason
+                data:
+                  value: "Mealie write-back was not confirmed"
+          - conditions: "{{ states('input_text.meal_prep_mealie_marked_key') == meal_prep_identity }}"
+            sequence:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_status
+                data:
+                  value: duplicate
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_reason
+                data:
+                  value: "This recipe is already marked made for today"
+        default:
+          - choose:
+              - conditions: >
+                  {{ states('input_text.meal_prep_mealie_write_pending_key') != meal_prep_identity or
+                     as_timestamp(states('input_text.meal_prep_mealie_write_pending_timestamp'), default=none) is none }}
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_pending_key
+                    data:
+                      value: "{{ meal_prep_identity }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_pending_timestamp
+                    data:
+                      value: "{{ now().isoformat() }}"
+          - variables:
+              mealie_made_timestamp: >
+                {% set pending_timestamp = states('input_text.meal_prep_mealie_write_pending_timestamp') %}
+                {{ pending_timestamp if states('input_text.meal_prep_mealie_write_pending_key') == meal_prep_identity and as_timestamp(pending_timestamp, default=none) is not none else now().isoformat() }}
+          - action: rest_command.mealie_mark_made
+            data:
+              mealie_recipe_id: "{{ recipe_reference }}"
+              mealie_made_timestamp: "{{ mealie_made_timestamp }}"
+            response_variable: mealie_write_response
+            continue_on_error: true
+          - variables:
+              mealie_write_status: "{{ mealie_write_response.status | default(0, true) | int(0) }}"
+              mealie_write_content: "{{ mealie_write_response.content | default({}, true) }}"
+          - choose:
+              - conditions: >
+                  {{ mealie_write_status == 200 and mealie_write_content is mapping and
+                     (mealie_write_content.id | default('', true) | string | lower | trim) == (recipe_reference | lower) }}
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_marked_key
+                    data:
+                      value: "{{ meal_prep_identity }}"
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_status
+                    data:
+                      value: success
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_reason
+                    data:
+                      value: "Marked made in Mealie"
+              - conditions: "{{ mealie_write_status in [401, 403] }}"
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_status
+                    data:
+                      value: unauthorized
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_reason
+                    data:
+                      value: "Mealie write-back was not authorized"
+              - conditions: "{{ mealie_write_status == 409 }}"
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_status
+                    data:
+                      value: duplicate
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_reason
+                    data:
+                      value: "Mealie rejected the write as a duplicate"
+              - conditions: "{{ mealie_write_status in [404, 405, 501] }}"
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_status
+                    data:
+                      value: unsupported
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_reason
+                    data:
+                      value: "Mealie write-back endpoint is unavailable"
+              - conditions: "{{ mealie_write_status in [408, 504] }}"
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_status
+                    data:
+                      value: timeout
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_reason
+                    data:
+                      value: "Mealie write-back timed out; retry is safe"
+              - conditions: "{{ mealie_write_status == 0 }}"
+                sequence:
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_status
+                    data:
+                      value: unavailable
+                  - action: input_text.set_value
+                    target:
+                      entity_id: input_text.meal_prep_mealie_write_reason
+                    data:
+                      value: "Mealie write-back was unavailable; retry is safe"
+            default:
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_status
+                data:
+                  value: failed
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.meal_prep_mealie_write_reason
+                data:
+                  value: "Mealie write-back response was malformed or unsuccessful"
 
   meal_prep_show_dashboard:
     alias: "Kitchen Prep: Show dashboard"

--- a/packages/mealie_read_only.yaml
+++ b/packages/mealie_read_only.yaml
@@ -1,8 +1,10 @@
 # packages/mealie_read_only.yaml
 #
-# Read-only Mealie adapter for the Kitchen Prep state model. All endpoints are
-# GET-only. URLs and the complete Authorization header stay in secrets.yaml;
+# Read-only Mealie adapter for the Kitchen Prep state model. Its refresh endpoints
+# are GET-only. URLs and the complete Authorization header stay in secrets.yaml;
 # never add a token, header value, or response payload to this repository.
+# The sole exception is the separately enabled, confirmed Kitchen Prep
+# `mealie_mark_made` script, which uses the verified PATCH last-made endpoint.
 #
 # The refresh runs at startup and every 15 minutes. It requests today's plan,
 # then one bounded today-to-+7-day range only when today has no entries. Recipe
@@ -15,7 +17,7 @@ rest_command:
     url: !secret mealie_today_url
     method: GET
     timeout: 15
-    headers:
+    headers: &mealie_read_headers
       Authorization: !secret mealie_authorization_header
       Accept: application/json
 
@@ -35,9 +37,18 @@ rest_command:
     url: !secret mealie_recipe_url
     method: GET
     timeout: 15
+    headers: *mealie_read_headers
+
+  mealie_mark_made:
+    # The explicit Kitchen Prep script supplies mealie_recipe_id and a stable
+    # retry timestamp. This is never called by refresh, Start, or Finish today.
+    url: !secret mealie_mark_made_url
+    method: PATCH
+    timeout: 15
     headers:
-      Authorization: !secret mealie_authorization_header
-      Accept: application/json
+      <<: *mealie_read_headers
+      Content-Type: application/json
+    payload: '{"timestamp":"{{ mealie_made_timestamp }}"}'
 
 automation:
   - alias: "Refresh Meal Prep from Mealie"

--- a/tests/test_kitchen_prep_dashboard.py
+++ b/tests/test_kitchen_prep_dashboard.py
@@ -65,7 +65,10 @@ def test_kitchen_prep_dashboard_presents_only_real_state_and_control_seams():
     assert dashboard["views"][0]["path"] == "kitchen-prep"
     assert dashboard["views"][0]["badges"] == []
     assert refs == {
+        "input_boolean.meal_prep_mealie_writeback_enabled",
         "input_select.meal_prep_automatic_lead_time_policy",
+        "input_text.meal_prep_mealie_write_reason",
+        "input_text.meal_prep_mealie_write_status",
         "sensor.meal_prep_automatic_start_time",
         "sensor.meal_prep_source_status",
         "sensor.meal_prep_session_state",
@@ -91,6 +94,7 @@ def test_kitchen_prep_dashboard_presents_only_real_state_and_control_seams():
         "script.meal_prep_skip_current_step",
         "script.meal_prep_snooze_preparation",
         "script.meal_prep_finish_for_today",
+        "script.meal_prep_mark_made_in_mealie",
         "script.meal_prep_show_dashboard",
         "script.meal_prep_clear_session",
     ):
@@ -157,6 +161,7 @@ def test_kitchen_prep_dashboard_buttons_call_only_real_manual_script_services():
         "Skip",
         "Snooze 30 min",
         "Finish today",
+        "Mark made in Mealie",
         "Show display",
         "Clear session",
     ]
@@ -170,6 +175,14 @@ def test_kitchen_prep_dashboard_buttons_call_only_real_manual_script_services():
             "data": {"snooze_minutes": 30},
         },
         {"action": "perform-action", "perform_action": "script.meal_prep_finish_for_today"},
+        {
+            "action": "perform-action",
+            "perform_action": "script.meal_prep_mark_made_in_mealie",
+            "data": {"confirm": True},
+            "confirmation": {
+                "text": "Set this linked recipe's Last made timestamp in Mealie? Finish today stays local-only."
+            },
+        },
         {"action": "perform-action", "perform_action": "script.meal_prep_show_dashboard"},
         {"action": "perform-action", "perform_action": "script.meal_prep_clear_session"},
     ]

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -85,6 +85,7 @@ def test_all_required_manual_control_scripts_are_stable_and_non_automatic():
         "meal_prep_skip_current_step",
         "meal_prep_snooze_preparation",
         "meal_prep_finish_for_today",
+        "meal_prep_mark_made_in_mealie",
         "meal_prep_show_dashboard",
         "meal_prep_clear_session",
     }

--- a/tests/test_meal_prep_orchestration.py
+++ b/tests/test_meal_prep_orchestration.py
@@ -212,7 +212,7 @@ def test_cleanup_covers_restart_rollover_away_and_stale_without_display_or_extra
     assert "kitchen occupancy" not in text.lower()
 
 
-def test_mealie_prep_time_is_bounded_source_data_and_no_write_endpoint_was_added():
+def test_mealie_prep_time_is_bounded_source_data_and_refresh_stays_get_only():
     mealie = load_yaml(MEALIE)
     helpers = load_yaml(STATE_MODEL)["input_text"]
     text = MEALIE.read_text()
@@ -220,6 +220,12 @@ def test_mealie_prep_time_is_bounded_source_data_and_no_write_endpoint_was_added
     assert helpers["meal_prep_recipe_prep_time"]["max"] == 40
     assert "input_text.meal_prep_recipe_prep_time" in text
     assert "mealie_recipe.prepTime" in text
-    assert all(command["method"] == "GET" for command in mealie["rest_command"].values())
-    for forbidden in ("POST", "PUT", "PATCH", "DELETE"):
+    assert all(
+        command["method"] == "GET"
+        for name, command in mealie["rest_command"].items()
+        if name != "mealie_mark_made"
+    )
+    assert mealie["rest_command"]["mealie_mark_made"]["method"] == "PATCH"
+    assert "rest_command.mealie_mark_made" not in str(mealie["automation"])
+    for forbidden in ("POST", "PUT", "DELETE"):
         assert forbidden not in text

--- a/tests/test_meal_prep_target_policy.py
+++ b/tests/test_meal_prep_target_policy.py
@@ -95,7 +95,7 @@ def test_timezone_conversion_and_date_rollover_use_local_meal_date_identity():
     )[1] == "none"
 
 
-def test_mealie_mapping_and_dashboard_surface_resolved_target_source_without_writes():
+def test_mealie_mapping_and_dashboard_surface_resolved_target_source_with_only_explicit_writeback():
     mealie = MEALIE.read_text()
     dashboard = DASHBOARD.read_text()
 
@@ -103,7 +103,9 @@ def test_mealie_mapping_and_dashboard_surface_resolved_target_source_without_wri
     assert "mealie_scheduled_time" in mealie
     assert "timezone-less timestamp is rejected" in mealie
     assert "input_text.meal_prep_source_scheduled_time" in mealie
-    assert "POST" not in mealie and "PUT" not in mealie and "PATCH" not in mealie and "DELETE" not in mealie
+    assert "POST" not in mealie and "PUT" not in mealie and "DELETE" not in mealie
+    assert mealie.count("method: PATCH") == 1
+    assert "mealie_mark_made" in mealie
     assert "Target-time source:" in dashboard
     assert "attribute: source" in dashboard
 

--- a/tests/test_mealie_read_only_path.py
+++ b/tests/test_mealie_read_only_path.py
@@ -58,7 +58,7 @@ def variable_value(actions, name, matching_text=None):
     return None
 
 
-def test_mealie_read_path_has_only_bounded_get_requests_with_secret_backed_wiring():
+def test_mealie_adapter_uses_bounded_get_requests_and_one_explicit_secret_backed_write_command():
     package = load_yaml(PACKAGE)
     commands = package["rest_command"]
 
@@ -66,12 +66,25 @@ def test_mealie_read_path_has_only_bounded_get_requests_with_secret_backed_wirin
         "mealie_get_today",
         "mealie_get_range",
         "mealie_get_recipe",
+        "mealie_mark_made",
     }
-    for command in commands.values():
+    for name in ("mealie_get_today", "mealie_get_range", "mealie_get_recipe"):
+        command = commands[name]
         assert command["method"] == "GET"
         assert command["timeout"] == 15
         assert command["headers"]["Authorization"] == "!secret mealie_authorization_header"
         assert command["headers"]["Accept"] == "application/json"
+
+    write = commands["mealie_mark_made"]
+    assert write["url"] == "!secret mealie_mark_made_url"
+    assert write["method"] == "PATCH"
+    assert write["timeout"] == 15
+    assert write["headers"] == {
+        "Authorization": "!secret mealie_authorization_header",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    assert write["payload"] == '{"timestamp":"{{ mealie_made_timestamp }}"}'
 
     assert commands["mealie_get_today"]["url"] == "!secret mealie_today_url"
     assert commands["mealie_get_range"]["url"] == "!secret mealie_range_url"
@@ -80,10 +93,12 @@ def test_mealie_read_path_has_only_bounded_get_requests_with_secret_backed_wirin
     package_text = PACKAGE.read_text()
     assert "POST" not in package_text
     assert "PUT" not in package_text
-    assert "PATCH" not in package_text
     assert "DELETE" not in package_text
     assert "Bearer " not in package_text
     assert "mealie_authorization_header" in package_text
+    assert "rest_command.mealie_mark_made" not in automation_by_alias(
+        package, "Refresh Meal Prep from Mealie"
+    )["action"].__str__()
 
 
 def test_dynamic_rest_command_urls_receive_explicit_nonempty_service_data():

--- a/tests/test_mealie_writeback.py
+++ b/tests/test_mealie_writeback.py
@@ -1,0 +1,260 @@
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment
+from jinja2.nativetypes import NativeEnvironment
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MEAL_PREP = ROOT / "packages" / "meal_prep.yaml"
+MEALIE = ROOT / "packages" / "mealie_read_only.yaml"
+DASHBOARD = ROOT / "dashboards" / "kitchen_prep.yaml"
+PACKAGE_README = ROOT / "packages" / "README.md"
+
+
+VALID_RECIPE_ID = "42b5c097-3900-4d27-a0d2-832cb3c3dc36"
+IDENTITY = f"2026-07-24|{VALID_RECIPE_ID}"
+TIMESTAMP = "2026-07-24T18:30:00+00:00"
+
+
+def load_yaml(path):
+    class SecretLoader(yaml.SafeLoader):
+        pass
+
+    SecretLoader.add_constructor(
+        "!secret", lambda loader, node: f"!secret {loader.construct_scalar(node)}"
+    )
+    return yaml.load(path.read_text(), Loader=SecretLoader)
+
+
+def script_services(node):
+    services = []
+
+    if isinstance(node, dict):
+        if "action" in node:
+            services.append(node["action"])
+        for value in node.values():
+            services.extend(script_services(value))
+    elif isinstance(node, list):
+        for item in node:
+            services.extend(script_services(item))
+    return services
+
+
+def condition_templates(node):
+    templates = []
+
+    if isinstance(node, dict):
+        if "conditions" in node:
+            templates.append(node["conditions"])
+        for value in node.values():
+            templates.extend(condition_templates(value))
+    elif isinstance(node, list):
+        for item in node:
+            templates.extend(condition_templates(item))
+    return templates
+
+
+def sequence_for_condition(node, condition):
+    if isinstance(node, dict):
+        for choice in node.get("choose", []):
+            if choice.get("conditions") == condition:
+                return choice["sequence"]
+        for value in node.values():
+            found = sequence_for_condition(value, condition)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = sequence_for_condition(item, condition)
+            if found is not None:
+                return found
+    return None
+
+
+def set_values(sequence):
+    return [
+        action["data"]["value"]
+        for action in sequence
+        if action.get("action") == "input_text.set_value"
+    ]
+
+
+def render(template, **context):
+    environment = Environment(trim_blocks=True, lstrip_blocks=True)
+    environment.globals["is_state"] = context.pop("is_state")
+    environment.globals["states"] = context.pop("states")
+    return environment.from_string(template).render(**context).strip()
+
+
+def test_writeback_is_disabled_by_default_and_finish_today_stays_local_only():
+    package = load_yaml(MEAL_PREP)
+    script = package["script"]["meal_prep_mark_made_in_mealie"]
+    finish = package["script"]["meal_prep_finish_for_today"]
+
+    assert "initial" not in package["input_boolean"]["meal_prep_mealie_writeback_enabled"]
+    assert script["mode"] == "single"
+    assert script["fields"]["confirm"]["required"] is True
+    assert "rest_command" not in str(finish["sequence"])
+    assert "mealie_mark_made" not in str(finish["sequence"])
+
+    disabled_condition = next(
+        condition
+        for condition in condition_templates(script["sequence"])
+        if "meal_prep_mealie_writeback_enabled" in condition
+    )
+    assert render(
+        disabled_condition,
+        is_state=lambda entity_id, state: entity_id.endswith("writeback_enabled")
+        and state == "on"
+        and False,
+        states=lambda _: "",
+    ) == "True"
+    assert set_values(sequence_for_condition(script["sequence"], disabled_condition)) == [
+        "disabled",
+        "Mealie write-back is disabled",
+    ]
+
+
+def test_writeback_uses_verified_patch_contract_only_from_the_explicit_script():
+    mealie = load_yaml(MEALIE)
+    script = load_yaml(MEAL_PREP)["script"]["meal_prep_mark_made_in_mealie"]
+    command = mealie["rest_command"]["mealie_mark_made"]
+
+    assert command["method"] == "PATCH"
+    assert command["url"] == "!secret mealie_mark_made_url"
+    assert command["payload"] == '{"timestamp":"{{ mealie_made_timestamp }}"}'
+    assert command["headers"]["Content-Type"] == "application/json"
+    assert script_services(script["sequence"]).count("rest_command.mealie_mark_made") == 1
+    assert "rest_command.mealie_mark_made" not in str(
+        next(
+            automation
+            for automation in mealie["automation"]
+            if automation["alias"] == "Refresh Meal Prep from Mealie"
+        )["action"]
+    )
+
+
+def test_valid_success_requires_matching_recipe_response_and_records_only_bounded_state():
+    package = load_yaml(MEAL_PREP)
+    script = package["script"]["meal_prep_mark_made_in_mealie"]
+    success_condition = next(
+        condition
+        for condition in condition_templates(script["sequence"])
+        if "mealie_write_status == 200" in condition
+    )
+    environment = NativeEnvironment(trim_blocks=True, lstrip_blocks=True)
+    rendered = environment.from_string(success_condition).render(
+        mealie_write_status=200,
+        mealie_write_content={"id": VALID_RECIPE_ID},
+        recipe_reference=VALID_RECIPE_ID,
+    )
+    wrong_recipe = environment.from_string(success_condition).render(
+        mealie_write_status=200,
+        mealie_write_content={"id": "00000000-0000-4000-8000-000000000000"},
+        recipe_reference=VALID_RECIPE_ID,
+    )
+
+    assert rendered is True
+    assert wrong_recipe is False
+    assert set_values(sequence_for_condition(script["sequence"], success_condition)) == [
+        "{{ meal_prep_identity }}",
+        "success",
+        "Marked made in Mealie",
+    ]
+    assert "mealie_write_content" not in str(package["input_text"])
+    assert "mealie_mark_made_url" not in str(package["input_text"])
+
+
+def test_retry_reuses_stable_pending_identity_and_timestamp_before_the_patch():
+    script = load_yaml(MEAL_PREP)["script"]["meal_prep_mark_made_in_mealie"]
+    text = str(script["sequence"])
+    services = script_services(script["sequence"])
+
+    assert "meal_prep_mealie_write_pending_key" in text
+    assert "meal_prep_mealie_write_pending_timestamp" in text
+    assert "mealie_made_timestamp" in text
+    assert "states('input_text.meal_prep_mealie_write_pending_key') == meal_prep_identity" in text
+    assert services.index("rest_command.mealie_mark_made") > services.index(
+        "input_text.set_value"
+    )
+
+
+def test_duplicate_and_failure_paths_fail_closed_without_marking_success():
+    script = load_yaml(MEAL_PREP)["script"]["meal_prep_mark_made_in_mealie"]
+    conditions = condition_templates(script["sequence"])
+
+    expected = {
+        "{{ states('input_text.meal_prep_mealie_marked_key') == meal_prep_identity }}": (
+            "duplicate",
+            "This recipe is already marked made for today",
+        ),
+        "{{ mealie_write_status in [401, 403] }}": (
+            "unauthorized",
+            "Mealie write-back was not authorized",
+        ),
+        "{{ mealie_write_status == 409 }}": (
+            "duplicate",
+            "Mealie rejected the write as a duplicate",
+        ),
+        "{{ mealie_write_status in [404, 405, 501] }}": (
+            "unsupported",
+            "Mealie write-back endpoint is unavailable",
+        ),
+        "{{ mealie_write_status in [408, 504] }}": (
+            "timeout",
+            "Mealie write-back timed out; retry is safe",
+        ),
+        "{{ mealie_write_status == 0 }}": (
+            "unavailable",
+            "Mealie write-back was unavailable; retry is safe",
+        ),
+    }
+
+    for condition, values in expected.items():
+        assert condition in conditions
+        assert tuple(set_values(sequence_for_condition(script["sequence"], condition))) == values
+
+    assert "failed" in str(script["sequence"])
+    assert "Mealie write-back response was malformed or unsuccessful" in str(script["sequence"])
+    assert "mealie_write_status == 200" in str(script["sequence"])
+
+
+def test_unconfirmed_or_malformed_requests_cannot_reach_the_patch_action():
+    script = load_yaml(MEAL_PREP)["script"]["meal_prep_mark_made_in_mealie"]
+    conditions = condition_templates(script["sequence"])
+
+    unconfirmed = "{{ confirm | default(false) | bool == false }}"
+    malformed = next(
+        condition for condition in conditions if "regex_match" in condition
+    )
+    assert set_values(sequence_for_condition(script["sequence"], unconfirmed)) == [
+        "unconfirmed",
+        "Mealie write-back was not confirmed",
+    ]
+    assert "[1-5]" in malformed
+    assert "sensor.meal_prep_source_status" in malformed
+    assert "fresh linked recipe" in str(sequence_for_condition(script["sequence"], malformed))
+
+
+def test_dashboard_requires_confirmation_and_documents_the_opt_in_and_disable_path():
+    dashboard = yaml.safe_load(DASHBOARD.read_text())
+    buttons = next(
+        card["cards"]
+        for card in dashboard["views"][0]["cards"]
+        if card.get("title") == "Preparation controls"
+    )
+    write_button = next(button for button in buttons if button["name"] == "Mark made in Mealie")
+    docs = PACKAGE_README.read_text()
+
+    assert write_button["tap_action"] == {
+        "action": "perform-action",
+        "perform_action": "script.meal_prep_mark_made_in_mealie",
+        "data": {"confirm": True},
+        "confirmation": {
+            "text": "Set this linked recipe's Last made timestamp in Mealie? Finish today stays local-only."
+        },
+    }
+    assert "input_boolean.meal_prep_mealie_writeback_enabled" in docs
+    assert "PATCH /api/recipes/{slug}/last-made" in docs
+    assert "To disable the feature immediately" in docs


### PR DESCRIPTION
## Summary
- add a default-off, explicitly confirmed Kitchen Prep path that PATCHes only the linked recipe Last made timestamp in Mealie
- preserve GET-only refresh and local-only Start / Finish today actions, with bounded local audit and retry state
- document the operator secret/setup and add dashboard controls plus contract coverage

## Validation
- `python3 -m pytest -q` (180 passed)
- `git diff --check`

Closes #226