### PR TITLE
feat(esphome): preserve Bluetooth proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The system currently emphasizes:
 - Device health monitoring for batteries, stale devices, Z-Wave health, and integration availability.
 - Household safety and security flows for cameras, garage doors, secure-house sanity checks, security lighting, routines, and notifications.
 - Weather, air-quality, seasonal, school, and window-ventilation advice driven by templates and helper entities.
-- ESPHome/device-specific configuration, currently including a RATGDO garage-door controller YAML file.
+- ESPHome/device-specific configuration, including a RATGDO garage-door controller and Bluetooth proxy YAML files.
 
 ## Repository layout
 

--- a/esphome/esphome-web-caff90.yaml
+++ b/esphome/esphome-web-caff90.yaml
@@ -1,0 +1,26 @@
+esphome:
+  name: bluetooth-proxy
+  friendly_name: Bluetooth Proxy
+  min_version: 2026.4.0
+  name_add_mac_suffix: false
+
+esp32:
+  variant: esp32
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+
+# Allow Over-The-Air updates
+ota:
+- platform: esphome
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+bluetooth_proxy:


### PR DESCRIPTION
## Summary
- Adds the verified working ESPHome Bluetooth proxy configuration at `esphome/esphome-web-caff90.yaml`.
- Documents the tracked Bluetooth proxy alongside the existing RATGDO ESPHome configuration.
- Preserves the supplied source exactly (SHA-256: `8c17b307a406453f261b83ceefa745df48c71af06fcd1da764862235c0099cc6`).

## Validation
- Exact source hash comparison and byte-for-byte comparison passed.
- ESPHome 2026.6.5: `esphome config esphome/esphome-web-caff90.yaml` passed.
- YAML semantic assertions passed for the required ESPHome, ESP32/ESP-IDF, OTA, Wi-Fi-secret, and active Bluetooth proxy settings.
- `pytest -q`: 182 passed.
- `git diff --check` passed.

## Documentation impact
- Updated the ESPHome overview in `README.md` to include the Bluetooth proxy configuration.

## Live deployment
- No live Home Assistant action, ESP32 firmware flash, or device restart was performed; the device firmware is already working and this PR preserves its repository configuration.

Closes #242
