### PR TITLE
feat(closet): automate light from door sensor

### DIFF
--- a/packages/master_bedroom_closet_light.yaml
+++ b/packages/master_bedroom_closet_light.yaml
@@ -1,0 +1,30 @@
+# packages/master_bedroom_closet_light.yaml
+#
+# Controls the master bedroom closet light directly from its contact sensor.
+
+automation:
+  - alias: "master_bedroom_closet_light_on_open"
+    id: "master_bedroom_closet_light_on_open"
+    description: "Turn on the closet light when the closet door opens."
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.master_bathroom_master_bedroom_closet
+        to: "on"
+    action:
+      - service: light.turn_on
+        target:
+          entity_id: light.master_bathroom_master_bathroom_closet
+    mode: single
+
+  - alias: "master_bedroom_closet_light_off_close"
+    id: "master_bedroom_closet_light_off_close"
+    description: "Turn off the closet light when the closet door closes."
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.master_bathroom_master_bedroom_closet
+        to: "off"
+    action:
+      - service: light.turn_off
+        target:
+          entity_id: light.master_bathroom_master_bathroom_closet
+    mode: single

--- a/tests/test_master_bedroom_closet_light.py
+++ b/tests/test_master_bedroom_closet_light.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "master_bedroom_closet_light.yaml"
+DOOR_SENSOR = "binary_sensor.master_bathroom_master_bedroom_closet"
+CLOSET_LIGHT = "light.master_bathroom_master_bathroom_closet"
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def automation_by_id(package, automation_id):
+    for automation in package["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def assert_direct_state_transition(automation, *, state, service):
+    assert automation["trigger"] == [
+        {
+            "platform": "state",
+            "entity_id": DOOR_SENSOR,
+            "to": state,
+        }
+    ]
+    assert automation["action"] == [
+        {
+            "service": service,
+            "target": {"entity_id": CLOSET_LIGHT},
+        }
+    ]
+    assert "condition" not in automation
+    assert "delay" not in str(automation["action"])
+    assert automation["mode"] == "single"
+
+
+def test_opening_closet_door_turns_on_exact_closet_light():
+    automation = automation_by_id(load_package(), "master_bedroom_closet_light_on_open")
+
+    assert_direct_state_transition(automation, state="on", service="light.turn_on")
+
+
+def test_closing_closet_door_turns_off_exact_closet_light():
+    automation = automation_by_id(load_package(), "master_bedroom_closet_light_off_close")
+
+    assert_direct_state_transition(automation, state="off", service="light.turn_off")


### PR DESCRIPTION
## Summary
- add a package-scoped automation that turns on the master bedroom closet light when its contact sensor opens
- add a matching close transition that turns the same light off
- cover both exact entity IDs and direct, unrestricted transitions with regression tests

## Validation
- `python -m pytest -q tests/test_master_bedroom_closet_light.py`
- `python -m pytest -q`
- YAML syntax parse for configuration, automation, scene, and package files (34 files)
- `git diff --check`

## Documentation impact
No documentation changes: this is a self-contained package automation with no setup or operator workflow change.

Closes #236