### PR TITLE
chore(http): comment legacy YAML configuration

### DIFF
--- a/.github/CI-README.md
+++ b/.github/CI-README.md
@@ -11,10 +11,11 @@ The current job is:
 1. **Home Assistant Core Configuration Check**
    - Checks out the repository.
    - Creates a dummy `SERVICE_ACCOUNT.json` with the fields required by `configuration.yaml`.
+   - Creates a non-secret `secrets.yaml` fixture for every active package secret reference.
    - Creates `.storage/` for Home Assistant runtime expectations.
    - Runs `frenck/action-home-assistant@v1.4.1` with `version: stable`.
 
-The workflow currently sets `continue-on-error: true` on the Home Assistant check step, so review the logs even when GitHub reports the job as non-blocking.
+The configuration-check step is required: a Home Assistant configuration error fails the workflow.
 
 ## Local validation
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -23,12 +23,22 @@ jobs:
             "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dummy.iam.gserviceaccount.com"
           }' > SERVICE_ACCOUNT.json
-          
-          # Create any other required files/directories
+
+          # Placeholder-only configuration for every Home Assistant package
+          # secret. These values are deliberately non-functional and exist
+          # only so the configuration checker can load the repository.
+          cat > secrets.yaml <<'EOF'
+          mealie_today_url: "https://example.invalid/mealie/today"
+          mealie_range_url: "https://example.invalid/mealie/range?start={{ mealie_range_start }}&end={{ mealie_range_end }}"
+          mealie_recipe_url: "https://example.invalid/mealie/recipes/{{ mealie_recipe_id }}"
+          mealie_mark_made_url: "https://example.invalid/mealie/recipes/{{ mealie_recipe_id }}/last-made"
+          mealie_authorization_header: "Bearer placeholder"
+          EOF
+
+          # Create the required runtime directory.
           mkdir -p .storage
       
       - name: Run Home Assistant Configuration Check
         uses: frenck/action-home-assistant@v1.4.1
         with:
           version: stable
-        continue-on-error: true  # Continue even if there are expected errors

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See `DEVELOPMENT.md` for implementation standards and `CONTRIBUTING.md` for the 
 
 For documentation-only changes, verify the package inventory and run a Markdown/link sanity check when available. For configuration changes, prefer static validation first and only run Home Assistant config checks when the task or environment provides a known-safe local command.
 
-The GitHub Actions workflow in `.github/workflows/validate.yaml` prepares dummy credential files and runs a Home Assistant Core configuration check with `frenck/action-home-assistant`.
+The GitHub Actions workflow in `.github/workflows/validate.yaml` prepares dummy credential files and non-secret package-secret placeholders, then runs a required Home Assistant Core configuration check with `frenck/action-home-assistant`.
 
 ## License
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -12,12 +12,13 @@ automation: !include_dir_merge_list automation
 input_boolean: !include_dir_merge_named input_boolean
 scene: !include scenes.yaml
 
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-    # Interim issue #93 fix: trust only the current server-VLAN CIDR until
-    # Cloudflare tunnel traffic is bound to a single stable proxy IP.
-    - 10.10.50.0/24
+# Legacy HTTP configuration migrated to Settings -> System -> Network.
+# http:
+#   use_x_forwarded_for: true
+#   trusted_proxies:
+#     Interim issue #93 fix: trust only the current server-VLAN CIDR until
+#     Cloudflare tunnel traffic is bound to a single stable proxy IP.
+#     - 10.10.50.0/24
 
 google_assistant:
   project_id: homeassistant-32654

--- a/tests/test_legacy_http_configuration.py
+++ b/tests/test_legacy_http_configuration.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+import re
 
 import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIGURATION_YAML = ROOT / "configuration.yaml"
+PACKAGES_DIRECTORY = ROOT / "packages"
+VALIDATION_WORKFLOW = ROOT / ".github" / "workflows" / "validate.yaml"
 
 
 def test_legacy_http_configuration_is_commented_and_ui_migration_is_documented():
@@ -21,3 +24,18 @@ def test_legacy_http_configuration_is_commented_and_ui_migration_is_documented()
     assert "#     Interim issue #93 fix: trust only the current server-VLAN CIDR until" in config_text
     assert "#     Cloudflare tunnel traffic is bound to a single stable proxy IP." in config_text
     assert "#     - 10.10.50.0/24" in config_text
+
+
+def test_validation_workflow_has_non_secret_placeholders_for_package_secrets():
+    package_secret_references = {
+        match.group(1)
+        for package in PACKAGES_DIRECTORY.glob("*.yaml")
+        for match in re.finditer(r"!secret\s+([a-z0-9_]+)", package.read_text())
+    }
+    workflow_text = VALIDATION_WORKFLOW.read_text()
+    fixture_text = workflow_text.split("cat > secrets.yaml <<'EOF'\n", 1)[1].split("\n          EOF", 1)[0]
+    fixture_secret_names = set(re.findall(r"^\s*([a-z0-9_]+):", fixture_text, re.MULTILINE))
+
+    assert package_secret_references == fixture_secret_names
+    assert "mealie_today_url" in fixture_secret_names
+    assert "continue-on-error" not in workflow_text

--- a/tests/test_legacy_http_configuration.py
+++ b/tests/test_legacy_http_configuration.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGURATION_YAML = ROOT / "configuration.yaml"
+
+
+def test_legacy_http_configuration_is_commented_and_ui_migration_is_documented():
+    config_text = CONFIGURATION_YAML.read_text()
+    root = yaml.compose(config_text)
+    top_level_keys = [key.value for key, _ in root.value]
+
+    assert "http" not in top_level_keys
+    assert "google_assistant" in top_level_keys
+    assert "# Legacy HTTP configuration migrated to Settings -> System -> Network." in config_text
+    assert "# http:" in config_text
+    assert "#   use_x_forwarded_for: true" in config_text
+    assert "#   trusted_proxies:" in config_text
+    assert "#     Interim issue #93 fix: trust only the current server-VLAN CIDR until" in config_text
+    assert "#     Cloudflare tunnel traffic is bound to a single stable proxy IP." in config_text
+    assert "#     - 10.10.50.0/24" in config_text


### PR DESCRIPTION
## Summary
- Commented the legacy http: YAML block while retaining the exact 10.10.50.0/24 setting and issue #93 rationale.
- Added a focused regression test that verifies no active top-level http mapping remains and google_assistant stays active.
- Made CI Home Assistant validation required and supplied non-secret placeholders for every active package secret reference.

## Validation
- uv run --with pytest --with pyyaml pytest tests/test_legacy_http_configuration.py (2 passed)
- uv run --with pytest --with pyyaml --with jinja2 pytest (184 passed)
- docker run --rm -v \"$(pwd):/config\" ghcr.io/home-assistant/home-assistant:stable hass -c /config --script check_config (passed with local placeholder-only fixtures)
- git diff --check origin/dev...HEAD
- Required GitHub Actions Home Assistant Core Configuration Check passed twice on the current head.

## Deployment gate
Merging this PR to dev is not live deployment. Before any deployment, an operator must confirm Settings -> System -> Network still has equivalent use_x_forwarded_for and exactly 10.10.50.0/24; stop for correction if it does not.

Ref #238