### PR TITLE
fix(kitchen): dispatch automatic Cast directly

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -145,11 +145,12 @@ in no automatic start rather than guessing.
 
 The restored `input_text.meal_prep_automatic_handled_key` is set for both manual
 and automatic starts. It prevents refreshes, reloads, and restarts from repeating
-the same meal's Cast. The only automatic device action is the shared display
-script, which directly calls `cast.show_lovelace_view` with `dashboard_path` and
-`view_path` both `kitchen-prep`; it makes no state-dependent wake or settle
-calls, so the same Cast request is used for already-awake and off receivers. It
-adds no lights, announcements, occupancy inference, or Mealie writes. Cleanup clears only local
+the same meal's Cast. Automatic orchestration directly calls
+`cast.show_lovelace_view` with `dashboard_path` and `view_path` both
+`kitchen-prep`, bypassing the display-script service wrapper. It makes no
+state-dependent wake or settle calls, so the same proven Cast request is used
+for already-awake and off receivers. It adds no lights, announcements, occupancy
+inference, or Mealie writes. Cleanup clears only local
 Kitchen Prep state for stale/invalid source, meal rollover, or everyone away
 outside guest mode; `presence_everyone_left` remains the authoritative
 display-off automation.

--- a/packages/meal_prep_orchestration.yaml
+++ b/packages/meal_prep_orchestration.yaml
@@ -77,7 +77,14 @@ automation:
       - action: input_boolean.turn_on
         target:
           entity_id: input_boolean.meal_prep_active
-      - action: script.meal_prep_show_dashboard
+      # Direct dispatch avoids the script-service wrapper. The same Cast payload
+      # has been proven to render on both already-awake and off receivers.
+      - action: cast.show_lovelace_view
+        target:
+          entity_id: media_player.kitchen_display
+        data:
+          dashboard_path: kitchen-prep
+          view_path: kitchen-prep
 
   - alias: "Kitchen Prep: Clear invalid or rolled-over preparation session"
     id: "meal_prep_automatic_cleanup"

--- a/tests/test_meal_prep_orchestration.py
+++ b/tests/test_meal_prep_orchestration.py
@@ -107,7 +107,7 @@ def automatic_start_is_eligible(
     )
 
 
-def test_automatic_start_has_bounded_triggers_and_reuses_the_display_script():
+def test_automatic_start_has_bounded_triggers_and_directly_casts_the_registered_view():
     automatic = automation_by_id(load_yaml(PACKAGE), "meal_prep_automatic_start")
     text = PACKAGE.read_text()
 
@@ -122,9 +122,17 @@ def test_automatic_start_has_bounded_triggers_and_reuses_the_display_script():
         "input_text.set_value",
         "input_text.set_value",
         "input_boolean.turn_on",
-        "script.meal_prep_show_dashboard",
+        "cast.show_lovelace_view",
     ]
-    assert automatic["action"][-1] == {"action": "script.meal_prep_show_dashboard"}
+    assert automatic["action"][-1] == {
+        "action": "cast.show_lovelace_view",
+        "target": {"entity_id": "media_player.kitchen_display"},
+        "data": {
+            "dashboard_path": "kitchen-prep",
+            "view_path": "kitchen-prep",
+        },
+    }
+    assert "script.meal_prep_show_dashboard" not in str(automatic["action"])
     assert "homeassistant.turn_off" not in text
 
 


### PR DESCRIPTION
## Summary
- Routes the automatic Kitchen Prep path directly to the proven `cast.show_lovelace_view` action instead of calling `script.meal_prep_show_dashboard`.
- Preserves the exact Kitchen Display target and `kitchen-prep` dashboard/view paths.
- Retains the dashboard script for manual **Show display** use and the existing no-meal dashboard behavior.

## Investigation
The direct manual Cast service call reliably renders Kitchen Prep, while the script/wrapped automatic path can report success yet leave the receiver on the Cast splash. Automatic orchestration now emits the known-good direct service payload without a script-service wrapper, pre-wake, wait, or delay.

## Validation
- `python -m pytest -q tests/test_meal_prep_controls.py tests/test_meal_prep_orchestration.py tests/test_kitchen_prep_dashboard.py` — 23 passed
- `python -m pytest -q` — 180 passed
- Parsed changed Kitchen Prep YAML plus its dashboard with PyYAML
- `git diff --check`

## Documentation impact
Updated `packages/README.md` to document that automatic orchestration bypasses the display-script wrapper.

## Required post-merge verification
After reviewer merge, repeat the authorised live smoke for an already-awake receiver and an off receiver. In each case require `media_title: Kitchen Prep: Kitchen Prep` and physical confirmation that Kitchen Prep (including its no-meal state when applicable) renders, not the Cast splash.

Refs #232
