### PR TITLE
fix(kitchen): sequence display wake before cast

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -119,7 +119,7 @@ refresh, notification, or inferred cooking transition.
 | `script.meal_prep_snooze_preparation` | Requires an active matching fresh session and writes an ISO deadline bounded to 5–60 minutes (dashboard default: 30). |
 | `script.meal_prep_finish_for_today` | Stops the active matching session, clears its snooze, and sets its restored done flag; a different date/recipe identity does not inherit completion. |
 | `script.meal_prep_mark_made_in_mealie` | Separate, disabled-by-default Mealie write. It requires the dashboard's confirmation and a fresh UUID-linked recipe, then PATCHes only that recipe's `last-made` timestamp. It never runs from Start or Finish today; local identity/timestamp state blocks duplicates and makes unknown-outcome retries safe. |
-| `script.meal_prep_show_dashboard` | Statically configures `cast.show_lovelace_view` for `media_player.kitchen_display` and the registered `kitchen-prep` view; repository validation does not call it. |
+| `script.meal_prep_show_dashboard` | When the kitchen display is off, wakes it and waits briefly for the receiver before calling `cast.show_lovelace_view` for the registered `kitchen-prep` view; repository validation does not call it. |
 | `script.meal_prep_clear_session` | Clears only local session flags/audit state, never the Mealie snapshot. |
 
 All scripts use `mode: single`, have no triggers, and fail closed on missing,
@@ -145,10 +145,11 @@ in no automatic start rather than guessing.
 
 The restored `input_text.meal_prep_automatic_handled_key` is set for both manual
 and automatic starts. It prevents refreshes, reloads, and restarts from repeating
-the same meal's Cast. The only automatic device action is
-`cast.show_lovelace_view` to `media_player.kitchen_display` with
-`dashboard_path` and `view_path` both `kitchen-prep`. It adds no lights,
-announcements, occupancy inference, or Mealie writes. Cleanup clears only local
+the same meal's Cast. The only automatic device action is the shared display script, which conditionally
+wakes `media_player.kitchen_display`, waits for its receiver to settle, then
+calls `cast.show_lovelace_view` with `dashboard_path` and `view_path` both
+`kitchen-prep`. It adds no lights, announcements, occupancy inference, or Mealie
+writes. Cleanup clears only local
 Kitchen Prep state for stale/invalid source, meal rollover, or everyone away
 outside guest mode; `presence_everyone_left` remains the authoritative
 display-off automation.

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -590,9 +590,24 @@ script:
 
   meal_prep_show_dashboard:
     alias: "Kitchen Prep: Show dashboard"
-    description: "Show the YAML-managed Kitchen Prep view on the kitchen display."
+    description: >
+      Wake the kitchen display when needed, allow its Cast receiver to settle,
+      then show the YAML-managed Kitchen Prep view.
     mode: single
     sequence:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: media_player.kitchen_display
+                state: "off"
+            sequence:
+              - action: media_player.turn_on
+                target:
+                  entity_id: media_player.kitchen_display
+              - wait_template: "{{ not is_state('media_player.kitchen_display', 'off') }}"
+                timeout: "00:00:15"
+                continue_on_timeout: false
+              - delay: "00:00:02"
       - action: cast.show_lovelace_view
         target:
           entity_id: media_player.kitchen_display

--- a/packages/meal_prep_orchestration.yaml
+++ b/packages/meal_prep_orchestration.yaml
@@ -77,12 +77,7 @@ automation:
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.meal_prep_active
-      - action: cast.show_lovelace_view
-        target:
-          entity_id: media_player.kitchen_display
-        data:
-          dashboard_path: kitchen-prep
-          view_path: kitchen-prep
+      - action: script.meal_prep_show_dashboard
 
   - alias: "Kitchen Prep: Clear invalid or rolled-over preparation session"
     id: "meal_prep_automatic_cleanup"

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -207,8 +207,31 @@ def test_finish_and_clear_are_local_persistent_state_transitions():
 def test_show_dashboard_targets_the_registered_kitchen_display_view():
     script = load_package()["script"]["meal_prep_show_dashboard"]
 
-    assert script_services(script) == ["cast.show_lovelace_view"]
-    action = script["sequence"][0]
+    wake_display = script["sequence"][0]
+    assert wake_display["choose"][0]["conditions"] == [
+        {
+            "condition": "state",
+            "entity_id": "media_player.kitchen_display",
+            "state": "off",
+        }
+    ]
+    wake_sequence = wake_display["choose"][0]["sequence"]
+    assert wake_sequence[0] == {
+        "action": "media_player.turn_on",
+        "target": {"entity_id": "media_player.kitchen_display"},
+    }
+    assert wake_sequence[1] == {
+        "wait_template": "{{ not is_state('media_player.kitchen_display', 'off') }}",
+        "timeout": "00:00:15",
+        "continue_on_timeout": False,
+    }
+    assert wake_sequence[2] == {"delay": "00:00:02"}
+
+    assert script_services(script) == [
+        "media_player.turn_on",
+        "cast.show_lovelace_view",
+    ]
+    action = script["sequence"][-1]
     assert action["target"]["entity_id"] == "media_player.kitchen_display"
     assert action["data"] == {
         "dashboard_path": "kitchen-prep",

--- a/tests/test_meal_prep_orchestration.py
+++ b/tests/test_meal_prep_orchestration.py
@@ -107,7 +107,7 @@ def automatic_start_is_eligible(
     )
 
 
-def test_automatic_start_has_bounded_triggers_and_exact_cast_payload():
+def test_automatic_start_has_bounded_triggers_and_reuses_the_display_script():
     automatic = automation_by_id(load_yaml(PACKAGE), "meal_prep_automatic_start")
     text = PACKAGE.read_text()
 
@@ -122,15 +122,9 @@ def test_automatic_start_has_bounded_triggers_and_exact_cast_payload():
         "input_text.set_value",
         "input_text.set_value",
         "input_boolean.turn_on",
-        "cast.show_lovelace_view",
+        "script.meal_prep_show_dashboard",
     ]
-    cast = automatic["action"][-1]
-    assert cast["target"]["entity_id"] == "media_player.kitchen_display"
-    assert cast["data"] == {
-        "dashboard_path": "kitchen-prep",
-        "view_path": "kitchen-prep",
-    }
-    assert automatic["action"][-1]["action"] == "cast.show_lovelace_view"
+    assert automatic["action"][-1] == {"action": "script.meal_prep_show_dashboard"}
     assert "homeassistant.turn_off" not in text
 
 


### PR DESCRIPTION
## Summary
- Wake the kitchen display only when it is off, wait for it to leave the off state, and allow a short Cast receiver settle interval before showing Kitchen Prep.
- Keep the verified `dashboard_path: kitchen-prep` / `view_path: kitchen-prep` contract and route automatic orchestration through the same tested display script.
- Add regression coverage for the wake/settle branch and shared automatic path.

## Validation
- `python -m pytest -q tests/test_meal_prep_controls.py tests/test_meal_prep_orchestration.py tests/test_kitchen_prep_dashboard.py` — 23 passed
- `python -m pytest -q` — 180 passed
- Home Assistant stable `hass -c /config --script check_config` with temporary dummy credentials — passed
- Parsed changed Kitchen Prep YAML and reviewed `git diff --check`

## Follow-up
A reviewer-gated post-merge live-verification card will confirm that the physical kitchen display renders the no-meal Kitchen Prep state rather than the Cast splash.

Fixes #232
