### PR TITLE
fix(kitchen): restore direct Cast dashboard action

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -119,7 +119,7 @@ refresh, notification, or inferred cooking transition.
 | `script.meal_prep_snooze_preparation` | Requires an active matching fresh session and writes an ISO deadline bounded to 5–60 minutes (dashboard default: 30). |
 | `script.meal_prep_finish_for_today` | Stops the active matching session, clears its snooze, and sets its restored done flag; a different date/recipe identity does not inherit completion. |
 | `script.meal_prep_mark_made_in_mealie` | Separate, disabled-by-default Mealie write. It requires the dashboard's confirmation and a fresh UUID-linked recipe, then PATCHes only that recipe's `last-made` timestamp. It never runs from Start or Finish today; local identity/timestamp state blocks duplicates and makes unknown-outcome retries safe. |
-| `script.meal_prep_show_dashboard` | When the kitchen display is off, wakes it and waits briefly for the receiver before calling `cast.show_lovelace_view` for the registered `kitchen-prep` view; repository validation does not call it. |
+| `script.meal_prep_show_dashboard` | Directly calls `cast.show_lovelace_view` for the registered `kitchen-prep` view, regardless of whether the receiver is already awake or off. Receiver wake/launch handling remains with the Cast integration; repository validation does not call it. |
 | `script.meal_prep_clear_session` | Clears only local session flags/audit state, never the Mealie snapshot. |
 
 All scripts use `mode: single`, have no triggers, and fail closed on missing,
@@ -145,11 +145,11 @@ in no automatic start rather than guessing.
 
 The restored `input_text.meal_prep_automatic_handled_key` is set for both manual
 and automatic starts. It prevents refreshes, reloads, and restarts from repeating
-the same meal's Cast. The only automatic device action is the shared display script, which conditionally
-wakes `media_player.kitchen_display`, waits for its receiver to settle, then
-calls `cast.show_lovelace_view` with `dashboard_path` and `view_path` both
-`kitchen-prep`. It adds no lights, announcements, occupancy inference, or Mealie
-writes. Cleanup clears only local
+the same meal's Cast. The only automatic device action is the shared display
+script, which directly calls `cast.show_lovelace_view` with `dashboard_path` and
+`view_path` both `kitchen-prep`; it makes no state-dependent wake or settle
+calls, so the same Cast request is used for already-awake and off receivers. It
+adds no lights, announcements, occupancy inference, or Mealie writes. Cleanup clears only local
 Kitchen Prep state for stale/invalid source, meal rollover, or everyone away
 outside guest mode; `presence_everyone_left` remains the authoritative
 display-off automation.

--- a/packages/meal_prep.yaml
+++ b/packages/meal_prep.yaml
@@ -591,23 +591,11 @@ script:
   meal_prep_show_dashboard:
     alias: "Kitchen Prep: Show dashboard"
     description: >
-      Wake the kitchen display when needed, allow its Cast receiver to settle,
-      then show the YAML-managed Kitchen Prep view.
+      Directly show the YAML-managed Kitchen Prep view on the kitchen display.
+      The Cast integration owns receiver wake/launch handling; pre-waking the
+      receiver can leave it on the Cast splash instead of rendering this view.
     mode: single
     sequence:
-      - choose:
-          - conditions:
-              - condition: state
-                entity_id: media_player.kitchen_display
-                state: "off"
-            sequence:
-              - action: media_player.turn_on
-                target:
-                  entity_id: media_player.kitchen_display
-              - wait_template: "{{ not is_state('media_player.kitchen_display', 'off') }}"
-                timeout: "00:00:15"
-                continue_on_timeout: false
-              - delay: "00:00:02"
       - action: cast.show_lovelace_view
         target:
           entity_id: media_player.kitchen_display

--- a/tests/test_meal_prep_controls.py
+++ b/tests/test_meal_prep_controls.py
@@ -207,31 +207,11 @@ def test_finish_and_clear_are_local_persistent_state_transitions():
 def test_show_dashboard_targets_the_registered_kitchen_display_view():
     script = load_package()["script"]["meal_prep_show_dashboard"]
 
-    wake_display = script["sequence"][0]
-    assert wake_display["choose"][0]["conditions"] == [
-        {
-            "condition": "state",
-            "entity_id": "media_player.kitchen_display",
-            "state": "off",
-        }
-    ]
-    wake_sequence = wake_display["choose"][0]["sequence"]
-    assert wake_sequence[0] == {
-        "action": "media_player.turn_on",
-        "target": {"entity_id": "media_player.kitchen_display"},
-    }
-    assert wake_sequence[1] == {
-        "wait_template": "{{ not is_state('media_player.kitchen_display', 'off') }}",
-        "timeout": "00:00:15",
-        "continue_on_timeout": False,
-    }
-    assert wake_sequence[2] == {"delay": "00:00:02"}
-
-    assert script_services(script) == [
-        "media_player.turn_on",
-        "cast.show_lovelace_view",
-    ]
-    action = script["sequence"][-1]
+    # The Cast action is deliberately state-agnostic: the integration handles
+    # either an already-awake or an off receiver without a pre-wake sequence.
+    assert script_services(script) == ["cast.show_lovelace_view"]
+    assert len(script["sequence"]) == 1
+    action = script["sequence"][0]
     assert action["target"]["entity_id"] == "media_player.kitchen_display"
     assert action["data"] == {
         "dashboard_path": "kitchen-prep",


### PR DESCRIPTION
## Summary
- Removes PR #233’s explicit `media_player.turn_on` / wait / delay sequence from the Kitchen Prep display script.
- Restores the previously working, state-agnostic direct `cast.show_lovelace_view` action for the registered `kitchen-prep` dashboard/view.
- Adds regression coverage that the script emits exactly that one Cast action and documents the no-pre-wake contract.

## Investigation
- The regression began after #233 added the wake/settle sequence. Live evidence shows that sequence leaves the receiver on the Home Assistant Cast splash even though the script succeeds.
- Home Assistant Core’s Cast service schema requires the Cast media-player target and `view_path`; it defines no required explicit wake or receiver-settle operation.
- The direct action is intentionally identical for an already-awake or off receiver, leaving receiver launch handling to the Cast integration.

## Validation
- `python -m pytest -q tests/test_meal_prep_controls.py tests/test_meal_prep_orchestration.py tests/test_kitchen_prep_dashboard.py` — 23 passed
- `python -m pytest -q` — 180 passed
- Parsed `packages/meal_prep.yaml`, `packages/meal_prep_orchestration.yaml`, and `dashboards/kitchen_prep.yaml` with PyYAML
- `git diff --check`

## Documentation impact
- Updated `packages/README.md` to document direct, state-agnostic Cast dispatch.

## Required post-merge verification
After reviewer merge, perform the authorised live smoke on both an already-awake receiver and an off receiver. Confirm the physical display renders Kitchen Prep (including its no-meal state where applicable), rather than only confirming service success or receiver state.

Refs #232