### PR TITLE
feat(grill): add temporary Weber temperature watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ All active package files under `packages/*.yaml` are documented in `packages/REA
 - `shared_infrastructure.yaml` - shared notifier/dashboard contracts for packages.
 - `towner_notifications.yaml` - school arrival/departure notification state handling.
 - `trash_recycling_reminder.yaml` - municipal calendar-driven Zooz wall-switch/dimmer LED reminder with per-device snapshot and midnight restore.
+- `weber_temp_watch.yaml` - temporary notification-only Weber Connect Hub temperature watch for the current grill test; remove after the test.
 - `weather.yaml` - weather caching, MQTT data, forecasts, and weather-driven automation.
 - `window_ventilation.yaml` - advisory ventilation recommendations and notification-only open-window HVAC warnings.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -47,6 +47,7 @@ Complex domains should stay split by responsibility. Climate is the current mode
 | `shared_infrastructure.yaml` | Shared package contracts: `notify.all_mobile_devices` and YAML-managed Lovelace dashboards for climate control, ventilation advice, and Kitchen Prep. |
 | `towner_notifications.yaml` | School arrival/departure notification workflow that handles infrequent location updates, race conditions, verification windows, and timeout/reset states. |
 | `trash_recycling_reminder.yaml` | Municipality-calendar-driven trash/recycling-night Zooz LED reminder. It snapshots and restores explicitly scoped wall-switch/dimmer LED settings, shows blue for garbage-only and green when recycling is also listed, and safely ignores unknown or recycling-only calendar text. |
+| `weber_temp_watch.yaml` | Temporary, notification-only Weber Connect Hub temperature watch for the current grill test. Remove this package after the test. |
 | `weather.yaml` | Weather processing and cache helpers, including MQTT weather data, forecast sensors, and an open-window rain alert that names affected monitored windows and clears after they all close. |
 | `window_ventilation.yaml` | Advisory window-ventilation recommendations using indoor/outdoor comfort, dew point, rain forecast, HVAC state, and relative air-quality context. |
 

--- a/packages/weber_temp_watch.yaml
+++ b/packages/weber_temp_watch.yaml
@@ -1,0 +1,43 @@
+# TEMP: Remove this package after the current Weber grill test.
+automation:
+  - alias: "TEMP Weber Grill Temperature Watch"
+    id: "temp_weber_grill_temperature_watch"
+    description: >
+      Temporary notification-only monitoring for Weber Connect Hub grill and
+      food probe temperature thresholds during the current grill test.
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.back_yard_weber_connect_hub_probe_1
+        above: 260
+        id: probe_1_above_260
+      - platform: numeric_state
+        entity_id: sensor.back_yard_weber_connect_hub_probe_1
+        below: 240
+        id: probe_1_below_240
+      - platform: numeric_state
+        entity_id: sensor.back_yard_weber_connect_hub_grill_temp_derivative
+        above: 0.5
+        id: grill_temp_rising_fast
+      - platform: numeric_state
+        entity_id: sensor.back_yard_weber_connect_hub_grill_temp_derivative
+        below: -0.5
+        id: grill_temp_falling_fast
+      - platform: numeric_state
+        entity_id: sensor.back_yard_weber_connect_hub_probe_2
+        above: 165
+        for: "00:01:00"
+        id: probe_2_above_165_for_one_minute
+    action:
+      - action: notify.mobile_app_brian_phone
+        data:
+          title: "TEMP Weber Grill Watch"
+          message: >-
+            {% set conditions = {
+              'probe_1_above_260': 'Probe 1 rose above 260 °F.',
+              'probe_1_below_240': 'Probe 1 fell below 240 °F.',
+              'grill_temp_rising_fast': 'Grill temperature is rising faster than +0.5 °F/min.',
+              'grill_temp_falling_fast': 'Grill temperature is falling faster than -0.5 °F/min.',
+              'probe_2_above_165_for_one_minute': 'Probe 2 has remained above 165 °F for one minute.'
+            } %}
+            {{ conditions[trigger.id] }} Current value: {{ states(trigger.entity_id) }} {{ state_attr(trigger.entity_id, 'unit_of_measurement') | default('', true) }}.
+    mode: single

--- a/tests/test_weber_temp_watch.py
+++ b/tests/test_weber_temp_watch.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "packages" / "weber_temp_watch.yaml"
+PROBE_1 = "sensor.back_yard_weber_connect_hub_probe_1"
+DERIVATIVE = "sensor.back_yard_weber_connect_hub_grill_temp_derivative"
+PROBE_2 = "sensor.back_yard_weber_connect_hub_probe_2"
+AUTOMATION_ID = "temp_weber_grill_temperature_watch"
+
+
+def load_package():
+    return yaml.safe_load(PACKAGE.read_text())
+
+
+def automation_by_id(package, automation_id):
+    for automation in package["automation"]:
+        if automation["id"] == automation_id:
+            return automation
+    raise AssertionError(f"automation {automation_id!r} not found")
+
+
+def test_temp_weber_watch_uses_exact_threshold_crossing_triggers():
+    automation = automation_by_id(load_package(), AUTOMATION_ID)
+
+    assert automation["trigger"] == [
+        {
+            "platform": "numeric_state",
+            "entity_id": PROBE_1,
+            "above": 260,
+            "id": "probe_1_above_260",
+        },
+        {
+            "platform": "numeric_state",
+            "entity_id": PROBE_1,
+            "below": 240,
+            "id": "probe_1_below_240",
+        },
+        {
+            "platform": "numeric_state",
+            "entity_id": DERIVATIVE,
+            "above": 0.5,
+            "id": "grill_temp_rising_fast",
+        },
+        {
+            "platform": "numeric_state",
+            "entity_id": DERIVATIVE,
+            "below": -0.5,
+            "id": "grill_temp_falling_fast",
+        },
+        {
+            "platform": "numeric_state",
+            "entity_id": PROBE_2,
+            "above": 165,
+            "for": "00:01:00",
+            "id": "probe_2_above_165_for_one_minute",
+        },
+    ]
+
+
+def test_temp_weber_watch_sends_one_templated_brian_notification_per_trigger():
+    automation = automation_by_id(load_package(), AUTOMATION_ID)
+
+    assert automation["alias"].startswith("TEMP")
+    assert automation["mode"] == "single"
+    assert "condition" not in automation
+    assert automation["action"][0]["action"] == "notify.mobile_app_brian_phone"
+
+    message = automation["action"][0]["data"]["message"]
+    assert "conditions[trigger.id]" in message
+    assert "states(trigger.entity_id)" in message
+    assert "state_attr(trigger.entity_id, 'unit_of_measurement')" in message
+    for trigger in automation["trigger"]:
+        assert trigger["id"] in message


### PR DESCRIPTION
## Summary
- add a clearly marked temporary Weber Connect Hub temperature-watch package for the current grill test
- notify Brian for the five specified Probe 1, derivative, and sustained Probe 2 threshold crossings
- add focused regression coverage and document the temporary package inventory

## Validation
- `python3` PyYAML parse of `packages/weber_temp_watch.yaml`
- `uv run --with pytest --with pyyaml pytest -q tests/test_weber_temp_watch.py` (2 passed)
- `uv run --with pytest --with pyyaml --with jinja2 pytest -q` (186 passed)
- `git diff --check`

## Documentation impact
- Updated root and package inventories to identify the temporary package and its removal requirement.

## Live deployment gate
- Not deployed or reloaded. After review and integration, an operator must deploy through the established Home Assistant workflow and verify the five threshold notifications on the actual mobile device.

Closes #240